### PR TITLE
[WIP] non-root user for NodeJS template

### DIFF
--- a/template/node/Dockerfile
+++ b/template/node/Dockerfile
@@ -1,33 +1,36 @@
 FROM node:6.11.2-alpine
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
-RUN apk --no-cache add curl \ 
+RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
     && curl -sSL https://github.com/alexellis/faas/releases/download/0.6.1/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
+RUN addgroup -S app && adduser -S -g app app
 WORKDIR /root/
 
 # Turn down the verbosity to default level.
 ENV NPM_CONFIG_LOGLEVEL warn
 
+RUN mkdir -p /home/app
+
 # Wrapper/boot-strapper
-COPY package.json       .
+COPY package.json       /home/app
+
+WORKDIR /home/app
 RUN npm i
 
 # Function
-COPY index.js           .
-RUN mkdir -p ./root/function
+COPY index.js           /home/app
 
-COPY function/*.json    ./function/
-WORKDIR /root/function
+COPY function/*.json    /home/app/function/
+WORKDIR /home/app/function
 RUN npm i || :
-WORKDIR /root/
-COPY function           function
-WORKDIR /root/function
+WORKDIR /home/app/
+COPY function           ./function
 
-WORKDIR /root/
+USER app
 
 ENV cgi_headers="true"
 

--- a/template/node/Dockerfile
+++ b/template/node/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:6.11.2-alpine
 
+RUN addgroup -S app && adduser -S -g app app
+
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
@@ -7,7 +9,6 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-RUN addgroup -S app && adduser -S -g app app
 WORKDIR /root/
 
 # Turn down the verbosity to default level.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Initial draft of non-root user in the NodeJS template.

## Description
<!--- Describe your changes in detail -->
update the template/node/Dockerfile to use the `node` user rather than root. function directory structure needed to changed from `/root/` to `/usr/local/app/` as well 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows users to run function as non-root which may increase security
<!--- If it fixes an open issue, please link to the issue here. -->
This relates to #81 
- [x] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))
already raised by @alex #81 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually built test function after changes, deployed and tested through the UI gateway
<!--- Include details of your testing environment, and the tests you ran to -->
Linux 16+ on Docker CE 17.06
<!--- see how your change affects other areas of the code, etc. -->
Will only impact the NodeJS template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
