### PR TITLE
Final non-root changes to Python, Ruby and C# templates

### DIFF
--- a/template/csharp/Dockerfile
+++ b/template/csharp/Dockerfile
@@ -4,12 +4,13 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
 # Optimize for Docker builder caching by adding projects first.
 
-RUN mkdir -p /root/src/function
-WORKDIR /root/src/function
+RUN mkdir -p /home/app/src/function
+WORKDIR /home/app/src/function
 COPY ./function/Function.csproj  .
 
-WORKDIR /root/src/
+WORKDIR /home/app/src
 COPY ./root.csproj  .
+
 RUN dotnet restore ./root.csproj
 
 COPY .  .
@@ -17,6 +18,7 @@ COPY .  .
 RUN dotnet publish -c release -o published
 
 FROM microsoft/dotnet:2.0-runtime
+RUN useradd app
 
 RUN apt-get update -qy \
     && apt-get install -qy curl ca-certificates --no-install-recommends \ 
@@ -27,8 +29,11 @@ RUN apt-get update -qy \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /root/
-COPY --from=builder /root/src/published .
+WORKDIR /home/app/
+COPY --from=builder /home/app/src/published .
+
+RUN chown -R app ./
+USER app
 
 ENV fprocess="dotnet ./root.dll"
 EXPOSE 8080

--- a/template/csharp/Dockerfile
+++ b/template/csharp/Dockerfile
@@ -18,12 +18,12 @@ COPY .  .
 RUN dotnet publish -c release -o published
 
 FROM microsoft/dotnet:2.0-runtime
-RUN useradd app
+RUN addgroup -S app && adduser -S -g app app
 
 RUN apt-get update -qy \
     && apt-get install -qy curl ca-certificates --no-install-recommends \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.12/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apt-get -qy remove curl \
     && apt-get clean \
@@ -32,7 +32,10 @@ RUN apt-get update -qy \
 WORKDIR /home/app/
 COPY --from=builder /home/app/src/published .
 
-RUN chown -R app ./
+# chmod for tmp is for a buildkit issue (@alexellis)
+RUN chown app:app -R /home/app \
+    && chmod 777 /tmp
+
 USER app
 
 ENV fprocess="dotnet ./root.dll"

--- a/template/node/Dockerfile
+++ b/template/node/Dockerfile
@@ -5,7 +5,7 @@ RUN addgroup -S app && adduser -S -g app app
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.12/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -1,15 +1,13 @@
 FROM python:2.7-alpine
 
-RUN adduser app -D
+RUN addgroup -S app && adduser -S -g app app
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.12/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
-
-RUN mkdir -p /home/app/function
 
 COPY index.py           /home/app
 COPY requirements.txt   /home/app
@@ -26,7 +24,10 @@ RUN pip install -r requirements.txt
 WORKDIR /home/app
 COPY function           function
 
-RUN chown -R app ./
+# chmod for tmp is for a buildkit issue (@alexellis)
+RUN chown app:app -R /home/app \
+    && chmod 777 /tmp
+
 USER app
 
 ENV fprocess="python index.py"

--- a/template/python/Dockerfile
+++ b/template/python/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:2.7-alpine
 
+RUN adduser app -D
+
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
@@ -7,20 +9,25 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-WORKDIR /root/
+RUN mkdir -p /home/app/function
 
-COPY index.py           .
-COPY requirements.txt   .
+COPY index.py           /home/app
+COPY requirements.txt   /home/app
+
+WORKDIR /home/app
 RUN pip install -r requirements.txt
 
 RUN mkdir -p function
 RUN touch ./function/__init__.py
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 COPY function/requirements.txt	.
 RUN pip install -r requirements.txt
 
-WORKDIR /root/
+WORKDIR /home/app
 COPY function           function
+
+RUN chown -R app ./
+USER app
 
 ENV fprocess="python index.py"
 

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -1,11 +1,11 @@
 FROM python:3-alpine
 
-RUN adduser app -D
+RUN addgroup -S app && adduser -S -g app app
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.12/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
@@ -26,7 +26,10 @@ RUN pip install -r requirements.txt
 
 WORKDIR /home/app
 
-RUN chown -R app ./
+# chmod for tmp is for a buildkit issue (@alexellis)
+RUN chown app:app -R /home/app \
+    && chmod 777 /tmp
+
 USER app
 
 ENV fprocess="python3 index.py"

--- a/template/python3/Dockerfile
+++ b/template/python3/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3-alpine
 
+RUN adduser app -D
+
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
@@ -7,7 +9,7 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-WORKDIR /root/
+WORKDIR /home/app
 
 COPY index.py           .
 COPY requirements.txt   .
@@ -17,11 +19,15 @@ COPY function           function
 
 RUN touch ./function/__init__.py
 
-WORKDIR /root/function/
+WORKDIR /home/app/function/
+
 COPY function/requirements.txt	.
 RUN pip install -r requirements.txt
 
-WORKDIR /root/
+WORKDIR /home/app
+
+RUN chown -R app ./
+USER app
 
 ENV fprocess="python3 index.py"
 

--- a/template/ruby/Dockerfile
+++ b/template/ruby/Dockerfile
@@ -1,5 +1,7 @@
 FROM ruby:2.4-alpine3.6
 
+RUN adduser app -D
+
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
@@ -7,17 +9,22 @@ RUN apk --no-cache add curl \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-WORKDIR /root/
+RUN mkdir -p /home/app/
+WORKDIR /home/app/
 
 COPY Gemfile		.
 COPY index.rb           .
 COPY function           function
 RUN bundle install 
 
-WORKDIR /root/function/
+WORKDIR /home/app/function/
 RUN bundle install 
 
-WORKDIR /root/
+WORKDIR /home/app/
+
+RUN chown -R app ./
+USER app
+
 ENV fprocess="ruby index.rb"
 HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
 

--- a/template/ruby/Dockerfile
+++ b/template/ruby/Dockerfile
@@ -1,15 +1,14 @@
 FROM ruby:2.4-alpine3.6
 
-RUN adduser app -D
+RUN addgroup -S app && adduser -S -g app app
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
-    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.12/fwatchdog > /usr/bin/fwatchdog \
     && chmod +x /usr/bin/fwatchdog \
     && apk del curl --no-cache
 
-RUN mkdir -p /home/app/
 WORKDIR /home/app/
 
 COPY Gemfile		.
@@ -22,7 +21,10 @@ RUN bundle install
 
 WORKDIR /home/app/
 
-RUN chown -R app ./
+# chmod for tmp is for a buildkit issue (@alexellis)
+RUN chown app:app -R /home/app \
+    && chmod 777 /tmp
+
 USER app
 
 ENV fprocess="ruby index.rb"


### PR DESCRIPTION
Dockerfile for python, ruby, and C# template should not use ROOT

Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Like #83, this change is to have template Dockerfiles establish the function in an environment not running as `root`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))
https://github.com/alexellis/faas-cli/issues/81

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ad-hoc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
