### PR TITLE
Updated go package references to point to new repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.8.3
 
-WORKDIR /go/src/github.com/alexellis/faas-cli
+WORKDIR /go/src/github.com/openfaas/faas-cli
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
@@ -8,7 +8,7 @@ RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 
 RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
  && GIT_COMMIT=$(git rev-list -1 HEAD) \
- && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli .
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli .
 RUN go test ./...
 
 FROM alpine:latest
@@ -16,7 +16,7 @@ RUN apk --no-cache add ca-certificates
 
 WORKDIR /root/
 
-COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli    .
+COPY --from=0 /go/src/github.com/openfaas/faas-cli/faas-cli    .
 
 CMD ["./faas-cli"]
 

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -1,6 +1,6 @@
 FROM golang:1.8.3
 
-WORKDIR /go/src/github.com/alexellis/faas-cli
+WORKDIR /go/src/github.com/openfaas/faas-cli
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
@@ -11,21 +11,21 @@ RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 
 RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
  && GIT_COMMIT=$(git rev-list -1 HEAD) \
- && GOARCH=arm GOARM=6 CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-armhf \
- && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-darwin \
- && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli \
- && CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli.exe \
- && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w -X github.com/alexellis/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/alexellis/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-arm64
+ && GOARCH=arm GOARM=6 CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-armhf \
+ && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-darwin \
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli \
+ && CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli.exe \
+ && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli-arm64
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /root/
 
-COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli                .
-COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli-darwin         .
-COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli-armhf          .
-COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli.exe            .
-COPY --from=0 /go/src/github.com/alexellis/faas-cli/faas-cli-arm64          .
+COPY --from=0 /go/src/github.com/openfaas/faas-cli/faas-cli                .
+COPY --from=0 /go/src/github.com/openfaas/faas-cli/faas-cli-darwin         .
+COPY --from=0 /go/src/github.com/openfaas/faas-cli/faas-cli-armhf          .
+COPY --from=0 /go/src/github.com/openfaas/faas-cli/faas-cli.exe            .
+COPY --from=0 /go/src/github.com/openfaas/faas-cli/faas-cli-arm64          .
 
 CMD ["./faas"]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Help for all of the commands supported by the CLI can be found by running:
 
 * `faas-cli help` or `faas-cli [command] --help`
 
-You can chose between using a [programming language template](https://github.com/alexellis/faas-cli/tree/master/template) where you only need to provide a handler file, or a Docker that you can build yourself.
+You can chose between using a [programming language template](https://github.com/openfaas/faas-cli/tree/master/template) where you only need to provide a handler file, or a Docker that you can build yourself.
 
 **Templates**
 
@@ -208,7 +208,7 @@ $ curl --data-binary @README.md http://localhost:8080/function/nodejs-echo
 $ uname -a | curl http://localhost:8080/function/nodejs-echo--data-binary @-
 ```
 
-> For further instructions on the manual CLI flags (without using a YAML file) read [manual_cli.md](https://github.com/alexellis/faas-cli/blob/master/MANUAL_CLI.md)
+> For further instructions on the manual CLI flags (without using a YAML file) read [manual_cli.md](https://github.com/openfaas/faas-cli/blob/master/MANUAL_CLI.md)
 
 
 **Bash Auto-completion [experimental]**
@@ -240,7 +240,7 @@ Refer to your distributions instructions on installing and enabling `bash-comple
 
 ## FaaS-CLI Developers / Contributors
 
-See [contributing guide](https://github.com/alexellis/faas-cli/blob/master/CONTRIBUTING.md).
+See [contributing guide](https://github.com/openfaas/faas-cli/blob/master/CONTRIBUTING.md).
 
 ### License
 

--- a/app.go
+++ b/app.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/alexellis/faas-cli/commands"
+	"github.com/openfaas/faas-cli/commands"
 )
 
 func main() {

--- a/commands/build.go
+++ b/commands/build.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/alexellis/faas-cli/builder"
-	"github.com/alexellis/faas-cli/stack"
+	"github.com/openfaas/faas-cli/builder"
+	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -12,8 +12,8 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/alexellis/faas-cli/proxy"
-	"github.com/alexellis/faas-cli/stack"
+	"github.com/openfaas/faas-cli/proxy"
+	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -10,6 +10,7 @@ import (
 )
 
 const defaultGateway = "http://localhost:8080"
+
 const defaultNetwork = "func_functions"
 
 // Flags that are to be added to all commands.

--- a/commands/fetch_templates.go
+++ b/commands/fetch_templates.go
@@ -69,7 +69,7 @@ func fetchMasterZip(templateUrl string) error {
 	if _, err = os.Stat(ZipFileName); err != nil {
 
 		if len(templateUrl) == 0 {
-			templateUrl = "https://github.com/alexellis/faas-cli/archive/" + ZipFileName
+			templateUrl = "https://github.com/openfaas/faas-cli/archive/" + ZipFileName
 		}
 		c := http.Client{}
 

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -9,8 +9,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/alexellis/faas-cli/proxy"
-	"github.com/alexellis/faas-cli/stack"
+	"github.com/openfaas/faas-cli/proxy"
+	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/list.go
+++ b/commands/list.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/alexellis/faas-cli/proxy"
-	"github.com/alexellis/faas-cli/stack"
+	"github.com/openfaas/faas-cli/proxy"
+	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/alexellis/faas-cli/builder"
+	"github.com/openfaas/faas-cli/builder"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/push.go
+++ b/commands/push.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/alexellis/faas-cli/builder"
-	"github.com/alexellis/faas-cli/stack"
+	"github.com/openfaas/faas-cli/builder"
+	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/alexellis/faas-cli/proxy"
-	"github.com/alexellis/faas-cli/stack"
+	"github.com/openfaas/faas-cli/proxy"
+	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 )
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -29,7 +29,7 @@ var versionCmd = &cobra.Command{
 	Long: fmt.Sprintf(`The version command returns the current clients version information.
 
 This currently consists of the GitSHA from which the client was built.
-- https://github.com/alexellis/faas-cli/tree/%s`, GitCommit),
+- https://github.com/openfaas/faas-cli/tree/%s`, GitCommit),
 	Example: `  faas-cli version
   faas-cli version --short-version`,
 	Run: runVersion,

--- a/vendor/github.com/alexellis/faas/README.md
+++ b/vendor/github.com/alexellis/faas/README.md
@@ -12,7 +12,7 @@ OpenFaaS is a framework for building serverless functions with Docker which has 
 * Ease of use through UI portal and *one-click* install
 * Write functions in any language for Linux or Windows and package in Docker/OCI image format
 * Portable - runs on existing hardware or public/private cloud - [Kubernetes](https://github.com/alexellis/faas-netes) or Docker Swarm
-* [CLI](http://github.com/alexellis/faas-cli) available with YAML format for templating and defining functions
+* [CLI](http://github.com/openfaas/faas-cli) available with YAML format for templating and defining functions
 * Auto-scales as demand increases
 
 ## Overview of OpenFaaS
@@ -34,7 +34,7 @@ OpenFaaS is a framework for building serverless functions with Docker which has 
 
 ### CLI
 
-Any container or process in a Docker container can be a serverless function in FaaS. Using the [FaaS CLI](http://github.com/alexellis/faas-cli) you can deploy your functions or quickly create new functions from templates such as Node.js or Python.
+Any container or process in a Docker container can be a serverless function in FaaS. Using the [FaaS CLI](http://github.com/openfaas/faas-cli) you can deploy your functions or quickly create new functions from templates such as Node.js or Python.
 
 > The CLI is effectively a RESTful client for the API Gateway.
 
@@ -62,7 +62,7 @@ $ curl -sSL https://cli.openfaas.com | sudo sh
 Clone the samples and templates from Github:
 
 ```
-$ git clone https://github.com/alexellis/faas-cli
+$ git clone https://github.com/openfaas/faas-cli
 $ cd faas-cli
 ```
 


### PR DESCRIPTION
## Description
Search and replace on references to alexellis/faas-cli and replace to openfaas/faas-cli to represent the new repo paths.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Ran go test ./... and built and manually tested the CLI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/alexellis/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.