### PR TITLE
Use PUT verb for function updates and update messages

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -122,7 +122,11 @@ func runDeploy(cmd *cobra.Command, args []string) {
 
 		for k, function := range services.Functions {
 			function.Name = k
-			fmt.Printf("Deploying: %s.\n", function.Name)
+			if update {
+				fmt.Printf("Updating: %s.\n", function.Name)
+			} else {
+				fmt.Printf("Deploying: %s.\n", function.Name)
+			}
 			if function.Constraints != nil {
 				constraints = *function.Constraints
 			}

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -56,7 +56,7 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	method := "POST"
 	// "application/json"
 	if update {
-		method = "UPDATE"
+		method = "PUT"
 	}
 
 	request, _ = http.NewRequest(method, gateway+"/system/functions", reader)

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -74,7 +74,11 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 
 	switch res.StatusCode {
 	case 200, 201, 202:
-		fmt.Println("Deployed.")
+		if update {
+			fmt.Println("Updated.")
+		} else {
+			fmt.Println("Deployed.")
+		}
 
 		deployedURL := fmt.Sprintf("URL: %s/function/%s\n", gateway, functionName)
 		fmt.Println(deployedURL)


### PR DESCRIPTION
This PR is part of a group of 3:
- openfaas/faas#208
- openfaas/faas-cli#123
- openfaas/faas-provider#4

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit switches the verb used for updates from the non-HTTP UPDATE to PUT.

It also updates the message returned from the deploy action depending on whether its a deploy or update:
```
$ ./faas-cli-darwin deploy -f ./samples.yml --replace=false --update
Updating: ruby-echo.
Updated.
URL: http://localhost:8080/function/ruby-echo
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (openfaas/faas#208)

UPDATE is not a valid HTTP verb, the correct verb to use for updates is PUT (as pointed out by @imeoer - thx!)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested performing a range of updates on a local swarm, changing envvars etc.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
