### PR TITLE
Print error message when no matches are found by --filter or --regex flag

### DIFF
--- a/stack/stack.go
+++ b/stack/stack.go
@@ -66,7 +66,6 @@ func ParseYAMLData(fileData []byte, regex string, filter string) (*Services, err
 			if regexExists {
 				match, err = regexp.MatchString(regex, function.Name)
 				if err != nil {
-					fmt.Printf("Invalid regex passed to --regex option\n")
 					return nil, err
 				}
 			} else {
@@ -76,6 +75,10 @@ func ParseYAMLData(fileData []byte, regex string, filter string) (*Services, err
 			if !match {
 				delete(services.Functions, function.Name)
 			}
+		}
+
+		if len(services.Functions) == 0 {
+			return nil, errors.New("No functions matching --filter/--regex were found in the YAML file")
 		}
 
 	}

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -5,6 +5,7 @@ package stack
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -48,165 +49,199 @@ const TestData_2 string = `provider:
 
 `
 
+const noMatchesErrorMsg string = "No functions matching --filter/--regex were found in the YAML file"
+const invalidRegexErrorMsg string = "error parsing regexp"
+
 var ParseYAMLTests_Regex = []struct {
-	title       string
-	searchTerm  string
-	functions   []string
-	file        string
-	expectError bool
+	title         string
+	searchTerm    string
+	functions     []string
+	file          string
+	expectedError string
 }{
 	{
-		title:       "Regex search for functions only containing 'node'",
-		searchTerm:  "node",
-		functions:   []string{"nodejs-echo"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for functions only containing 'node'",
+		searchTerm:    "node",
+		functions:     []string{"nodejs-echo"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex search for functions only containing 'echo'",
-		searchTerm:  "echo",
-		functions:   []string{"nodejs-echo", "ruby-echo"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for functions only containing 'echo'",
+		searchTerm:    "echo",
+		functions:     []string{"nodejs-echo", "ruby-echo"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex search for functions only containing '.+-.+'",
-		searchTerm:  ".+-.+",
-		functions:   []string{"abcd-eeee", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for functions only containing '.+-.+'",
+		searchTerm:    ".+-.+",
+		functions:     []string{"abcd-eeee", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex search for all functions: '.*'",
-		searchTerm:  ".*",
-		functions:   []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for all functions: '.*'",
+		searchTerm:    ".*",
+		functions:     []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex search for no functions: '----'",
-		searchTerm:  "----",
-		functions:   []string{},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for no functions: '----'",
+		searchTerm:    "----",
+		functions:     []string{},
+		file:          TestData_1,
+		expectedError: noMatchesErrorMsg,
 	},
 	{
-		title:       "Regex search for functions without dashes: '^[^-]+$'",
-		searchTerm:  "^[^-]+$",
-		functions:   []string{"imagemagick"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for functions without dashes: '^[^-]+$'",
+		searchTerm:    "^[^-]+$",
+		functions:     []string{"imagemagick"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex search for functions with 8 characters: '^.{8}$'",
-		searchTerm:  "^.{8}$",
-		functions:   []string{"url-ping"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for functions with 8 characters: '^.{8}$'",
+		searchTerm:    "^.{8}$",
+		functions:     []string{"url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex search for function with repeated 'e': 'e{2}'",
-		searchTerm:  "e{2}",
-		functions:   []string{"abcd-eeee"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex search for function with repeated 'e': 'e{2}'",
+		searchTerm:    "e{2}",
+		functions:     []string{"abcd-eeee"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex empty search term: ''",
-		searchTerm:  "",
-		functions:   []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:        TestData_1,
-		expectError: false,
+		title:         "Regex empty search term: ''",
+		searchTerm:    "",
+		functions:     []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:       "Regex invalid regex 1: '['",
-		searchTerm:  "[",
-		functions:   []string{},
-		file:        TestData_1,
-		expectError: true,
+		title:         "Regex invalid regex 1: '['",
+		searchTerm:    "[",
+		functions:     []string{},
+		file:          TestData_1,
+		expectedError: invalidRegexErrorMsg,
 	},
 	{
-		title:       "Regex invalid regex 2: '*'",
-		searchTerm:  "*",
-		functions:   []string{},
-		file:        TestData_1,
-		expectError: true,
+		title:         "Regex invalid regex 2: '*'",
+		searchTerm:    "*",
+		functions:     []string{},
+		file:          TestData_1,
+		expectedError: invalidRegexErrorMsg,
 	},
 	{
-		title:       "Regex invalid regex 3: '(\\w)\\1'",
-		searchTerm:  `(\w)\1`,
-		functions:   []string{},
-		file:        TestData_1,
-		expectError: true,
+		title:         "Regex invalid regex 3: '(\\w)\\1'",
+		searchTerm:    `(\w)\1`,
+		functions:     []string{},
+		file:          TestData_1,
+		expectedError: invalidRegexErrorMsg,
 	},
 	{
-		title:       "Regex empty search term in empty YAML file: ",
-		searchTerm:  "",
-		functions:   []string{},
-		file:        TestData_2,
-		expectError: false,
+		title:         "Regex that finds no matches: 'RANDOMREGEX'",
+		searchTerm:    "RANDOMREGEX",
+		functions:     []string{},
+		file:          TestData_1,
+		expectedError: noMatchesErrorMsg,
+	},
+	{
+		title:         "Regex empty search term in empty YAML file: ",
+		searchTerm:    "",
+		functions:     []string{},
+		file:          TestData_2,
+		expectedError: "",
 	},
 }
 
 var ParseYAMLTests_Filter = []struct {
-	title      string
-	searchTerm string
-	functions  []string
-	file       string
+	title         string
+	searchTerm    string
+	functions     []string
+	file          string
+	expectedError string
 }{
 	{
-		title:      "Wildcard search for functions ending with 'echo'",
-		searchTerm: "*echo",
-		functions:  []string{"nodejs-echo", "ruby-echo"},
-		file:       TestData_1,
+		title:         "Wildcard search for functions ending with 'echo'",
+		searchTerm:    "*echo",
+		functions:     []string{"nodejs-echo", "ruby-echo"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:      "Wildcard search for functions with a - in between two words: '*-*'",
-		searchTerm: "*-*",
-		functions:  []string{"abcd-eeee", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:       TestData_1,
+		title:         "Wildcard search for functions with a - in between two words: '*-*'",
+		searchTerm:    "*-*",
+		functions:     []string{"abcd-eeee", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:      "Wildcard search for specific function: 'imagemagick'",
-		searchTerm: "imagemagick",
-		functions:  []string{"imagemagick"},
-		file:       TestData_1,
+		title:         "Wildcard search for specific function: 'imagemagick'",
+		searchTerm:    "imagemagick",
+		functions:     []string{"imagemagick"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:      "Wildcard search for all functions: '*'",
-		searchTerm: "*",
-		functions:  []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:       TestData_1,
+		title:         "Wildcard search for all functions: '*'",
+		searchTerm:    "*",
+		functions:     []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:      "Wildcard empty search term: ''",
-		searchTerm: "",
-		functions:  []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:       TestData_1,
+		title:         "Wildcard empty search term: ''",
+		searchTerm:    "",
+		functions:     []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:      "Wildcard multiple wildcard characters: '**'",
-		searchTerm: "**",
-		functions:  []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
-		file:       TestData_1,
+		title:         "Wildcard multiple wildcard characters: '**'",
+		searchTerm:    "**",
+		functions:     []string{"abcd-eeee", "imagemagick", "nodejs-echo", "ruby-echo", "url-ping"},
+		file:          TestData_1,
+		expectedError: "",
 	},
 	{
-		title:      "Wildcard empty search term in empty YAML file: ''",
-		searchTerm: "",
-		functions:  []string{},
-		file:       TestData_2,
+		title:         "Wildcard that finds no matches: 'RANDOMTEXT'",
+		searchTerm:    "RANDOMTEXT",
+		functions:     []string{},
+		file:          TestData_1,
+		expectedError: noMatchesErrorMsg,
+	},
+	{
+		title:         "Wildcard empty search term in empty YAML file: ''",
+		searchTerm:    "",
+		functions:     []string{},
+		file:          TestData_2,
+		expectedError: "",
 	},
 }
 
 func Test_ParseYAMLDataRegex(t *testing.T) {
+
 	for _, test := range ParseYAMLTests_Regex {
 		t.Run(test.title, func(t *testing.T) {
+
 			parsedYAML, err := ParseYAMLData([]byte(test.file), test.searchTerm, "")
-			if test.expectError {
+
+			if len(test.expectedError) > 0 {
 				if err == nil {
 					t.Errorf("Test_ParseYAMLDataRegex test [%s] test failed, expected error not thrown", test.title)
 				}
+
+				if !strings.Contains(err.Error(), test.expectedError) {
+					t.Errorf("Test_ParseYAMLDataRegex test [%s] test failed, expected error message of '%s', got '%v'", test.title, test.expectedError, err)
+				}
+
 			} else {
+
 				if err != nil {
 					t.Errorf("Test_ParseYAMLDataRegex test [%s] test failed, unexpected error thrown: %v", test.title, err)
 					return
@@ -214,9 +249,11 @@ func Test_ParseYAMLDataRegex(t *testing.T) {
 
 				keys := reflect.ValueOf(parsedYAML.Functions).MapKeys()
 				strkeys := make([]string, len(keys))
+
 				for i := 0; i < len(keys); i++ {
 					strkeys[i] = keys[i].String()
 				}
+
 				sort.Strings(strkeys)
 				t.Log(strkeys)
 
@@ -233,28 +270,46 @@ func Test_ParseYAMLDataRegex(t *testing.T) {
 }
 
 func Test_ParseYAMLDataFilter(t *testing.T) {
+
 	for _, test := range ParseYAMLTests_Filter {
 		t.Run(test.title, func(t *testing.T) {
+
 			parsedYAML, err := ParseYAMLData([]byte(test.file), "", test.searchTerm)
-			if err != nil {
-				t.Errorf("Test_ParseYAMLDataFilter test [%s] test failed, unexpected error thrown: %v", test.title, err)
-				return
-			}
 
-			keys := reflect.ValueOf(parsedYAML.Functions).MapKeys()
-			strkeys := make([]string, len(keys))
-			for i := 0; i < len(keys); i++ {
-				strkeys[i] = keys[i].String()
-			}
-			sort.Strings(strkeys)
-			t.Log(strkeys)
+			if len(test.expectedError) > 0 {
 
-			if !reflect.DeepEqual(strkeys, test.functions) {
-				t.Errorf("Test_ParseYAMLDataFilter test [%s] failed, does not match expected result;\n  parsedYAML:   [%v]\n  expected: [%v]",
-					test.title,
-					strkeys,
-					test.functions,
-				)
+				if err == nil {
+					t.Errorf("Test_ParseYAMLDataFilter test [%s] test failed, expected error not thrown", test.title)
+				}
+
+				if !strings.Contains(err.Error(), test.expectedError) {
+					t.Errorf("Test_ParseYAMLDataFilter test [%s] test failed, expected error message of '%s', got '%v'", test.title, test.expectedError, err)
+				}
+
+			} else {
+
+				if err != nil {
+					t.Errorf("Test_ParseYAMLDataFilter test [%s] test failed, unexpected error thrown: %v", test.title, err)
+					return
+				}
+
+				keys := reflect.ValueOf(parsedYAML.Functions).MapKeys()
+				strkeys := make([]string, len(keys))
+
+				for i := 0; i < len(keys); i++ {
+					strkeys[i] = keys[i].String()
+				}
+
+				sort.Strings(strkeys)
+				t.Log(strkeys)
+
+				if !reflect.DeepEqual(strkeys, test.functions) {
+					t.Errorf("Test_ParseYAMLDataFilter test [%s] failed, does not match expected result;\n  parsedYAML:   [%v]\n  expected: [%v]",
+						test.title,
+						strkeys,
+						test.functions,
+					)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Print error message when no matches are found by --filter or --regex flag

Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is to return an error message when all functions are filtered out by the --filter or --regex option. The current error message is `"No functions found in YAML, check --filter/--regex"`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Issue #124 

This will help users figure out what is wrong with their command if they expect functions to be deployed, and nothing happens.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests were upgraded to accommodate this change and check for this error to be properly thrown when --filter and --regex remove all functions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
