### PR TITLE
Default to stack.yml when no --yaml flag given

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Specify `lang: Dockerfile` if you want the faas-cli to execute a build or `skip_
 
 A YAML stack file groups functions together and also saves on typing.
 
-You can define individual functions or a set of of them within a YAML file. This makes the CLI easier to use and means you can use this file to deploy to your OpenFaaS instance.
+You can define individual functions or a set of of them within a YAML file. This makes the CLI easier to use and means you can use this file to deploy to your OpenFaaS instance.  By default the faas-cli will attempt to load `stack.yaml` from the current directory.
 
 Here is an example file using the `samples.yml` file included in the repository.
 

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -5,12 +5,16 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
 
-const defaultGateway = "http://localhost:8080"
-const defaultNetwork = "func_functions"
+const (
+	defaultGateway = "http://localhost:8080"
+	defaultNetwork = "func_functions"
+	defaultYAML    = "stack.yml"
+)
 
 // Flags that are to be added to all commands.
 var (
@@ -42,9 +46,18 @@ func init() {
 
 // Execute TODO
 func Execute(customArgs []string) {
+	checkAndSetDefaultYaml()
+
 	faasCmd.SilenceUsage = true
 	faasCmd.SetArgs(customArgs[1:])
 	faasCmd.Execute()
+}
+
+func checkAndSetDefaultYaml() {
+	// Check if there is a default yaml file and set it
+	if _, err := os.Stat(defaultYAML); err == nil {
+		yamlFile = defaultYAML
+	}
 }
 
 // faasCmd is the FaaS CLI root command and mimics the legacy client behaviour

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -34,6 +34,10 @@ var (
 	language     string
 )
 
+var stat = func(filename string) (os.FileInfo, error) {
+	return os.Stat(filename)
+}
+
 func init() {
 	faasCmd.PersistentFlags().StringVarP(&yamlFile, "yaml", "f", "", "Path to YAML file describing function(s)")
 	faasCmd.PersistentFlags().StringVarP(&regex, "regex", "", "", "Regex to match with function names in YAML file")
@@ -55,7 +59,7 @@ func Execute(customArgs []string) {
 
 func checkAndSetDefaultYaml() {
 	// Check if there is a default yaml file and set it
-	if _, err := os.Stat(defaultYAML); err == nil {
+	if _, err := stat(defaultYAML); err == nil {
 		yamlFile = defaultYAML
 	}
 }

--- a/commands/faas_test.go
+++ b/commands/faas_test.go
@@ -3,50 +3,58 @@ package commands
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
-func TestLoadsDefaultYAMLWhenPresent(t *testing.T) {
-	rs := resetState()
-	defer rs()
-	os.Chdir("./testdata")
+var mockStatParams string
+
+func setupFaas(statError error) {
+	yamlFile = ""
+	mockStatParams = ""
+	faasCmd.SetOutput(ioutil.Discard)
+
+	stat = func(f string) (os.FileInfo, error) {
+		mockStatParams = f
+		return nil, statError
+	}
+}
+
+func TestCallsStatWithDefaulYAMLFileName(t *testing.T) {
+	setupFaas(nil)
 
 	Execute([]string{"help"})
 
-	if yamlFile != "stack.yml" {
-		t.Fatalf("Expected yamlFile to equal %v got %v\n", "stack.yml", yamlFile)
+	if mockStatParams != defaultYAML {
+		t.Fatalf("Expected yamlFile to equal %v got %v\n", defaultYAML, yamlFile)
+	}
+}
+
+func TestLoadsDefaultYAMLWhenPresent(t *testing.T) {
+	setupFaas(nil)
+
+	Execute([]string{"help"})
+
+	if yamlFile != defaultYAML {
+		t.Fatalf("Expected yamlFile to equal %v got %v\n", defaultYAML, yamlFile)
 	}
 }
 
 func TestLoadsFromParmetersYAMLWhenPresentAndDefaultYAMLFileAlsoPresent(t *testing.T) {
-	rs := resetState()
-	defer rs()
-	os.Chdir("./testdata")
+	setupFaas(nil)
 
 	Execute([]string{"help", "--yaml=myfile.yml"})
 
 	if yamlFile != "myfile.yml" {
-		t.Fatalf("Expected yamlFile to equal %v got %v\n", "stack.yml", yamlFile)
+		t.Fatalf("Expected yamlFile to equal %v got %v\n", "myfile.yml", yamlFile)
 	}
 }
 
 func TestDoesNotLoadDefaultYAMLWhenMissing(t *testing.T) {
-	rs := resetState()
-	defer rs()
+	setupFaas(os.ErrNotExist)
 
 	Execute([]string{"help"})
 
 	if yamlFile != "" {
 		t.Fatalf("Expected yamlFile to be blank got %v\n", yamlFile)
-	}
-}
-
-func resetState() func() {
-	faasCmd.SetOutput(ioutil.Discard)
-	dir, _ := filepath.Abs("./")
-	return func() {
-		os.Chdir(dir)
-		yamlFile = ""
 	}
 }

--- a/commands/faas_test.go
+++ b/commands/faas_test.go
@@ -1,0 +1,52 @@
+package commands
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadsDefaultYAMLWhenPresent(t *testing.T) {
+	rs := resetState()
+	defer rs()
+	os.Chdir("./testdata")
+
+	Execute([]string{"help"})
+
+	if yamlFile != "stack.yml" {
+		t.Fatalf("Expected yamlFile to equal %v got %v\n", "stack.yml", yamlFile)
+	}
+}
+
+func TestLoadsFromParmetersYAMLWhenPresentAndDefaultYAMLFileAlsoPresent(t *testing.T) {
+	rs := resetState()
+	defer rs()
+	os.Chdir("./testdata")
+
+	Execute([]string{"help", "--yaml=myfile.yml"})
+
+	if yamlFile != "myfile.yml" {
+		t.Fatalf("Expected yamlFile to equal %v got %v\n", "stack.yml", yamlFile)
+	}
+}
+
+func TestDoesNotLoadDefaultYAMLWhenMissing(t *testing.T) {
+	rs := resetState()
+	defer rs()
+
+	Execute([]string{"help"})
+
+	if yamlFile != "" {
+		t.Fatalf("Expected yamlFile to be blank got %v\n", yamlFile)
+	}
+}
+
+func resetState() func() {
+	faasCmd.SetOutput(ioutil.Discard)
+	dir, _ := filepath.Abs("./")
+	return func() {
+		os.Chdir(dir)
+		yamlFile = ""
+	}
+}

--- a/commands/testdata/stack.yml
+++ b/commands/testdata/stack.yml
@@ -1,3 +1,0 @@
-provider:
-  name: faas
-  gateway: http://localhost:8080

--- a/commands/testdata/stack.yml
+++ b/commands/testdata/stack.yml
@@ -1,0 +1,3 @@
+provider:
+  name: faas
+  gateway: http://localhost:8080


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added capability to load a default configuration file `stack.yaml` when present in the current folder.  If a default is present this can still be overridden by providing the flag `--yaml=file.yaml`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Code has been tested on a unit level and basic manual testing has also been performed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.