### PR TITLE
Error checking for cli exec-commands

### DIFF
--- a/builder/exec.go
+++ b/builder/exec.go
@@ -4,8 +4,12 @@
 package builder
 
 import (
+	"fmt"
+	"log"
 	"os"
 	"os/exec"
+
+	"github.com/morikuni/aec"
 )
 
 // ExecCommand run a system command
@@ -15,5 +19,9 @@ func ExecCommand(tempPath string, builder []string) {
 	targetCmd.Stdout = os.Stdout
 	targetCmd.Stderr = os.Stderr
 	targetCmd.Start()
-	targetCmd.Wait()
+	err := targetCmd.Wait()
+	if err != nil {
+		errString := fmt.Sprintf("ERROR - Could not execute command: %s", builder)
+		log.Fatalf(aec.RedF.Apply(errString))
+	}
 }


### PR DESCRIPTION
  faas-cli will now check the exit status of exec commands
  (i.e. <docker build ...>) and will "stop the world" if
  a non-zero exit occurs.

Signed-off-by: Alex Shorsher <alex.shorsher@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, even if `faas-cli build` failed when building a container from a Dockerfile, faas-cli would continue executing.  The correct behavior should be to stop faas-cli execution, log, and present the user with a noticeable error message.  

The issue originally just referenced throwing an error if `faas-cli build` fails, however, it seems my changes would also add error checking for other commands that use ExecuteCommand() (currently just `faas-cli push`).  I think this is acceptable?

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#138 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Here are some gif's of me running tests using the included samples.  They include a single function building  w/ a Dockerfile failing as expected, multiple functions with an expected failing Dockerfile, and one correct build using the samples.  Apologizing in advance for the crap gif quality.  

**Single function failure**
http://gph.is/2g98SlH
**Multi-function failure**
http://gph.is/2g9nmlx
**Passing example**
http://gph.is/2g7SZfs


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
