### PR TITLE
Add Go template capability for creating functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ WORKDIR /go/src/github.com/openfaas/faas-cli
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
-RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
  && GIT_COMMIT=$(git rev-list -1 HEAD) \
- && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli .
-RUN go test $(go list ./... | grep -v /vendor/ | grep -v /template/) -cover
+ && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli . \
+ && go test $(go list ./... | grep -v /vendor/ | grep -v /template/) -cover
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 RUN VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
  && GIT_COMMIT=$(git rev-list -1 HEAD) \
  && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w -X github.com/openfaas/faas-cli/commands.GitCommit=${GIT_COMMIT} -X github.com/openfaas/faas-cli/commands.Version=${VERSION}" -a -installsuffix cgo -o faas-cli .
-RUN go test ./... -cover
+RUN go test $(go list ./... | grep -v /vendor/ | grep -v /template/) -cover
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,9 @@
 
 build:
 	./build.sh
+
 build_redist:
 	./build_redist.sh
+
+unit_test:
+	go test $(shell go list ./... | grep -v /vendor/ | grep -v /template/) -cover

--- a/builder/build.go
+++ b/builder/build.go
@@ -15,7 +15,7 @@ import (
 func BuildImage(image string, handler string, functionName string, language string, nocache bool, squash bool) {
 
 	switch language {
-	case "node", "python", "ruby", "csharp", "python3":
+	case "node", "python", "ruby", "csharp", "python3", "go":
 		tempPath := createBuildTemplate(functionName, handler, language)
 
 		fmt.Printf("Building: %s with %s template. Please wait..\n", image, language)

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -52,6 +52,7 @@ func runNewFunction(cmd *cobra.Command, args []string) {
 - ruby
 - csharp
 - Dockerfile
+- go
 
 Or alternatively create a folder containing a Dockerfile, then pick
 the "Dockerfile" lang type in your YAML file.

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /go/src/handler
 COPY . .
 
 # Run a gofmt and exclude all vendored code.
-RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 RUN CGO_ENABLED=0 GOOS=linux \
-    go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
-RUN go test ./... -cover
+    go build --ldflags "-s -w" -a -installsuffix cgo -o handler . &&
+    go test ./... -cover
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -13,16 +13,24 @@ COPY . .
 RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))" || { echo "Run \"gofmt -s -w\" on your Golang code"; exit 1; }
 
 RUN CGO_ENABLED=0 GOOS=linux \
-    go build --ldflags "-s -w" -a -installsuffix cgo -o handler . &&
+    go build --ldflags "-s -w" -a -installsuffix cgo -o handler . && \
     go test ./... -cover
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 
-WORKDIR /root/
+# Add non root user
+RUN addgroup -S app && adduser -S -g app app
+RUN mkdir -p /home/app
+RUN chown app /home/app
+
+WORKDIR /home/app
 
 COPY --from=0 /go/src/handler/handler    .
 COPY --from=0 /usr/bin/fwatchdog         .
+
+USER app
+
 ENV fprocess="./handler"
 
 CMD ["./fwatchdog"]

--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.8.3-alpine
+
+RUN apk --no-cache add curl \ 
+    && echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.5/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && apk del curl --no-cache
+
+WORKDIR /go/src/handler
+COPY . .
+
+# Run a gofmt and exclude all vendored code.
+RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
+
+RUN CGO_ENABLED=0 GOOS=linux \
+    go build --ldflags "-s -w" -a -installsuffix cgo -o handler .
+RUN go test ./... -cover
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
+
+WORKDIR /root/
+
+COPY --from=0 /go/src/handler/handler    .
+COPY --from=0 /usr/bin/fwatchdog         .
+ENV fprocess="./handler"
+
+CMD ["./fwatchdog"]

--- a/template/go/function/handler.go
+++ b/template/go/function/handler.go
@@ -1,0 +1,10 @@
+package function
+
+import (
+	"fmt"
+)
+
+// Handle a serverless request
+func Handle(req []byte) string {
+	return fmt.Sprintf("Hello, Go. You said: %s", string(req))
+}

--- a/template/go/function/handler_test.go
+++ b/template/go/function/handler_test.go
@@ -1,0 +1,12 @@
+package function
+
+import "testing"
+
+func TestHandleReturnsCorrectResponse(t *testing.T) {
+	expected := "Hello, Go. You said: Hello World ss"
+	resp := Handle([]byte("Hello World"))
+
+	if resp != expected {
+		t.Fatalf("Expected: %v, Got: %v", expected, resp)
+	}
+}

--- a/template/go/function/handler_test.go
+++ b/template/go/function/handler_test.go
@@ -3,7 +3,7 @@ package function
 import "testing"
 
 func TestHandleReturnsCorrectResponse(t *testing.T) {
-	expected := "Hello, Go. You said: Hello World ss"
+	expected := "Hello, Go. You said: Hello World"
 	resp := Handle([]byte("Hello World"))
 
 	if resp != expected {

--- a/template/go/main.go
+++ b/template/go/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"handler/function"
+)
+
+func main() {
+	input, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("Unable to read standard input: %s", err.Error())
+	}
+
+	fmt.Println(function.Handle(input))
+}


### PR DESCRIPTION
## Description
Added capability to create functions in go, a new template has been added and the cli has been modified to allow an additional language 'Go'.

## Motivation and Context
This update adds the capability to create new functions using the Go programming language using the fans-cli.

https://github.com/openfaas/faas-cli/issues/86
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Unit tests have been run and a manual test has been performed creating a Go function and deploying it to OpenFaaS.  The function was then load tested on the running OpenFaaS instance.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.