### PR TITLE
Amend golang template Dockerfile so that go test ignores vendor fixes #146

### DIFF
--- a/template/go/Dockerfile
+++ b/template/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8.3-alpine
+FROM golang:1.8.3-alpine3.6
 
 RUN apk --no-cache add curl \ 
     && echo "Pulling watchdog binary from Github." \
@@ -14,7 +14,7 @@ RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 
 RUN CGO_ENABLED=0 GOOS=linux \
     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . && \
-    go test ./... -cover
+    go test $(go list ./... | grep -v /vendor/) -cover
 
 FROM alpine:3.6
 RUN apk --no-cache add ca-certificates


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Changes step 6 of the golang template Dockerfile so that `go test` ignores the vendor directory.

## Motivation and Context
Fixes #146 
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Pre-Testing
```
Step 6/17 : RUN CGO_ENABLED=0 GOOS=linux     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . &&     go test ./... -cover
 ---> Running in 1e4f120fde05
?   	handler	[no test files]
ok  	handler/function	0.003s	coverage: 80.0% of statements
ok  	handler/function/vendor/github.com/cnf/structhash	0.003s	coverage: 88.4% of statements
 ---> f8ec69fde5ce
```

Post-Testing
```
Step 6/17 : RUN CGO_ENABLED=0 GOOS=linux     go build --ldflags "-s -w" -a -installsuffix cgo -o handler . &&     go test $(go list ./... | grep -v /vendor/) -cover
 ---> Running in 43b6eb844b50
?   	handler	[no test files]
ok  	handler/function	0.003s	coverage: 80.0% of statements
 ---> 45d105e39fac
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
