### PR TITLE
Fix environment file example

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ If you specify a variable such as "access_key" in more than one `environment_fil
 
 Environment file format:
 
-```
+```yaml
 environment:
-  - access_key: key1
-  - secret_key: key2
+  access_key: key1
+  secret_key: key2
 ```
 
 * Define environment in-line within the file:
@@ -167,14 +167,14 @@ Constraints work with Docker Swarm and are useful for pinning functions to certa
 
 Here is an example of picking only Linux:
 
-```
+```yaml
    constraints:
      - "node.platform.os == linux"
 ```
 
 Or only Windows:
 
-```
+```yaml
    constraints:
      - "node.platform.os == windows"
 ```


### PR DESCRIPTION
Signed-off-by: Finnian Anderson <get@finnian.io>

<!--- Provide a general summary of your changes in the Title above -->
In the README, there is an example for the `environment_file` which has the incorrect syntax for the yaml.

## Description
This:
```yaml
environment:
  - access_key: key1
  - secret_key: key2
```

Should be this:
```yaml
environment:
  access_key: key1
  secret_key: key2
```

I've also added a couple of missing `yaml` code block syntax highlighting labels.

## Motivation and Context
Misleading example, had to battle with it for 10 minutes so I thought it would be nice to update the example so others don't encounter the same issue.
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
