### PR TITLE
Add missing deps to vendor.conf

### DIFF
--- a/vendor.conf
+++ b/vendor.conf
@@ -3,3 +3,5 @@ gopkg.in/yaml.v2 cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 github.com/spf13/cobra 2df9a531813370438a4d79bfc33e21f58063ed87
 github.com/spf13/pflag e57e3eeb33f795204c1ca35f56c44f83227c6e6
 github.com/ryanuber/go-glob 256dc444b735e061061cf46c809487313d5b0065
+github.com/morikuni/aec 39771216ff4c63d11f5e604076f9c45e8be1067b
+github.com/inconshreveable/mousetrap 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75


### PR DESCRIPTION
Signed-off-by: John McCabe <john@johnmccabe.net>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Looks like `vendor.conf` hadn't been updated when the `aec` and `inconshreveable` deps were added.

This commit freezes the deps in `vendor.conf` without altering any of the vendored versions.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Skipped due to trivial nature of the change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
