### PR TITLE
Modified installation script to pull .exe on Windows / Git Bash

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -39,6 +39,9 @@ getPackage() {
         ;;
         esac
     ;;
+    *_NT*)
+    suffix=".exe"
+    ;;
     esac
 
     if [ -e /tmp/faas-cli ]; then


### PR DESCRIPTION
Signed-off-by: Weston Steimel <wsteimel77@gmail.com>

## Description
Added another case when parsing uname to try and get the correct binary suffix when installing on a Windows system.

## Motivation and Context
Running the script in Windows currently installs the Linux binary
#159
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have used this script to install faas-cli using Git Bash on a Windows 10 machine
I have also used the modified script to install faas-cli on Arch Linux

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
