### PR TITLE
Remove language default and fix command flags

### DIFF
--- a/MANUAL_CLI.md
+++ b/MANUAL_CLI.md
@@ -10,11 +10,12 @@ So if you want to write in another language, just prepare a Dockerfile and build
 
 This will generate a Docker image for a Node.js function using the code in `/samples/info`.
 
-* The `faas-cli build` command can accept a `--lang` option of `python` or `node` and is `node` by default.
+* The `faas-cli build` command can accept a `--lang` option of `python`, `node`, `ruby`, `csharp`, `python3`, `go`, or `dockerfile`.
 
 ```
    $ faas-cli build \
       --image=alexellis2/node_info \
+      --lang= node \
       --name=node_info \
       --handler=./sample/node_info
 

--- a/commands/build.go
+++ b/commands/build.go
@@ -26,7 +26,7 @@ func init() {
 	buildCmd.Flags().StringVar(&image, "image", "", "Docker image name to build")
 	buildCmd.Flags().StringVar(&handler, "handler", "", "Directory with handler for function, e.g. handler.js")
 	buildCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
-	buildCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
+	buildCmd.Flags().StringVar(&language, "lang", "", "Programming language template")
 
 	// Setup flags that are used only by this command (variables defined above)
 	buildCmd.Flags().BoolVar(&nocache, "no-cache", false, "Do not use Docker's build cache")

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -33,7 +33,7 @@ func init() {
 	deployCmd.Flags().StringVar(&gateway, "gateway", defaultGateway, "Gateway URI")
 	deployCmd.Flags().StringVar(&handler, "handler", "", "Directory with handler for function, e.g. handler.js")
 	deployCmd.Flags().StringVar(&image, "image", "", "Docker image name to build")
-	deployCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
+	deployCmd.Flags().StringVar(&language, "lang", "", "Programming language template")
 	deployCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
 	deployCmd.Flags().StringVar(&network, "network", defaultNetwork, "Name of the network")
 

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	verboseInvoke bool
-	contentType   string
+	contentType string
 )
 
 func init() {
@@ -24,9 +23,7 @@ func init() {
 	invokeCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
 	invokeCmd.Flags().StringVar(&gateway, "gateway", defaultGateway, "Gateway URI")
 
-	invokeCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
 	invokeCmd.Flags().StringVar(&contentType, "content-type", "text/plain", "The content-type HTTP header such as application/json")
-	invokeCmd.Flags().BoolVar(&verboseInvoke, "verbose", false, "Verbose output for the function list")
 
 	faasCmd.AddCommand(invokeCmd)
 }

--- a/commands/list.go
+++ b/commands/list.go
@@ -18,12 +18,7 @@ var (
 
 func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
-	listCmd.Flags().StringVar(&fprocess, "fprocess", "", "Fprocess to be run by the watchdog")
 	listCmd.Flags().StringVar(&gateway, "gateway", defaultGateway, "Gateway URI")
-	listCmd.Flags().StringVar(&handler, "handler", "", "Directory with handler for function, e.g. handler.js")
-	listCmd.Flags().StringVar(&image, "image", "", "Docker image name to build")
-	listCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
-	listCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
 
 	listCmd.Flags().BoolVar(&verboseList, "verbose", false, "Verbose output for the function list")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR stops using `node` as a default language due to it conflicting with functions where the `fprocess`envvar  is set in the image.

Given the large numbers of languages having a default makes less sense now.

It also removes some of the copy-paste/redundant/irrelevant flag definitions that ended up in newly added subcommands.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (#169, also openfaas/faas#297)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Have run deploy, build, invoke and list commands without problem.
2. Run a deploy with no `--fprocess` flag, function gets created with one being set as expected and correctly honours the setting in the image.
3. Ran a build with --lang set and successfully built and deployed (used the [first-faas-python-function](https://blog.alexellis.io/first-faas-python-function/) guide as a test run).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Strictly speaking this *is* a breaking change, but it only impacts a very small edge case - that is where you deploy node functions via the CLI and rely on the language being set to `node` by default.

As mentioned above, the growing number of function languages means that for the vast majority of users this won't be an issue and I think we're better having a single common behaviour for all users - which for the moment should include setting the language flag `--lang`.

Note that the logic setting a default `fprocess` when a language is set has not changed and remains useful.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
