### PR TITLE
Modified installation script to pull .exe on Windows / Git Bash

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -39,6 +39,9 @@ getPackage() {
         ;;
         esac
     ;;
+    *_NT*)
+    suffix=".exe"
+    ;;
     esac
 
     if [ -e /tmp/faas-cli ]; then

--- a/get.sh
+++ b/get.sh
@@ -21,7 +21,7 @@ getPackage() {
     uname=$(uname)
 
     suffix=""
-    temp="/tmp/faas-cli"
+    cli="/tmp/faas-cli"
     case $uname in
     "Darwin")
     suffix="-darwin"
@@ -42,23 +42,28 @@ getPackage() {
     ;;
     *_NT*)
     suffix=".exe"
-    temp=$temp$suffix
+    cli=$cli$suffix
     ;;
     esac
 
-    if [ -e $temp ]; then
-        rm $temp
+    if [ -e $cli ]; then
+        rm $cli
     fi
 
     url=https://github.com/openfaas/faas-cli/releases/download/$version/faas-cli$suffix
     echo "Getting package $url"
 
-    curl -sSL $url > $temp
+    curl -sSL $url > $cli
 
     if [ "$?" = "0" ]; then
         echo "Attemping to move faas-cli to /usr/local/bin"
-        chmod +x $temp
-        cp $temp /usr/local/bin/
+	
+	if [ ! -d /usr/local/bin ]; then
+	    mkdir -p /usr/local/bin
+        fi
+
+        chmod +x $cli
+        cp $cli /usr/local/bin/
         if [ "$?" = "0" ]; then
             echo "New version of faas-cli installed to /usr/local/bin"
         fi

--- a/get.sh
+++ b/get.sh
@@ -21,6 +21,7 @@ getPackage() {
     uname=$(uname)
 
     suffix=""
+    temp="/tmp/faas-cli"
     case $uname in
     "Darwin")
     suffix="-darwin"
@@ -41,22 +42,23 @@ getPackage() {
     ;;
     *_NT*)
     suffix=".exe"
+    temp=$temp$suffix
     ;;
     esac
 
-    if [ -e /tmp/faas-cli ]; then
-        rm /tmp/faas-cli
+    if [ -e $temp ]; then
+        rm $temp
     fi
 
     url=https://github.com/openfaas/faas-cli/releases/download/$version/faas-cli$suffix
     echo "Getting package $url"
 
-    curl -sSL $url > /tmp/faas-cli
+    curl -sSL $url > $temp
 
     if [ "$?" = "0" ]; then
         echo "Attemping to move faas-cli to /usr/local/bin"
-        chmod +x /tmp/faas-cli
-        cp /tmp/faas-cli /usr/local/bin/
+        chmod +x $temp
+        cp $temp /usr/local/bin/
         if [ "$?" = "0" ]; then
             echo "New version of faas-cli installed to /usr/local/bin"
         fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added another case when parsing uname to try and get the correct binary suffix when installing on a Windows system and retain the .exe extension when saving to temp dir.

## Motivation and Context
Running the script in Windows currently installs the Linux binary
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#159 

## How Has This Been Tested?
Invoked in Git Bash on Windows 10:
```
$ sh get.sh
You already have the faas-cli!
Overwriting in 1 seconds.. Press Control+C to cancel.
Getting package https://github.com/openfaas/faas-cli/releases/download/0.4.18b/faas-cli.exe
Attemping to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
$ faas-cli version
  ___                   _____           ____
/ _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
\___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

Commit: e804a60889e4d339762fb3643a315a173a963f26
Version: 0.4.18b
```

Then tested in Powershell with faas-cli.exe included in the path and was able to successfully invoke faas-cli because .exe is retained.

I have also successfully updated faas-cli on Arch Linux using the revised script. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
