### PR TITLE
Enable passing query string parameters when using invoke

### DIFF
--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -17,6 +17,7 @@ import (
 var (
 	verboseInvoke bool
 	contentType   string
+	query         []string
 )
 
 func init() {
@@ -26,17 +27,18 @@ func init() {
 
 	invokeCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
 	invokeCmd.Flags().StringVar(&contentType, "content-type", "text/plain", "The content-type HTTP header such as application/json")
+	invokeCmd.Flags().StringArrayVar(&query, "query", []string{}, "Pass query string parameters (key=value)")
 	invokeCmd.Flags().BoolVar(&verboseInvoke, "verbose", false, "Verbose output for the function list")
 
 	faasCmd.AddCommand(invokeCmd)
 }
 
 var invokeCmd = &cobra.Command{
-	Use:   `invoke FUNCTION_NAME [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE]`,
+	Use:   `invoke FUNCTION_NAME [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE] [--query PARAM=VALUE]`,
 	Short: "Invoke an OpenFaaS function",
 	Long:  `Invokes an OpenFaaS function and reads from STDIN for the body of the request`,
 	Example: `  faas-cli invoke echo --gateway https://domain:port
-  faas-cli invoke echo --gateway https://domain:port --content-type application/json`,
+  faas-cli invoke echo --gateway https://domain:port --content-type application/json --query repo=faas-cli --query org=openfaas`,
 	Run: runInvoke,
 }
 
@@ -74,7 +76,7 @@ func runInvoke(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	response, err := proxy.InvokeFunction(gateway, functionName, &functionInput, contentType)
+	response, err := proxy.InvokeFunction(gateway, functionName, &query, &functionInput, contentType)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -8,17 +8,25 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
 // InvokeFunction a function
-func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType string) (*[]byte, error) {
+func InvokeFunction(gateway string, name string, query *[]string, bytesIn *[]byte, contentType string) (*[]byte, error) {
 	var resBytes []byte
 
 	gateway = strings.TrimRight(gateway, "/")
 
+	funcURL, err := buildURL(gateway+"/function/"+name, query)
+	if err != nil {
+		fmt.Println()
+		fmt.Println(err)
+		return nil, fmt.Errorf("cannot create the URL")
+	}
+
 	reader := bytes.NewReader(*bytesIn)
-	res, err := http.Post(gateway+"/function/"+name, contentType, reader)
+	res, err := http.Post(funcURL, contentType, reader)
 	if err != nil {
 		fmt.Println()
 		fmt.Println(err)
@@ -45,4 +53,27 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 	}
 
 	return &resBytes, nil
+}
+
+func buildURL(baseURL string, query *[]string) (string, error) {
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		fmt.Println()
+		fmt.Println(err)
+		return "", fmt.Errorf("cannot parse URL: %s", baseURL)
+	}
+
+	if *query != nil {
+		q := u.Query()
+		for _, valueStr := range *query {
+			value := strings.Split(valueStr, "=")
+			if len(value) != 2 {
+				return "", fmt.Errorf("wrong query format, should be key=value %s", valueStr)
+			}
+			q.Add(value[0], value[1])
+		}
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
 }

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -55,3 +55,28 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 		t.Fatalf("Error not matched: %s", err)
 	}
 }
+
+func Test_buildURL(t *testing.T) {
+
+	baseURL := "http://localhost:8080/function/function"
+	query := []string{"ascii=<key: 0x90>", "key=foo & bar"}
+	fullURL := baseURL + "?ascii=%3Ckey%3A+0x90%3E&key=foo+%26+bar"
+	u, err := buildURL(baseURL, &query)
+	if err != nil {
+		if u != fullURL {
+			t.Fatalf("building the URL failed")
+		}
+	}
+
+	query = []string{"no_equal_sign"}
+	u, err = buildURL(baseURL, &query)
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+
+	baseURL = "http://127.0.0.%31:8080"
+	u, err = buildURL(baseURL, &query)
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+}

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -18,9 +18,11 @@ func Test_InvokeFunction(t *testing.T) {
 	defer s.Close()
 
 	bytesIn := []byte("test data")
+	query := []string{"ascii=<key: 0x90>", "key=foo & bar"}
 	_, err := InvokeFunction(
 		s.URL,
 		"function",
+		&query,
 		&bytesIn,
 		"text/plain",
 	)
@@ -35,9 +37,11 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 	defer s.Close()
 
 	bytesIn := []byte("test data")
+	query := []string{"key=val"}
 	_, err := InvokeFunction(
 		s.URL,
 		"function",
+		&query,
 		&bytesIn,
 		"text/plain",
 	)


### PR DESCRIPTION
Signed-off-by: Nenad Ilic <nenadilic84@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
New parameter `query` is added to the `invoke` command to allow passing query strings
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It implements the issue #168 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
faas-cli invoke flaskapp --query name=test
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
