### PR TITLE
Fixes --gateway override which was ignored when using YAML

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -104,7 +104,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		}
 
 		// Override gateway if passed
-		if len(gateway) > 0 && gateway != defaultGateway {
+		if len(gateway) > 0 && gateway != parsedServices.Provider.GatewayURL {
 			parsedServices.Provider.GatewayURL = gateway
 		}
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

if you have a non-default gateway in YAML the --gateway flag is ignored if passed as an override.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Bug fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Use YAML with a non-default gateway and pass --gateway.