### PR TITLE
Initial Basic Auth works

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -36,6 +36,8 @@ func init() {
 	deployCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
 	deployCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
 	deployCmd.Flags().StringVar(&network, "network", defaultNetwork, "Name of the network")
+	deployCmd.Flags().StringVar(&username, "username", "", "Username to be used in authentication with gateway")
+	deployCmd.Flags().StringVar(&password, "password", "", "Password to be used in authentication with gateway")
 
 	// Setup flags that are used only by this command (variables defined above)
 	deployCmd.Flags().StringArrayVarP(&envvarOpts, "env", "e", []string{}, "Set one or more environment variables (ENVVAR=VALUE)")
@@ -61,6 +63,8 @@ var deployCmd = &cobra.Command{
                   [--network NETWORK_NAME]
                   [--handler HANDLER_DIR]
                   [--fprocess PROCESS]
+                  [--username USERNAME]
+                  [--password PASSWORD]
                   [--env ENVVAR=VALUE ...]
 				  [--replace=false]
 				  [--update=false]
@@ -138,7 +142,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 
 			allEnvironment := mergeMap(function.Environment, fileEnvironment)
 
-			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.Language, replace, allEnvironment, services.Provider.Network, constraints, update, secrets)
+			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.Language, replace, allEnvironment, services.Provider.Network, constraints, update, username, password, secrets)
 		}
 	} else {
 		if len(image) == 0 {
@@ -156,7 +160,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 			os.Exit(1)
 		}
 
-		proxy.DeployFunction(fprocess, gateway, functionName, image, language, replace, envvars, network, constraints, update, secrets)
+		proxy.DeployFunction(fprocess, gateway, functionName, image, language, replace, envvars, network, constraints, update, username, password, secrets)
 	}
 }
 

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -28,6 +28,8 @@ var (
 	handler      string
 	image        string
 	language     string
+	username     string
+	password     string
 )
 
 func init() {

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -23,6 +23,8 @@ func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
 	invokeCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
 	invokeCmd.Flags().StringVar(&gateway, "gateway", defaultGateway, "Gateway URI")
+	invokeCmd.Flags().StringVar(&username, "username", "", "Username to be used in authentication with gateway")
+	invokeCmd.Flags().StringVar(&password, "password", "", "Password to be used in authentication with gateway")
 
 	invokeCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
 	invokeCmd.Flags().StringVar(&contentType, "content-type", "text/plain", "The content-type HTTP header such as application/json")
@@ -32,7 +34,7 @@ func init() {
 }
 
 var invokeCmd = &cobra.Command{
-	Use:   `invoke FUNCTION_NAME [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE]`,
+	Use:   `invoke FUNCTION_NAME [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE] [--username USERNAME] [--password PASSWORD]`,
 	Short: "Invoke an OpenFaaS function",
 	Long:  `Invokes an OpenFaaS function and reads from STDIN for the body of the request`,
 	Example: `  faas-cli invoke echo --gateway https://domain:port
@@ -74,7 +76,7 @@ func runInvoke(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	response, err := proxy.InvokeFunction(gateway, functionName, &functionInput, contentType)
+	response, err := proxy.InvokeFunction(gateway, functionName, &functionInput, contentType, username, password)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/commands/list.go
+++ b/commands/list.go
@@ -24,6 +24,8 @@ func init() {
 	listCmd.Flags().StringVar(&image, "image", "", "Docker image name to build")
 	listCmd.Flags().StringVar(&language, "lang", "node", "Programming language template")
 	listCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
+	listCmd.Flags().StringVar(&username, "username", "", "Username to be used in authentication with gateway")
+	listCmd.Flags().StringVar(&password, "password", "", "Password to be used in authentication with gateway")
 
 	listCmd.Flags().BoolVar(&verboseList, "verbose", false, "Verbose output for the function list")
 
@@ -31,7 +33,7 @@ func init() {
 }
 
 var listCmd = &cobra.Command{
-	Use:     `list [--gateway GATEWAY_URL] [--verbose]`,
+	Use:     `list [--gateway GATEWAY_URL] [--username USERNAME] [--password PASSWORD] [--verbose]`,
 	Aliases: []string{"ls"},
 	Short:   "List OpenFaaS functions",
 	Long:    `Lists OpenFaaS functions either on a local or remote gateway`,
@@ -61,7 +63,7 @@ func runList(cmd *cobra.Command, args []string) {
 	}
 
 	// fmt.Println(gatewayAddress)
-	functions, err := proxy.ListFunctions(gatewayAddress)
+	functions, err := proxy.ListFunctions(gatewayAddress, username, password)
 	if err != nil {
 		log.Println(err)
 		return

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -15,13 +15,15 @@ import (
 func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
 	removeCmd.Flags().StringVar(&gateway, "gateway", defaultGateway, "Gateway URI")
+	removeCmd.Flags().StringVar(&username, "username", "", "Username to be used in authentication with gateway")
+	removeCmd.Flags().StringVar(&password, "password", "", "Password to be used in authentication with gateway")
 
 	faasCmd.AddCommand(removeCmd)
 }
 
 // removeCmd deletes/removes OpenFaaS function containers
 var removeCmd = &cobra.Command{
-	Use: `remove FUNCTION_NAME [--gateway GATEWAY_URL]
+	Use: `remove FUNCTION_NAME [--gateway GATEWAY_URL] [--username USERNAME] [--password PASSWORD]
   faas-cli remove -f YAML_FILE [--regex "REGEX"] [--filter "WILDCARD"]`,
 	Aliases: []string{"rm"},
 	Short:   "Remove deployed OpenFaaS functions",
@@ -60,7 +62,7 @@ func runDelete(cmd *cobra.Command, args []string) {
 			function.Name = k
 			fmt.Printf("Deleting: %s.\n", function.Name)
 
-			proxy.DeleteFunction(services.Provider.GatewayURL, function.Name)
+			proxy.DeleteFunction(services.Provider.GatewayURL, function.Name, username, password)
 		}
 	} else {
 		if len(args) < 1 {
@@ -70,6 +72,6 @@ func runDelete(cmd *cobra.Command, args []string) {
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
-		proxy.DeleteFunction(gateway, functionName)
+		proxy.DeleteFunction(gateway, functionName, username, password)
 	}
 }

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -15,7 +15,7 @@ import (
 )
 
 // DeleteFunction delete a function from the FaaS server
-func DeleteFunction(gateway string, functionName string) {
+func DeleteFunction(gateway string, functionName string, username string, password string) {
 	gateway = strings.TrimRight(gateway, "/")
 	delReq := requests.DeleteFunctionRequest{FunctionName: functionName}
 	reqBytes, _ := json.Marshal(&delReq)
@@ -23,6 +23,7 @@ func DeleteFunction(gateway string, functionName string) {
 
 	c := http.Client{}
 	req, _ := http.NewRequest("DELETE", gateway+"/system/functions", reader)
+	BasicAuthIfSet(req, username, password)
 	req.Header.Set("Content-Type", "application/json")
 	delRes, delErr := c.Do(req)
 	if delErr != nil {

--- a/proxy/delete_test.go
+++ b/proxy/delete_test.go
@@ -18,7 +18,7 @@ func Test_DeleteFunction(t *testing.T) {
 	defer s.Close()
 
 	stdout := test.CaptureStdout(func() {
-		DeleteFunction(s.URL, "function-to-delete")
+		DeleteFunction(s.URL, "function-to-delete", "", "")
 	})
 
 	r := regexp.MustCompile(`(?m:Removing old service.)`)
@@ -32,7 +32,7 @@ func Test_DeleteFunction_404(t *testing.T) {
 	defer s.Close()
 
 	stdout := test.CaptureStdout(func() {
-		DeleteFunction(s.URL, "function-to-delete")
+		DeleteFunction(s.URL, "function-to-delete", "", "")
 	})
 
 	r := regexp.MustCompile(`(?m:No existing service to remove)`)
@@ -46,7 +46,7 @@ func Test_DeleteFunction_Not2xxAnd404(t *testing.T) {
 	defer s.Close()
 
 	stdout := test.CaptureStdout(func() {
-		DeleteFunction(s.URL, "function-to-delete")
+		DeleteFunction(s.URL, "function-to-delete", "", "")
 	})
 
 	r := regexp.MustCompile(`(?m:Server returned unexpected status code)`)

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -15,7 +15,7 @@ import (
 )
 
 // DeployFunction call FaaS server to deploy a new function
-func DeployFunction(fprocess string, gateway string, functionName string, image string, language string, replace bool, envVars map[string]string, network string, constraints []string, update bool, secrets []string) {
+func DeployFunction(fprocess string, gateway string, functionName string, image string, language string, replace bool, envVars map[string]string, network string, constraints []string, update bool, username string, password string, secrets []string) {
 
 	// Need to alter Gateway to allow nil/empty string as fprocess, to avoid this repetition.
 	var fprocessTemplate string
@@ -36,7 +36,7 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	gateway = strings.TrimRight(gateway, "/")
 
 	if replace {
-		DeleteFunction(gateway, functionName)
+		DeleteFunction(gateway, functionName, username, password)
 	}
 
 	req := requests.CreateFunctionRequest{
@@ -60,6 +60,7 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	}
 
 	request, _ = http.NewRequest(method, gateway+"/system/functions", reader)
+	BasicAuthIfSet(request, username, password)
 	res, err := client.Do(request)
 
 	if err != nil {

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -33,6 +33,8 @@ func Test_DeployFunction(t *testing.T) {
 			"network",
 			[]string{},
 			false,
+			"",
+			"",
 			[]string{},
 		)
 	})
@@ -63,6 +65,8 @@ func Test_DeployFunction_Not2xx(t *testing.T) {
 			"network",
 			[]string{},
 			false,
+			"",
+			"",
 			[]string{},
 		)
 	})

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -12,13 +12,17 @@ import (
 )
 
 // InvokeFunction a function
-func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType string) (*[]byte, error) {
+func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType string, username string, password string) (*[]byte, error) {
 	var resBytes []byte
 
 	gateway = strings.TrimRight(gateway, "/")
 
 	reader := bytes.NewReader(*bytesIn)
-	res, err := http.Post(gateway+"/function/"+name, contentType, reader)
+	c := http.Client{}
+	req, _ := http.NewRequest("POST", gateway+"/function/"+name, reader)
+	req.Header.Set("Content-Type", contentType)
+	BasicAuthIfSet(req, username, password)
+	res, err := c.Do(req)
 	if err != nil {
 		fmt.Println()
 		fmt.Println(err)

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -23,7 +23,8 @@ func Test_InvokeFunction(t *testing.T) {
 		"function",
 		&bytesIn,
 		"text/plain",
-	)
+		"",
+		"")
 
 	if err != nil {
 		t.Fatalf("Error returned: %s", err)
@@ -40,7 +41,8 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 		"function",
 		&bytesIn,
 		"text/plain",
-	)
+		"",
+		"")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -14,12 +14,15 @@ import (
 )
 
 // ListFunctions list deployed functions
-func ListFunctions(gateway string) ([]requests.Function, error) {
+func ListFunctions(gateway string, username string, password string) ([]requests.Function, error) {
 	var results []requests.Function
 
 	gateway = strings.TrimRight(gateway, "/")
 
-	res, err := http.Get(gateway + "/system/functions")
+	c := http.Client{}
+	req, _ := http.NewRequest("GET", gateway+"/system/functions", nil)
+	BasicAuthIfSet(req, username, password)
+	res, err := c.Do(req)
 	if err != nil {
 		fmt.Println()
 		fmt.Println(err)

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -22,7 +22,7 @@ func Test_ListFunctions(t *testing.T) {
 	})
 	defer s.Close()
 
-	result, err := ListFunctions(s.URL)
+	result, err := ListFunctions(s.URL, "", "")
 
 	if err != nil {
 		t.Fatalf("Error returned: %s", err)
@@ -37,7 +37,7 @@ func Test_ListFunctions(t *testing.T) {
 func Test_ListFunctions_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
 
-	_, err := ListFunctions(s.URL)
+	_, err := ListFunctions(s.URL, "", "")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,11 @@
+package proxy
+
+import (
+	"net/http"
+)
+
+func BasicAuthIfSet(req *http.Request, username string, password string) {
+	if len(username) > 0 {
+		req.SetBasicAuth(username, password)
+	}
+}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,0 +1,27 @@
+package proxy
+
+import (
+	"net/http"
+
+	"testing"
+)
+
+func Test_BasicAuthCanAddIfSuppliedWithNonZeroLengthValues(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://someurl/", nil)
+	BasicAuthIfSet(req, "Aladdin", "open sesame")
+	header := req.Header.Get("Authorization")
+	expected := "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+	if header != expected {
+		t.Errorf("got header %q, want %q", header, expected)
+	}
+}
+
+func Test_BasicAuthWontAddIfNotSuppliedWithNonZeroLengthValues(t *testing.T) {
+	req, _ := http.NewRequest("GET", "http://someurl/", nil)
+	BasicAuthIfSet(req, "", "")
+	header := req.Header.Get("Authorization")
+	expected := ""
+	if header != expected {
+		t.Errorf("got header %q, want %q", header, expected)
+	}
+}


### PR DESCRIPTION
Initial Work on Basic Auth

## Description

 * Added helper to proxy with tests for basic auth
 * Deploy
 * Delete (because required by Deploy)

## Motivation and Context

- [x] ~~I have~~ raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

See #178 

## How Has This Been Tested?

Improves coverage of proxy by 2.6%, improves coverage by 1.1%. Two tests located in proxy for the new method added. (Should work in any Go repo using HttpRequest). Canned data used is from Go internal tests for `SetBasicAuth`. Added to proxy as it's really more of an implementation detail where it's used.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (some, but needs work, unsure how to communicate best)
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
