### PR TITLE
Add error handling for calls to http.NewRequest() in package proxy

### DIFF
--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -16,15 +16,17 @@ import (
 
 // DeleteFunction delete a function from the FaaS server
 func DeleteFunction(gateway string, functionName string) error {
-	var err error
-
 	gateway = strings.TrimRight(gateway, "/")
 	delReq := requests.DeleteFunctionRequest{FunctionName: functionName}
 	reqBytes, _ := json.Marshal(&delReq)
 	reader := bytes.NewReader(reqBytes)
 
 	c := http.Client{}
-	req, _ := http.NewRequest("DELETE", gateway+"/system/functions", reader)
+	req, err := http.NewRequest("DELETE", gateway+"/system/functions", reader)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
 	req.Header.Set("Content-Type", "application/json")
 	delRes, delErr := c.Do(req)
 

--- a/proxy/delete_test.go
+++ b/proxy/delete_test.go
@@ -54,3 +54,16 @@ func Test_DeleteFunction_Not2xxAnd404(t *testing.T) {
 		t.Fatalf("Output not matched: %s", stdout)
 	}
 }
+
+func Test_DeleteFunction_BadURL(t *testing.T) {
+	url := "127.0.0.1:8080"
+
+	stdout := test.CaptureStdout(func() {
+		DeleteFunction(url, "function-to-delete")
+	})
+
+	r := regexp.MustCompile(`(?m:first path segment in URL cannot contain colon)`)
+	if !r.MatchString(stdout) {
+		t.Fatalf("Output not matched: %s", stdout)
+	}
+}

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -72,7 +72,13 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 		method = http.MethodPut
 	}
 
-	request, _ = http.NewRequest(method, gateway+"/system/functions", reader)
+	var err error
+	request, err = http.NewRequest(method, gateway+"/system/functions", reader)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+
 	res, err := client.Do(request)
 
 	if err != nil {

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -74,3 +74,29 @@ func Test_DeployFunction_Not2xx(t *testing.T) {
 		t.Fatalf("Output not matched: %s", stdout)
 	}
 }
+
+func Test_DeployFunction_BadURL(t *testing.T) {
+	url := "127.0.0.1:8080"
+
+	stdout := test.CaptureStdout(func() {
+		DeployFunction(
+			"fprocess",
+			url,
+			"function",
+			"image",
+			"language",
+			false,
+			nil,
+			"network",
+			[]string{},
+			false,
+			[]string{},
+			map[string]string{},
+		)
+	})
+
+	r := regexp.MustCompile(`(?m:first path segment in URL cannot contain colon)`)
+	if !r.MatchString(stdout) {
+		t.Fatalf("Output not matched: %s", stdout)
+	}
+}

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -30,8 +30,14 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 	}
 
 	gatewayURL := gateway + "/function/" + name + qs
-	// fmt.Println(gatewayURL)
-	req, _ := http.NewRequest(http.MethodPost, gatewayURL, reader)
+
+	req, err := http.NewRequest(http.MethodPost, gatewayURL, reader)
+	if err != nil {
+		fmt.Println()
+		fmt.Println(err)
+		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+	}
+
 	req.Header.Add("Content-Type", contentType)
 
 	res, err := client.Do(req)

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -53,3 +53,24 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 		t.Fatalf("Error not matched: %s", err)
 	}
 }
+
+func Test_InvokeFunction_BadURL(t *testing.T) {
+
+	bytesIn := []byte("test data")
+	_, err := InvokeFunction(
+		"127.0.0.1:8080",
+		"function",
+		&bytesIn,
+		"text/plain",
+		[]string{},
+	)
+
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+
+	r := regexp.MustCompile(`(?m:cannot connect to OpenFaaS on URL: )`)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Error not matched: %s", err)
+	}
+}

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -23,7 +23,12 @@ func ListFunctions(gateway string) ([]requests.Function, error) {
 	timeout := 60 * time.Second
 	client := MakeHTTPClient(&timeout)
 
-	getRequest, _ := http.NewRequest(http.MethodGet, gateway+"/system/functions", nil)
+	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/functions", nil)
+	if err != nil {
+		fmt.Println()
+		fmt.Println(err)
+		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+	}
 	res, err := client.Do(getRequest)
 	if err != nil {
 		fmt.Println()

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -49,6 +49,19 @@ func Test_ListFunctions_Not200(t *testing.T) {
 	}
 }
 
+func Test_ListFunctions_BadURL(t *testing.T) {
+	_, err := ListFunctions("127.0.0.1:8080")
+
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+
+	r := regexp.MustCompile(`(?m:cannot connect to OpenFaaS on URL: )`)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Error not matched: %s", err)
+	}
+}
+
 var expectedListFunctionsResponse = []requests.Function{
 	{
 		Name:            "func-test1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This change is to add error handling for the `http.NewRequest()` call in the `list`, `deploy`, `delete`, and `invoke` files.

https://github.com/openfaas/faas-cli/blob/46b2db894024f8707d080510202a592930894d9e/proxy/list.go#L26

Currently if an error occurs here, the error variable is thrown out, and we call `client.Do()` with a `nil` parameter.

## Description
<!--- Describe your changes in detail -->

Handle the error each time `http.NewRequest()` is used, and return it to the user.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Got a runtime error when I put in an incorrectly formatted URL. Issue: #185 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
