### PR TITLE
Update tests for invalid --gateway URL to use got/want in error message

### DIFF
--- a/proxy/delete_test.go
+++ b/proxy/delete_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 
 	"testing"
@@ -55,15 +56,16 @@ func Test_DeleteFunction_Not2xxAnd404(t *testing.T) {
 	}
 }
 
-func Test_DeleteFunction_BadURL(t *testing.T) {
+func Test_DeleteFunction_MissingURLPrefix(t *testing.T) {
 	url := "127.0.0.1:8080"
 
 	stdout := test.CaptureStdout(func() {
 		DeleteFunction(url, "function-to-delete")
 	})
 
-	r := regexp.MustCompile(`(?m:first path segment in URL cannot contain colon)`)
+	expectedErrMsg := "first path segment in URL cannot contain colon"
+	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
 	if !r.MatchString(stdout) {
-		t.Fatalf("Output not matched: %s", stdout)
+		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, stdout)
 	}
 }

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 
 	"testing"
@@ -75,7 +76,7 @@ func Test_DeployFunction_Not2xx(t *testing.T) {
 	}
 }
 
-func Test_DeployFunction_BadURL(t *testing.T) {
+func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 	url := "127.0.0.1:8080"
 
 	stdout := test.CaptureStdout(func() {
@@ -95,8 +96,9 @@ func Test_DeployFunction_BadURL(t *testing.T) {
 		)
 	})
 
-	r := regexp.MustCompile(`(?m:first path segment in URL cannot contain colon)`)
+	expectedErrMsg := "first path segment in URL cannot contain colon"
+	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
 	if !r.MatchString(stdout) {
-		t.Fatalf("Output not matched: %s", stdout)
+		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, stdout)
 	}
 }

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 
 	"testing"
@@ -54,7 +55,7 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 	}
 }
 
-func Test_InvokeFunction_BadURL(t *testing.T) {
+func Test_InvokeFunction_MissingURLPrefix(t *testing.T) {
 
 	bytesIn := []byte("test data")
 	_, err := InvokeFunction(
@@ -69,8 +70,9 @@ func Test_InvokeFunction_BadURL(t *testing.T) {
 		t.Fatalf("Error was not returned")
 	}
 
-	r := regexp.MustCompile(`(?m:cannot connect to OpenFaaS on URL: )`)
+	expectedErrMsg := "cannot connect to OpenFaaS on URL:"
+	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
 	if !r.MatchString(err.Error()) {
-		t.Fatalf("Error not matched: %s", err)
+		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, err.Error())
 	}
 }

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -4,6 +4,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 
@@ -49,16 +50,17 @@ func Test_ListFunctions_Not200(t *testing.T) {
 	}
 }
 
-func Test_ListFunctions_BadURL(t *testing.T) {
+func Test_ListFunctions_MissingURLPrefix(t *testing.T) {
 	_, err := ListFunctions("127.0.0.1:8080")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
 	}
 
-	r := regexp.MustCompile(`(?m:cannot connect to OpenFaaS on URL: )`)
+	expectedErrMsg := "cannot connect to OpenFaaS on URL:"
+	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
 	if !r.MatchString(err.Error()) {
-		t.Fatalf("Error not matched: %s", err)
+		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, err.Error())
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This change is to add better testing for the changes recently merged from PR #198, as per the changes requested by Alex.

The reqeusted changes:
1. Error handling should use want/go syntax, for clearer error messages.
2. More descriptive function name is needed

## Description
<!--- Describe your changes in detail -->

Updated these tests to use a better name (`MissingURLPrefix` rather than `BadURL`) and use want/go error reporting syntax.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#185 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On build all tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
