### PR TITLE
Refactoring Commands to exit with non-0 status codes on failure.

### DIFF
--- a/commands/bash_completion.go
+++ b/commands/bash_completion.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -23,18 +24,20 @@ var bashcompletionCmd = &cobra.Command{
 This currently only works on Bash version 4, and is hidden
 pending a merge of https://github.com/spf13/cobra/pull/520.`,
 	Hidden: true,
-	Run:    runBashcompletion,
+	RunE:   runBashcompletion,
 }
 
-func runBashcompletion(cmd *cobra.Command, args []string) {
+func runBashcompletion(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
 		fmt.Println("Please provide filename for bash completion")
-		return
+		return errors.New("Please provide filename for bash completion")
 	}
 	fileName := args[0]
 	err := faasCmd.GenBashCompletionFile(fileName)
 	if err != nil {
 		fmt.Println("Unable to create bash completion file")
-		return
+		return errors.New("unable to create bash completion file")
 	}
+
+	return nil
 }

--- a/commands/bash_completion.go
+++ b/commands/bash_completion.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -29,14 +28,12 @@ pending a merge of https://github.com/spf13/cobra/pull/520.`,
 
 func runBashcompletion(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		fmt.Println("Please provide filename for bash completion")
-		return errors.New("Please provide filename for bash completion")
+		return fmt.Errorf("please provide filename for bash completion")
 	}
 	fileName := args[0]
 	err := faasCmd.GenBashCompletionFile(fileName)
 	if err != nil {
-		fmt.Println("Unable to create bash completion file")
-		return errors.New("unable to create bash completion file")
+		return fmt.Errorf("unable to create bash completion file")
 	}
 
 	return nil

--- a/commands/build.go
+++ b/commands/build.go
@@ -73,6 +73,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
+			fmt.Println(err)
 			return err
 		}
 
@@ -89,12 +90,15 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		build(&services, parallel, shrinkwrap)
 	} else {
 		if len(image) == 0 {
+			fmt.Println("Please provice a valid -image name for yout Docker image")
 			return fmt.Errorf("please provide a valid -image name for your Docker image")
 		}
 		if len(handler) == 0 {
+			fmt.Println("Please provide the full path to your function's handler")
 			return fmt.Errorf("please provide the full path to your function's handler")
 		}
 		if len(functionName) == 0 {
+			fmt.Println("Please provide the deployed -name of your function")
 			return fmt.Errorf("please provide the deployed -name of your function")
 		}
 		builder.BuildImage(image, handler, functionName, language, nocache, squash, shrinkwrap)

--- a/commands/build.go
+++ b/commands/build.go
@@ -73,7 +73,6 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			fmt.Println(err)
 			return err
 		}
 
@@ -90,16 +89,13 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		build(&services, parallel, shrinkwrap)
 	} else {
 		if len(image) == 0 {
-			fmt.Println("Please provice a valid -image name for yout Docker image")
-			return fmt.Errorf("please provide a valid -image name for your Docker image")
+			return fmt.Errorf("please provide a valid --image name for your Docker image")
 		}
 		if len(handler) == 0 {
-			fmt.Println("Please provide the full path to your function's handler")
 			return fmt.Errorf("please provide the full path to your function's handler")
 		}
 		if len(functionName) == 0 {
-			fmt.Println("Please provide the deployed -name of your function")
-			return fmt.Errorf("please provide the deployed -name of your function")
+			return fmt.Errorf("please provide the deployed --name of your function")
 		}
 		builder.BuildImage(image, handler, functionName, language, nocache, squash, shrinkwrap)
 	}
@@ -119,7 +115,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap bool) {
 			for function := range workChannel {
 				fmt.Printf("[%d] > Building: %s.\n", index, function.Name)
 				if len(function.Language) == 0 {
-					fmt.Println("Please provide a valid -lang or 'Dockerfile' for your function.")
+					fmt.Println("Please provide a valid --lang or 'Dockerfile' for your function.")
 
 				} else {
 					builder.BuildImage(function.Image, function.Handler, function.Name, function.Language, nocache, squash, shrinkwrap)

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -166,8 +167,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				var fprocessErr error
 				function.FProcess, fprocessErr = deriveFprocess(function)
 				if fprocessErr != nil {
-					log.Fatalln(fprocessErr)
-
+					return fprocessErr
 				}
 			}
 
@@ -237,7 +237,7 @@ func parseMap(envvars []string, keyName string) (map[string]string, error) {
 	for _, envvar := range envvars {
 		s := strings.SplitN(strings.TrimSpace(envvar), "=", 2)
 		if len(s) != 2 {
-			return nil, fmt.Errorf("Label format is not correct, needs key=value")
+			return nil, fmt.Errorf("label format is not correct, needs key=value")
 		}
 		envvarName := s[0]
 		envvarValue := s[1]

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -53,6 +53,7 @@ func Execute(customArgs []string) {
 	checkAndSetDefaultYaml()
 
 	faasCmd.SilenceUsage = true
+	faasCmd.SilenceErrors = true
 	faasCmd.SetArgs(customArgs[1:])
 	if err := faasCmd.Execute(); err != nil {
 		os.Exit(1)

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"fmt"
 	"os"
-	"unicode"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -57,7 +57,8 @@ func Execute(customArgs []string) {
 	faasCmd.SilenceErrors = true
 	faasCmd.SetArgs(customArgs[1:])
 	if err := faasCmd.Execute(); err != nil {
-		fmt.Println(capitaliseFirst(err.Error()))
+		e := err.Error()
+		fmt.Println(strings.ToUpper(e[:1]) + e[1:])
 		os.Exit(1)
 	}
 }
@@ -83,11 +84,4 @@ Manage your OpenFaaS functions from the command line`,
 func runFaas(cmd *cobra.Command, args []string) {
 	fmt.Printf(figletStr)
 	cmd.Help()
-}
-
-func capitaliseFirst(str string) string {
-	for _, c := range str {
-		return string(unicode.ToUpper(c)) + str[1:]
-	}
-	return ""
 }

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -6,7 +6,7 @@ package commands
 import (
 	"fmt"
 	"os"
-	"strings"
+	"unicode"
 
 	"github.com/spf13/cobra"
 )
@@ -57,11 +57,7 @@ func Execute(customArgs []string) {
 	faasCmd.SilenceErrors = true
 	faasCmd.SetArgs(customArgs[1:])
 	if err := faasCmd.Execute(); err != nil {
-		if len(err.Error()) > 2 {
-			splitted := strings.SplitAfterN(err.Error(), "", 2)
-			msg := strings.ToUpper(splitted[0]) + splitted[1]
-			fmt.Println(msg)
-		}
+		fmt.Println(capitaliseFirst(err.Error()))
 		os.Exit(1)
 	}
 }
@@ -87,4 +83,11 @@ Manage your OpenFaaS functions from the command line`,
 func runFaas(cmd *cobra.Command, args []string) {
 	fmt.Printf(figletStr)
 	cmd.Help()
+}
+
+func capitaliseFirst(str string) string {
+	for _, c := range str {
+		return string(unicode.ToUpper(c)) + str[1:]
+	}
+	return ""
 }

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -56,6 +57,11 @@ func Execute(customArgs []string) {
 	faasCmd.SilenceErrors = true
 	faasCmd.SetArgs(customArgs[1:])
 	if err := faasCmd.Execute(); err != nil {
+		if len(err.Error()) > 2 {
+			splitted := strings.SplitAfterN(err.Error(), "", 2)
+			msg := strings.ToUpper(splitted[0]) + splitted[1]
+			fmt.Println(msg)
+		}
 		os.Exit(1)
 	}
 }

--- a/commands/fetch_templates.go
+++ b/commands/fetch_templates.go
@@ -184,14 +184,12 @@ func fetchMasterZip(templateURL string) (string, error) {
 
 		req, err := http.NewRequest(http.MethodGet, templateURL, nil)
 		if err != nil {
-			log.Println(err.Error())
 			return "", err
 		}
 
 		log.Printf("HTTP GET %s\n", templateURL)
 		res, err := client.Do(req)
 		if err != nil {
-			log.Println(err.Error())
 			return "", err
 		}
 
@@ -207,14 +205,12 @@ func fetchMasterZip(templateURL string) (string, error) {
 
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err != nil {
-			log.Println(err.Error())
 			return "", err
 		}
 
 		log.Printf("Writing %dKb to %s\n", len(bytesOut)/1024, archive)
 		err = ioutil.WriteFile(archive, bytesOut, 0700)
 		if err != nil {
-			log.Println(err.Error())
 			return "", err
 		}
 	}

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -4,10 +4,8 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 
 	"github.com/openfaas/faas-cli/proxy"
@@ -45,8 +43,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 	var services stack.Services
 
 	if len(args) < 1 {
-		fmt.Println("Please provide a name for the function")
-		return errors.New("Please provide a name for the function")
+		return fmt.Errorf("please provide a name for the function")
 	}
 	var yamlGateway string
 	functionName = args[0]
@@ -54,7 +51,6 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Println(err.Error())
 			return err
 		}
 
@@ -73,13 +69,12 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 
 	functionInput, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
-		fmt.Printf("Unable to read standard input: %s\n", err.Error())
-		return err
+		return fmt.Errorf("unable to read standard input: %s", err.Error())
+
 	}
 
 	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType, query)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -70,7 +70,6 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 	functionInput, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		return fmt.Errorf("unable to read standard input: %s", err.Error())
-
 	}
 
 	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType, query)

--- a/commands/list.go
+++ b/commands/list.go
@@ -32,18 +32,18 @@ var listCmd = &cobra.Command{
 	Long:    `Lists OpenFaaS functions either on a local or remote gateway`,
 	Example: `  faas-cli list
   faas-cli list --gateway https://localhost:8080 --verbose`,
-	Run: runList,
+	RunE: runList,
 }
 
-func runList(cmd *cobra.Command, args []string) {
+func runList(cmd *cobra.Command, args []string) error {
 	var services stack.Services
 	var gatewayAddress string
 	var yamlGateway string
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Fatalln(err.Error())
-			return
+			log.Println(err.Error())
+			return err
 		}
 
 		if parsedServices != nil {
@@ -57,8 +57,8 @@ func runList(cmd *cobra.Command, args []string) {
 	// fmt.Println(gatewayAddress)
 	functions, err := proxy.ListFunctions(gatewayAddress)
 	if err != nil {
-		log.Println(err)
-		return
+		// ListFunctions prints out its own error messages
+		return err
 	}
 
 	if verboseList {
@@ -77,5 +77,5 @@ func runList(cmd *cobra.Command, args []string) {
 
 		}
 	}
-
+	return nil
 }

--- a/commands/list.go
+++ b/commands/list.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/stack"
@@ -42,7 +41,6 @@ func runList(cmd *cobra.Command, args []string) error {
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Println(err.Error())
 			return err
 		}
 
@@ -58,7 +56,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	functions, err := proxy.ListFunctions(gatewayAddress)
 	if err != nil {
 		// ListFunctions prints out its own error messages
-		return err
+		return fmt.Errorf("")
 	}
 
 	if verboseList {

--- a/commands/list.go
+++ b/commands/list.go
@@ -52,11 +52,9 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway)
 
-	// fmt.Println(gatewayAddress)
 	functions, err := proxy.ListFunctions(gatewayAddress)
 	if err != nil {
-		// ListFunctions prints out its own error messages
-		return fmt.Errorf("")
+		return err
 	}
 
 	if verboseList {

--- a/commands/login.go
+++ b/commands/login.go
@@ -43,48 +43,27 @@ var loginCmd = &cobra.Command{
 func runLogin(cmd *cobra.Command, args []string) error {
 
 	if len(username) == 0 {
-<<<<<<< HEAD
 		return fmt.Errorf("must provide --username or -u")
-=======
-		fmt.Println("Must provide --username or -u")
-		return errors.New("must provide --username or -u")
->>>>>>> Change cobra Run to RunE and return errors
 	}
 
 	if len(password) > 0 {
 		fmt.Println("WARNING! Using --password is insecure, consider using: cat ~/faas_pass.txt | faas-cli login -u user --password-stdin")
 		if passwordStdin {
-<<<<<<< HEAD
 			return fmt.Errorf("--password and --password-stdin are mutually exclusive")
 		}
 
 		if len(username) == 0 {
 			return fmt.Errorf("must provide --username with --password")
-=======
-			fmt.Println("--password and --password-stdin are mutually exclusive")
-			return errors.New("--password and --password-stdin are mutually exclusive")
-		}
-
-		if len(username) == 0 {
-			fmt.Println("Must provide --username with --password")
-			return errors.New("must provide --username with --password")
->>>>>>> Change cobra Run to RunE and return errors
 		}
 	}
 
 	if passwordStdin {
 		if len(username) == 0 {
-<<<<<<< HEAD
 			return fmt.Errorf("must provide --username with --password-stdin")
-=======
-			fmt.Println("Must provide --username with --password-stdin")
-			return errors.New("must provide --username with --password-stdin")
->>>>>>> Change cobra Run to RunE and return errors
 		}
 
 		passwordStdin, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			fmt.Println(err)
 			return err
 		}
 
@@ -94,24 +73,20 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	password = strings.TrimSpace(password)
 	if len(password) == 0 {
 		return fmt.Errorf("must provide a non-empty password via --password or --password-stdin")
-
 	}
 
 	fmt.Println("Calling the OpenFaaS server to validate the credentials...")
 	gateway = strings.TrimRight(strings.TrimSpace(gateway), "/")
 	if err := validateLogin(gateway, username, password); err != nil {
-		fmt.Println(err)
 		return err
 	}
 
 	if err := config.UpdateAuthConfig(gateway, username, password); err != nil {
-		fmt.Println(err)
 		return err
 	}
 
 	user, _, err := config.LookupAuthConfig(gateway)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	fmt.Println("credentials saved for", user, gateway)
@@ -137,7 +112,6 @@ func validateLogin(url string, user string, pass string) error {
 
 	res, err := client.Do(req)
 	if err != nil {
-		fmt.Println(err)
 		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gatewayUrl)
 	}
 

--- a/commands/login.go
+++ b/commands/login.go
@@ -43,27 +43,48 @@ var loginCmd = &cobra.Command{
 func runLogin(cmd *cobra.Command, args []string) error {
 
 	if len(username) == 0 {
+<<<<<<< HEAD
 		return fmt.Errorf("must provide --username or -u")
+=======
+		fmt.Println("Must provide --username or -u")
+		return errors.New("must provide --username or -u")
+>>>>>>> Change cobra Run to RunE and return errors
 	}
 
 	if len(password) > 0 {
 		fmt.Println("WARNING! Using --password is insecure, consider using: cat ~/faas_pass.txt | faas-cli login -u user --password-stdin")
 		if passwordStdin {
+<<<<<<< HEAD
 			return fmt.Errorf("--password and --password-stdin are mutually exclusive")
 		}
 
 		if len(username) == 0 {
 			return fmt.Errorf("must provide --username with --password")
+=======
+			fmt.Println("--password and --password-stdin are mutually exclusive")
+			return errors.New("--password and --password-stdin are mutually exclusive")
+		}
+
+		if len(username) == 0 {
+			fmt.Println("Must provide --username with --password")
+			return errors.New("must provide --username with --password")
+>>>>>>> Change cobra Run to RunE and return errors
 		}
 	}
 
 	if passwordStdin {
 		if len(username) == 0 {
+<<<<<<< HEAD
 			return fmt.Errorf("must provide --username with --password-stdin")
+=======
+			fmt.Println("Must provide --username with --password-stdin")
+			return errors.New("must provide --username with --password-stdin")
+>>>>>>> Change cobra Run to RunE and return errors
 		}
 
 		passwordStdin, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
+			fmt.Println(err)
 			return err
 		}
 
@@ -73,20 +94,24 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	password = strings.TrimSpace(password)
 	if len(password) == 0 {
 		return fmt.Errorf("must provide a non-empty password via --password or --password-stdin")
+
 	}
 
 	fmt.Println("Calling the OpenFaaS server to validate the credentials...")
 	gateway = strings.TrimRight(strings.TrimSpace(gateway), "/")
 	if err := validateLogin(gateway, username, password); err != nil {
+		fmt.Println(err)
 		return err
 	}
 
 	if err := config.UpdateAuthConfig(gateway, username, password); err != nil {
+		fmt.Println(err)
 		return err
 	}
 
 	user, _, err := config.LookupAuthConfig(gateway)
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 	fmt.Println("credentials saved for", user, gateway)

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -33,7 +33,6 @@ func runLogout(cmd *cobra.Command, args []string) error {
 	gateway = strings.TrimRight(strings.TrimSpace(gateway), "/")
 	err := config.RemoveAuthConfig(gateway)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	fmt.Println("credentials removed for", gateway)

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -33,6 +33,7 @@ func runLogout(cmd *cobra.Command, args []string) error {
 	gateway = strings.TrimRight(strings.TrimSpace(gateway), "/")
 	err := config.RemoveAuthConfig(gateway)
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 	fmt.Println("credentials removed for", gateway)

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -54,8 +54,7 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 		var availableTemplates []string
 
 		if templateFolders, err := ioutil.ReadDir(templateDirectory); err != nil {
-			return fmt.Errorf("No language templates were found. Please run 'faas-cli template pull'.")
-			return
+			return fmt.Errorf("no language templates were found. Please run 'faas-cli template pull'")
 		} else {
 			for _, file := range templateFolders {
 				if file.IsDir() {
@@ -89,7 +88,7 @@ the "Dockerfile" lang type in your YAML file.
 	}
 
 	if _, err := os.Stat(functionName); err == nil {
-		return fmt.Errorf("Folder: %s already exists", functionName)
+		return fmt.Errorf("folder: %s already exists", functionName)
 	}
 
 	if err := os.Mkdir("./"+functionName, 0700); err == nil {
@@ -97,7 +96,7 @@ the "Dockerfile" lang type in your YAML file.
 	}
 
 	if err := updateGitignore(); err != nil {
-		return fmt.Errorf("Got unexpected error while updating .gitignore file: %s", err)
+		return fmt.Errorf("got unexpected error while updating .gitignore file: %s", err)
 	}
 
 	// Only "template" language templates - Dockerfile must be custom, so start with empty directory.

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -50,7 +49,6 @@ language or type in --list for a list of languages available.`,
 	RunE: runNewFunction,
 }
 
-
 func runNewFunction(cmd *cobra.Command, args []string) error {
 	if list == true {
 		var availableTemplates []string
@@ -76,25 +74,22 @@ the "Dockerfile" lang type in your YAML file.
 	}
 
 	if len(args) < 1 {
-		fmt.Println("Please provide a name for the function")
-		return errors.New("please provide a name for the function")
+		return fmt.Errorf("please provide a name for the function")
 	}
 	functionName = args[0]
 
 	if len(lang) == 0 {
-		fmt.Println("You must supply a function language with the --lang flag")
-		return errors.New("you must supply a function language with the --lang flag")
+		return fmt.Errorf("you must supply a function language with the --lang flag")
 	}
 
 	PullTemplates("")
 
 	if stack.IsValidTemplate(lang) == false {
-		return fmt.Errorf("%s is unavailable or not supported.\n", lang)
-		
+		return fmt.Errorf("%s is unavailable or not supported", lang)
 	}
 
 	if _, err := os.Stat(functionName); err == nil {
-		return fmt.Errorf("Folder: %s already exists\n", functionName)
+		return fmt.Errorf("Folder: %s already exists", functionName)
 	}
 
 	if err := os.Mkdir("./"+functionName, 0700); err == nil {
@@ -102,8 +97,7 @@ the "Dockerfile" lang type in your YAML file.
 	}
 
 	if err := updateGitignore(); err != nil {
-		fmt.Println("Got unexpected error while updating .gitignore file.")
-		return err
+		return fmt.Errorf("Got unexpected error while updating .gitignore file: %s", err)
 	}
 
 	// Only "template" language templates - Dockerfile must be custom, so start with empty directory.
@@ -144,26 +138,19 @@ functions:
 
 	stackWriteErr := ioutil.WriteFile("./"+functionName+".yml", []byte(stack), 0600)
 	if stackWriteErr != nil {
-		fmt.Printf("Error writing stack file %s\n", stackWriteErr)
-		return errors.New("Error writing stack file")
+		return fmt.Errorf("error writing stack file %s", stackWriteErr)
 	}
 
 	fmt.Printf("Stack file written: %s\n", functionName+".yml")
 	return nil
 }
 
-<<<<<<< HEAD
 func printAvailableTemplates(availableTemplates []string) string {
 	var result string
 	sort.Sort(StrSort(availableTemplates))
 	for _, template := range availableTemplates {
 		result += fmt.Sprintf("- %s\n", template)
-=======
-func validTemplate(lang string) bool {
-	var found bool
-	if strings.ToLower(lang) == "dockerfile" {
-		found = true
->>>>>>> Change cobra Run to RunE and return errors
+
 	}
 	return result
 }

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -30,7 +31,7 @@ const ListOptionOutput = `Languages available as templates:
 - python3
 - ruby`
 
-const LangNotExistsOutput = `(?m:is unavailable or not supported.)`
+const LangNotExistsOutput = `(?m:is unavailable or not supported)`
 
 type NewFunctionTest struct {
 	title       string
@@ -79,15 +80,15 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 		"--gateway=" + defaultGateway,
 	}
 
-	stdOut := test.CaptureStdout(func() {
-		faasCmd.SetArgs(cmdParameters)
-		faasCmd.Execute()
-	})
+	/*
+		stdOut := test.CaptureStdout(func() {
+			faasCmd.SetArgs(cmdParameters)
+			faasCmd.Execute()
+		}) */
 
-	// Validate new function output
-	if found, err := regexp.MatchString(nft.expectedMsg, stdOut); err != nil || !found {
-		t.Fatalf("Output is not as expected: %s\n", stdOut)
-	}
+	faasCmd.SetArgs(cmdParameters)
+	fmt.Println("Executing command")
+	stdOut := faasCmd.Execute()
 
 	if nft.expectedMsg == SuccessMsg {
 
@@ -117,6 +118,11 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 		testServices.Functions[funcName] = stack.Function{Language: funcLang, Image: funcName, Handler: "./" + funcName}
 		if !reflect.DeepEqual(services.Functions[funcName], testServices.Functions[funcName]) {
 			t.Fatalf("YAML `functions` section was not created correctly for file %s, got %v", funcYAML, services.Functions[funcName])
+		}
+	} else {
+		// Validate new function output
+		if found, err := regexp.MatchString(nft.expectedMsg, stdOut.Error()); err != nil || !found {
+			t.Fatalf("Output is not as expected: %s\n", stdOut)
 		}
 	}
 
@@ -183,10 +189,8 @@ func Test_languageNotExists(t *testing.T) {
 		"--list=false",
 	}
 
-	stdOut := test.CaptureStdout(func() {
-		faasCmd.SetArgs(cmdParameters)
-		faasCmd.Execute()
-	})
+	faasCmd.SetArgs(cmdParameters)
+	stdOut := faasCmd.Execute().Error()
 
 	// Validate new function output
 	if found, err := regexp.MatchString(LangNotExistsOutput, stdOut); err != nil || !found {

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -80,12 +80,6 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 		"--gateway=" + defaultGateway,
 	}
 
-	/*
-		stdOut := test.CaptureStdout(func() {
-			faasCmd.SetArgs(cmdParameters)
-			faasCmd.Execute()
-		}) */
-
 	faasCmd.SetArgs(cmdParameters)
 	fmt.Println("Executing command")
 	stdOut := faasCmd.Execute()

--- a/commands/push.go
+++ b/commands/push.go
@@ -4,9 +4,7 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
-	"log"
 	"sync"
 
 	"github.com/openfaas/faas-cli/builder"
@@ -43,7 +41,6 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Println(err.Error())
 			return err
 		}
 
@@ -55,8 +52,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if len(services.Functions) > 0 {
 		pushStack(&services, parallel)
 	} else {
-		fmt.Println("You must supply a valid YAML file.")
-		return errors.New("you must supply a valid YAML file")
+		return fmt.Errorf("you must supply a valid YAML file")
 	}
 	return nil
 }

--- a/commands/push.go
+++ b/commands/push.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"sync"
@@ -33,17 +34,17 @@ These container images must already be present in your local image cache.`,
   faas-cli push -f ./samples.yml --parallel 4
   faas-cli push -f ./samples.yml --filter "*gif*"
   faas-cli push -f ./samples.yml --regex "fn[0-9]_.*"`,
-	Run: runPush,
+	RunE: runPush,
 }
 
-func runPush(cmd *cobra.Command, args []string) {
+func runPush(cmd *cobra.Command, args []string) error {
 
 	var services stack.Services
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Fatalln(err.Error())
-			return
+			log.Println(err.Error())
+			return err
 		}
 
 		if parsedServices != nil {
@@ -55,9 +56,9 @@ func runPush(cmd *cobra.Command, args []string) {
 		pushStack(&services, parallel)
 	} else {
 		fmt.Println("You must supply a valid YAML file.")
-		return
+		return errors.New("you must supply a valid YAML file")
 	}
-
+	return nil
 }
 
 func pushImage(image string) {
@@ -77,7 +78,6 @@ func pushStack(services *stack.Services, queueDepth int) {
 				fmt.Printf("[%d] > Pushing: %s.\n", index, function.Name)
 				if len(function.Image) == 0 {
 					fmt.Println("Please provide a valid Image value in the YAML file.")
-
 				} else {
 					pushImage(function.Image)
 				}

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -4,9 +4,7 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
-	"log"
 
 	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/stack"
@@ -43,7 +41,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Println(err.Error())
 			return err
 		}
 
@@ -65,8 +62,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		if len(args) < 1 {
-			fmt.Println("Please provide the name of a function to delete")
-			return errors.New("please provide the name of a function to delete")
+			return fmt.Errorf("Please provide the name of a function to delete")
 		}
 
 		functionName = args[0]

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"log"
 
@@ -34,16 +35,16 @@ explicitly specifying a function name.`,
   faas-cli remove -f ./samples.yml --regex "fn[0-9]_.*"
   faas-cli remove url-ping
   faas-cli remove img2ansi --gateway==http://remote-site.com:8080`,
-	Run: runDelete,
+	RunE: runDelete,
 }
 
-func runDelete(cmd *cobra.Command, args []string) {
+func runDelete(cmd *cobra.Command, args []string) error {
 	var services stack.Services
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
-			log.Fatalln(err.Error())
-			return
+			log.Println(err.Error())
+			return err
 		}
 
 		if parsedServices != nil {
@@ -65,11 +66,13 @@ func runDelete(cmd *cobra.Command, args []string) {
 	} else {
 		if len(args) < 1 {
 			fmt.Println("Please provide the name of a function to delete")
-			return
+			return errors.New("please provide the name of a function to delete")
 		}
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
 		proxy.DeleteFunction(gateway, functionName)
 	}
+
+	return nil
 }

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -62,7 +62,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		if len(args) < 1 {
-			return fmt.Errorf("Please provide the name of a function to delete")
+			return fmt.Errorf("please provide the name of a function to delete")
 		}
 
 		functionName = args[0]

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -86,10 +86,10 @@ func Test_templatePull_error_not_valid_url(t *testing.T) {
 
 	faasCmd.SetArgs([]string{"template", "pull", "git@github.com:openfaas/faas-cli.git"})
 	faasCmd.SetOutput(&buf)
-	faasCmd.Execute()
+	err := faasCmd.Execute()
 
-	if !strings.Contains(buf.String(), "Error: The repository URL must be in the format https://github.com/<owner>/<repository>") {
-		t.Fatal("Output does not contain the required string", buf.String())
+	if !strings.Contains(err.Error(), "The repository URL must be in the format https://github.com/<owner>/<repository>") {
+		t.Fatal("Output does not contain the required string", err.Error())
 	}
 }
 

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -27,15 +27,11 @@ func ListFunctions(gateway string) ([]requests.Function, error) {
 	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/functions", nil)
 	SetAuth(getRequest, gateway)
 	if err != nil {
-		fmt.Println()
-		fmt.Println(err)
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}
 
 	res, err := client.Do(getRequest)
 	if err != nil {
-		fmt.Println()
-		fmt.Println(err)
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}
 
@@ -59,7 +55,7 @@ func ListFunctions(gateway string) ([]requests.Function, error) {
 	default:
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err == nil {
-			return nil, fmt.Errorf("Server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
+			return nil, fmt.Errorf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
 		}
 	}
 	return results, nil

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -44,7 +44,7 @@ func Test_ListFunctions_Not200(t *testing.T) {
 		t.Fatalf("Error was not returned")
 	}
 
-	r := regexp.MustCompile(`(?m:Server returned unexpected status code)`)
+	r := regexp.MustCompile(`(?m:server returned unexpected status code)`)
 	if !r.MatchString(err.Error()) {
 		t.Fatalf("Error not matched: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Tommy Stigen Olsen <tommysolsen@gmail.com>

As discussed in #183, I have gone through the commands and made all of the cobra commands 
use RunE, returning errors which triggers os.Exit(1).

## Description
<!--- Describe your changes in detail -->
Refactors all cobra commands except version (which never generates errors). This lets all of the commands exit with status-code 1 if an error occurs.
I have also cleaned up some of the different ways each function handles failure to a standard `fmt.Println` and `return err` style to be consistent across the modules.

Since RunE will print any error it receives, i've suppressed them so the software doesnt repeat itself.

## Motivation and Context
See #183 

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested through compiling and running a few functions that failed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
