### PR TITLE
should return if validTemplate() fails, also fix bug in validTemplate()

### DIFF
--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -73,6 +73,7 @@ the "Dockerfile" lang type in your YAML file.
 
 	if validTemplate(lang) == false {
 		fmt.Printf("%s is unavailable or not supported.\n", lang)
+		return
 	}
 
 	if _, err := os.Stat(functionName); err == nil {
@@ -136,7 +137,7 @@ functions:
 
 func validTemplate(lang string) bool {
 	var found bool
-	if strings.ToLower(lang) != "dockerfile" {
+	if strings.ToLower(lang) == "dockerfile" {
 		found = true
 	}
 	if _, err := os.Stat(path.Join("./template/", lang)); err == nil {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. The method `validTemplate()` should return if it fails
2. A bug exists in `validTemplate()` where if an invalid function type is passed in that is not called `"dockerfile"`, it will be considered valid.

For example, before the fix, when passing in an invalid template, it will create the folder and fail afterwards:

```
$ fc new f5 --lang bashh
Folder: f5 created.
2017/11/07 08:46:29 open ./template/bashh/function/: no such file or directory
```

With the fix, it will immediately print an error when `validTemplate()` fails:

```
$ fc new f4 --lang bashh
bashh is unavailable or not supported.
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This issue was brought up in the slack channel when I was working on the append-to-yaml feature, and it was also found by @Razesdark when he was working on [the non-zero exit code changes](https://github.com/openfaas/faas-cli/pull/207)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with the above cases

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
