### PR TITLE
Updated build for node to fix issue with node_modules

### DIFF
--- a/template/node/.dockerignore
+++ b/template/node/.dockerignore
@@ -1,0 +1,1 @@
+*/node_modules

--- a/template/node/Dockerfile
+++ b/template/node/Dockerfile
@@ -17,28 +17,33 @@ ENV NPM_CONFIG_LOGLEVEL warn
 RUN mkdir -p /home/app
 
 # Wrapper/boot-strapper
-COPY package.json       /home/app
-
 WORKDIR /home/app
+COPY package.json ./
 RUN npm i
 
-# Function
-COPY index.js           /home/app
+# COPY Function entrypoint
+COPY index.js ./
 
-COPY function/*.json    /home/app/function/
+# COPY function node packages and install, adding this as a separate
+# entry allows caching of npm install
 WORKDIR /home/app/function
+COPY function/*.json ./
 RUN npm i || :
+
+# COPY function files and folders
+COPY function/ ./
+
+# Set correct permissions to use non root user
 WORKDIR /home/app/
-COPY function           ./function
 RUN chown app:app -R /home/app \
     && chmod 777 /tmp
 
 USER app
 
 ENV cgi_headers="true"
-
 ENV fprocess="node index.js"
 
 HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 
 CMD ["fwatchdog"]
+


### PR DESCRIPTION

Signed-off-by: Nic Jackson <jackson.nic@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
When building a node function any existing node_modules present in the function folder would be copied to the docker image and npm install would not happen causing permissions errors when running Docker on Linux.

<!--- Describe your changes in detail -->
Updated the Dockerfile to fix an issue where the npm install took place and the functions folder was copied over the top.
Added a .dockerignore file to ignore node modules.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested locally and and also against a cluster running in AWS

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.