### PR TITLE
Don't re-use constraints for each function

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -127,14 +127,19 @@ func runDeploy(cmd *cobra.Command, args []string) {
 		}
 
 		for k, function := range services.Functions {
+
 			function.Name = k
 			if update {
 				fmt.Printf("Updating: %s.\n", function.Name)
 			} else {
 				fmt.Printf("Deploying: %s.\n", function.Name)
 			}
+
+			var functionConstraints []string
 			if function.Constraints != nil {
-				constraints = *function.Constraints
+				functionConstraints = *function.Constraints
+			} else if len(constraints) > 0 {
+				functionConstraints = constraints
 			}
 
 			fileEnvironment, err := readFiles(function.EnvironmentFile)
@@ -160,7 +165,7 @@ func runDeploy(cmd *cobra.Command, args []string) {
 				log.Fatalln(envErr)
 			}
 
-			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.Language, replace, allEnvironment, services.Provider.Network, constraints, update, secrets, allLabels)
+			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.Language, replace, allEnvironment, services.Provider.Network, functionConstraints, update, secrets, allLabels)
 		}
 	} else {
 		if len(image) == 0 {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Don't re-use constraints for each function

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #218 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Via CLI

```
			var functionConstraints []string
			if function.Constraints != nil {
				functionConstraints = *function.Constraints
			} else if len(constraints) > 0 {
				functionConstraints = constraints
			}
```

Constraints are empty unless they are found in the YAML, unless they are found in argument parameters.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.