### PR TITLE
Amended get.sh to include the creation of the faas alias

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -57,6 +57,11 @@ getPackage() {
         if [ "$?" = "0" ]; then
             echo "New version of faas-cli installed to /usr/local/bin"
         fi
+        if [ ! -L /usr/local/bin/faas ]; then
+	    ln -s /usr/local/bin/{faas-cli,faas}
+	    echo "Creating alias 'faas' for 'faas-cli'."
+	fi
+
     fi
 }
 


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Added the creation of a symbolic link of `faas` which points to `faas-cli`

## Motivation and Context
Fixes #233
Referenced in #130
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Update to reflect current live script.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
