### PR TITLE
Merge secrets from command line options and YAML file

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -140,9 +140,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				functionConstraints = constraints
 			}
 
-			if len(function.Secrets) > 0 {
-				secrets = function.Secrets
-			}
+			functionSecrets := compileSecrets(function.Secrets, secrets)
 
 			fileEnvironment, err := readFiles(function.EnvironmentFile)
 			if err != nil {
@@ -180,7 +178,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 				Requests: function.Requests,
 			}
 
-			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.Language, replace, allEnvironment, services.Provider.Network, functionConstraints, update, secrets, allLabels, functionResourceRequest1)
+			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.Language, replace, allEnvironment, services.Provider.Network, functionConstraints, update, functionSecrets, allLabels, functionResourceRequest1)
 		}
 	} else {
 		if len(image) == 0 {
@@ -325,4 +323,26 @@ func deriveFprocess(function stack.Function) (string, error) {
 
 func languageExistsNotDockerfile(language string) bool {
 	return len(language) > 0 && strings.ToLower(language) != "dockerfile"
+}
+
+func compileSecrets(yamlSecrets []string, cmdLineSecrets []string) []string {
+	yamlSecretsMap := make(map[string]string)
+	cmdLineSecretsMap := make(map[string]string)
+	for _, y := range yamlSecrets {
+		yamlSecretsMap[y] = ""
+	}
+	for _, c := range cmdLineSecrets {
+		cmdLineSecretsMap[c] = ""
+	}
+
+	combinedMap := mergeMap(yamlSecretsMap, cmdLineSecretsMap)
+	return stringArrayFromMapKeys(combinedMap)
+}
+
+func stringArrayFromMapKeys(inputMap map[string]string) []string {
+	var merged []string
+	for i, _ := range inputMap {
+		merged = append(merged, i)
+	}
+	return merged
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
@alexellis mentioned in the Slack channel that we should merge the `secrets` from the command line flags with the `secrets` from the stack YAML. Currently `faas-cli` will only take the secrets from the YAML file **or** the command line flags. For example, this command:

`faas-cli deploy -f stack.yml --secret api_token_2`

Where `stack.yml` contains:

```
  functions:
    fun1:
      image: alpine:latest
      fprocess: cat
      secret: api_token_1
```

In the current state of the code, only `api_token_1` will be taken, because the secret passed in as a command line flag (`api_token_2`) will be ignored.

## Description
<!--- Describe your changes in detail -->
This change adds a function which merges all of the secrets for the function found in the stack YAML with all of the secrets found from the command line flags.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#227 

This issue was partially resolved by this merge: #235 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested using the instructions and bash script file in this repo: https://github.com/ericstoekl/secrets-yaml-test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
