### PR TITLE
Fix non-zero code return and safe cleanup of build

### DIFF
--- a/builder/exec.go
+++ b/builder/exec.go
@@ -5,15 +5,12 @@ package builder
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
-
-	"github.com/morikuni/aec"
 )
 
 // ExecCommand run a system command
-func ExecCommand(tempPath string, builder []string) {
+func ExecCommand(tempPath string, builder []string) error {
 	targetCmd := exec.Command(builder[0], builder[1:]...)
 	targetCmd.Dir = tempPath
 	targetCmd.Stdout = os.Stdout
@@ -21,7 +18,8 @@ func ExecCommand(tempPath string, builder []string) {
 	targetCmd.Start()
 	err := targetCmd.Wait()
 	if err != nil {
-		errString := fmt.Sprintf("ERROR - Could not execute command: %s", builder)
-		log.Fatalf(aec.RedF.Apply(errString))
+		errString := fmt.Sprintf("%s", builder)
+		return fmt.Errorf(errString)
 	}
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Tommy Stigen Olsen <tommysolsen@gmail.com>

Figured I would upload this for some feedback. First time I'm working with concurrency, but my solution feels ... not good.
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previous parallel build behavior was that only the worker that
encountered an error would exit, letting the other workers bury
the error message, and would subsequently not properly trigger a non-zero
exit code.

This patch addresses this issue by more tightly controlling the processes that are spawned by the workers, and killing them as soon as the first error message is received. 

This change required me to change a shared function, which shared between `build` and `push`.
A similar, but simpler change was done to `push` in order for that function to also return non-zero codes. 

## Motivation and Context
This issue was raised in #214. Alex reported seeing error messages that would quickly get buried by the output from the other workers. This was because the program did not stop gracefully opon errors as expected. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
### Build sample functions (all valid)
Tested on the sample functions on a set of valid functions
```
$ faas-cli build -f samples.yml --parallel 2
[...]
Successfully built e9df6ceab642
Successfully tagged functions/faas-echo:latest
[1] Stopping worker
[...]
Step 9/9 : CMD fwatchdog
 ---> Using cache
 ---> 5ff0c2740efd
Successfully built 5ff0c2740efd
Successfully tagged functions/sentimentanalysis:latest
[0] Stopping worker

$ echo $?
0
```
### Build sample functions(one intentionally broken)
Then with one function where the Dockerfile is faulty
```
$ faas-cli build -f samples.yml --parallel 4
[...]
 ---> 7661d95cbe23
Step 9/9 : CMD fwatchdog
 ---> Using cache
 ---> 4cdb87305f2c
Successfully built 4cdb87305f2c
Successfully tagged functions/node-info:latest
Building: functions/api-key-protected:latest with Dockerfile. Please wait..
Sending build context to Docker daemon  6.144kB                 ]  479.2kB/5.955MB
Error response from daemon: Dockerfile parse error line 10: Unknown instruction: EALTHCHECK
[3] Stopping worker
[0] Stopping worker
[1] Stopping worker
[2] Stopping worker
Parallel build exited with error

$ echo $?
1
```
This process was repeated several times to make sure it this was normal behavior. Since the output from the workers is all mixed, it is still kind of hard to make out which function is failing.
### Pushing two functions (All valid)

```
$ faas-cli push -f yt2bm.yml --parallel 2
[1] > Pushing: yt2bm.
[0] > Pushing: alpine.
The push refers to a repository [docker.io/okawari/yt2bpm]
The push refers to a repository [docker.io/okawari/alpinefunk]
d4a198633ded: Preparing 
edcfe3c693ab: Preparing 
[ ... ]
4d7cba4c5de2: Pushed 
2aebd096e0e2: Pushed 
latest: digest: sha256:51ee4a08997636ba99e5a1069e13098546317ce7f959d65acffd4a5f39202ac1 size: 950
[0] < Pushing done.

$ echo $?
0
```

### Pushing two functions (One intentionally broken)
```
$ faas-cli push -f yt2bm.yml --parallel 2
faasc push -f yt2bm.yml --parallel 2           
[1] > Pushing: yt2bm.
[0] > Pushing: alpine.
invalid reference format: repository name must be lowercase
[0] < Pushing done.
The push refers to a repository [docker.io/okawari/yt2bpm]
tag does not exist: okawari/yt2bpm:latest-fail
[1] < Pushing done.
Exit status 1

$ echo $?
1
```
### Last command has been started when an error occurs
```
faasc build -f yt2bm.yml --parallel 2  
[0] Starting worker
[1] Starting worker
Clearing temporary build folder: ./build/yt2bm/
Preparing ./yt2bpm/ ./build/yt2bm/function
Building: okawari/yt2bpm:latest with python3 template. Please wait..
Building: okawari/alpineFunk:latest with Dockerfile. Please wait..
invalid argument "okawari/alpineFunk:latest" for t: invalid reference format: repository name must be lowercase
See 'docker build --help'.
[1] Stopping worker
Sending build context to Docker daemon  138.8kB
Step 1/15 : FROM python:3-alpine
 ---> 343a1ad30061
Step 2/15 : RUN apk --no-cache add curl     && echo "Pulling watchdog binary from Github."     && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog     && chmod +x /usr/bin/fwatchdog     && apk del curl --no-cache
 ---> Using cache
 ---> b6385712f2b2
Step 3/15 : WORKDIR /root/
 ---> Using cache
 ---> 888e276e7cb6
Step 4/15 : COPY index.py .
 ---> Using cache
 ---> 7835ac5159f9
Step 5/15 : COPY requirements.txt .
 ---> Using cache
 ---> 400f9bd82e75
Step 6/15 : RUN pip install -r requirements.txt
 ---> Using cache
 ---> ed371d0a3d34
Step 7/15 : COPY function function
 ---> Using cache
 ---> 8682605a9195
Step 8/15 : RUN touch ./function/__init__.py
 ---> Using cache
 ---> b65d03ce6301
Step 9/15 : WORKDIR /root/function/
 ---> Using cache
 ---> 26a4f7063f31
Step 10/15 : COPY function/requirements.txt .
 ---> Using cache
 ---> 99b4bcb0cbcc
Step 11/15 : RUN pip install -r requirements.txt
 ---> Using cache
 ---> 2b1cdeacb611
Step 12/15 : WORKDIR /root/
 ---> Using cache
 ---> 35b5fbf19ec2
Step 13/15 : ENV fprocess "python3 index.py"
 ---> Using cache
 ---> 2bd5155b5489
Step 14/15 : HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 ---> Using cache
 ---> e361ac19cdd0
Step 15/15 : CMD fwatchdog
 ---> Using cache
 ---> 4cdc190821e8
Successfully built 4cdc190821e8
Successfully tagged okawari/yt2bpm:latest
[0] Stopping worker
Parallel build exited with error
```
Error message is now not at the bottom, but non-zero code is correct
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
