### PR TITLE
update node template with `const` keywords

### DIFF
--- a/template/node-arm64/index.js
+++ b/template/node-arm64/index.js
@@ -3,9 +3,9 @@
 
 "use strict"
 
-let getStdin = require('get-stdin');
+const getStdin = require('get-stdin');
 
-let handler = require('./function/handler');
+const handler = require('./function/handler');
 
 getStdin().then(val => {
     handler(val, (err, res) => {
@@ -22,10 +22,10 @@ getStdin().then(val => {
     console.error(e.stack);
 });
 
-let isArray = (a) => {
+const isArray = (a) => {
     return (!!a) && (a.constructor === Array);
 };
 
-let isObject = (a) => {
+const isObject = (a) => {
     return (!!a) && (a.constructor === Object);
 };

--- a/template/node-armhf/index.js
+++ b/template/node-armhf/index.js
@@ -3,9 +3,9 @@
 
 "use strict"
 
-let getStdin = require('get-stdin');
+const getStdin = require('get-stdin');
 
-let handler = require('./function/handler');
+const handler = require('./function/handler');
 
 getStdin().then(val => {
     handler(val, (err, res) => {
@@ -22,10 +22,10 @@ getStdin().then(val => {
     console.error(e.stack);
 });
 
-let isArray = (a) => {
+const isArray = (a) => {
     return (!!a) && (a.constructor === Array);
 };
 
-let isObject = (a) => {
+const isObject = (a) => {
     return (!!a) && (a.constructor === Object);
 };

--- a/template/node/index.js
+++ b/template/node/index.js
@@ -3,9 +3,9 @@
 
 "use strict"
 
-let getStdin = require('get-stdin');
+const getStdin = require('get-stdin');
 
-let handler = require('./function/handler');
+const handler = require('./function/handler');
 
 getStdin().then(val => {
     handler(val, (err, res) => {
@@ -22,10 +22,10 @@ getStdin().then(val => {
     console.error(e.stack);
 });
 
-let isArray = (a) => {
+const isArray = (a) => {
     return (!!a) && (a.constructor === Array);
 };
 
-let isObject = (a) => {
+const isObject = (a) => {
     return (!!a) && (a.constructor === Object);
 };


### PR DESCRIPTION
Assist the node memory manager by indicating non-changing names with `const` keyword instead of `let`.

Fixes #240

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>