### PR TITLE
Added the ability to run get.sh as non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,19 @@ Demo: [ASCII cinema](https://asciinema.org/a/141284)
 
 ### Get started: Install the CLI
 
-The easiest way to install the faas-cli is through a curl script or `brew`:
+Installation is simple with a choice of options using `curl` or `brew`:
 
+One shot with curl:
 ```
 $ curl -sSL https://cli.openfaas.com | sudo sh
 ```
 
-or
+Non-root with curl (requires further actions as advised after downloading):
+```
+$ curl -sSL https://cli.openfaas.com | sh
+```
 
+brew:
 ```
 $ brew install faas-cli
 ```


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Fixes #247 Let utility script run as non-root

## Motivation and Context
Users may be less comfortable running a remotely sourced script as root.  This change enables users to run the cli get script as a non-root user and instructs them as to the next steps to be performed in order to complete installation.

- [x] I have raised an issue to propose this change (#247)

## How Has This Been Tested?

Ran with and without sudo, thus:

```
$ cd ~
$ cat /tmp/get.sh | sudo sh

You already have the faas-cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/openfaas/faas-cli/releases/download/0.5.0/faas-cli-darwin as /tmp/faas-cli
Download complete.

Running as root - Attemping to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
```
And
```
$ cd ~
$ cat /tmp/get.sh | sh

You already have the faas-cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/openfaas/faas-cli/releases/download/0.5.0/faas-cli-darwin as /Users/rgee0/faas-cli
Download complete.

====================================================
== As the script was run as a non-root user the   ==
== following commands may need to be run manually ==
====================================================

     sudo cp faas-cli /usr/local/bin/
     sudo ln -s /usr/local/bin/{faas-cli,faas}
```
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
