### PR TITLE
Added CPU limits for deployments

### DIFF
--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openfaas/faas/gateway/requests"
 )
 
+// FunctionResourceRequest defines a request to set function resources
 type FunctionResourceRequest struct {
 	Limits   *stack.FunctionResources
 	Requests *stack.FunctionResources
@@ -49,16 +50,23 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 		Labels:      &labels,
 	}
 
+	req.Limits = &requests.FunctionResources{}
+	req.Requests = &requests.FunctionResources{}
+
 	if functionResourceRequest1.Limits != nil && len(functionResourceRequest1.Limits.Memory) > 0 {
-		req.Limits = &requests.FunctionResources{
-			Memory: functionResourceRequest1.Limits.Memory,
-		}
+		req.Limits.Memory = functionResourceRequest1.Limits.Memory
 	}
 
 	if functionResourceRequest1.Requests != nil && len(functionResourceRequest1.Requests.Memory) > 0 {
-		req.Requests = &requests.FunctionResources{
-			Memory: functionResourceRequest1.Requests.Memory,
-		}
+		req.Requests.Memory = functionResourceRequest1.Requests.Memory
+	}
+
+	if functionResourceRequest1.Limits != nil && len(functionResourceRequest1.Limits.CPU) > 0 {
+		req.Limits.CPU = functionResourceRequest1.Limits.CPU
+	}
+
+	if functionResourceRequest1.Requests != nil && len(functionResourceRequest1.Requests.CPU) > 0 {
+		req.Requests.CPU = functionResourceRequest1.Requests.CPU
 	}
 
 	reqBytes, _ := json.Marshal(&req)

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -27,7 +27,7 @@ type Function struct {
 	Environment map[string]string `yaml:"environment"`
 
 	// Secrets list of secrets to be made available to function
-	Secrets []string `json:"secrets"`
+	Secrets []string `yaml:"secrets"`
 
 	SkipBuild bool `yaml:"skip_build"`
 
@@ -40,16 +40,16 @@ type Function struct {
 	Labels *map[string]string `yaml:"labels"`
 
 	// Limits for function
-	Limits *FunctionResources `yaml:"limits",json:"limits"`
+	Limits *FunctionResources `yaml:"limits"`
 
 	// Requests of resources requested by function
-	Requests *FunctionResources `yaml:"requests",json:"requests"`
+	Requests *FunctionResources `yaml:"requests"`
 }
 
 // FunctionResources Memory and CPU
 type FunctionResources struct {
-	Memory string `yaml:"memory",json:"memory"`
-	CPU    string `yaml:"cpu",json:"cpu"`
+	Memory string `yaml:"memory"`
+	CPU    string `yaml:"cpu"`
 }
 
 // EnvironmentFile represents external file for environment data

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -40,16 +40,16 @@ type Function struct {
 	Labels *map[string]string `yaml:"labels"`
 
 	// Limits for function
-	Limits *FunctionResources `json:"limits"`
+	Limits *FunctionResources `yaml:"limits",json:"limits"`
 
 	// Requests of resources requested by function
-	Requests *FunctionResources `json:"requests"`
+	Requests *FunctionResources `yaml:"requests",json:"requests"`
 }
 
 // FunctionResources Memory and CPU
 type FunctionResources struct {
-	Memory string `json:"memory"`
-	CPU    string `json:"cpu"`
+	Memory string `yaml:"memory",json:"memory"`
+	CPU    string `yaml:"cpu",json:"cpu"`
 }
 
 // EnvironmentFile represents external file for environment data


### PR DESCRIPTION
Added CPU limits for deployments
Added capability to pass CPU based constraint with a stackfile

[https://github.com/openfaas/faas-cli/issues/250](https://github.com/openfaas/faas-cli/issues/250)

## Description
The stack schema has been changed adding yaml struct tags and also the deployment proxy has been modified to pass the CPU based constraint.

## Motivation and Context
CPU and memory based constraints should be possible
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested with local build and deployment to k8s

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
