### PR TITLE
Switch to external template repository

### DIFF
--- a/commands/fetch_templates.go
+++ b/commands/fetch_templates.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	defaultTemplateRepository = "https://github.com/openfaas/faas-cli"
+	defaultTemplateRepository = "https://github.com/openfaas/templates"
 	templateDirectory         = "./template/"
 	rootLanguageDirSplitCount = 3
 )


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Change switches to use openfaas/templates instead of the CLI repo for OpenFaaS templates.

https://github.com/openfaas/templates/

# Impact 

We'll have to "dual-maintain" two repos until we think folks have upgraded to the next release i.e. 0.5.1