### PR TITLE
while copying a file use file mode from the source file

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -140,7 +140,13 @@ func cp(src string, destination string) error {
 	if readErr != nil {
 		return fmt.Errorf("Error reading source file: %s\n" + readErr.Error())
 	}
-	writeErr := ioutil.WriteFile(destination, memoryBuffer, 0660)
+
+	srcInfo, infoErr := os.Stat(src)
+	if infoErr != nil {
+		return fmt.Errorf("Error reading source file mode: %s\n" + infoErr.Error())
+	}
+
+	writeErr := ioutil.WriteFile(destination, memoryBuffer, srcInfo.Mode())
 	if writeErr != nil {
 		return fmt.Errorf("Error writing file: %s\n" + writeErr.Error())
 	}

--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) OpenFaaS Project 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package builder
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func Test_CopyFiles(t *testing.T) {
+	fileModes := []int{0600, 0640, 0644, 0700, 0755}
+
+	dir := os.TempDir()
+	for _, mode := range fileModes {
+		// set up a source folder with 2 file
+		srcDir, srcDirErr := setupSourceFolder(2, mode)
+		if srcDirErr != nil {
+			log.Fatal("Error creating source folder")
+		}
+		defer os.RemoveAll(srcDir)
+
+		// create a destination folder to copy the files to
+		destDir, destDirErr := ioutil.TempDir(dir, "openfaas-test-destination-")
+		if destDirErr != nil {
+			t.Fatalf("Error creating destination folder\n%v", destDirErr)
+		}
+		defer os.RemoveAll(destDir)
+
+		CopyFiles(srcDir, destDir+"/", true)
+		err := checkDestinationFiles(destDir, 2, mode)
+		if err != nil {
+			t.Fatalf("Destination file mode differs from source file mode\n%v", err)
+		}
+	}
+}
+
+func setupSourceFolder(numberOfFiles, mode int) (string, error) {
+	dir := os.TempDir()
+	data := []byte("open faas")
+
+	// create a folder for source files
+	srcDir, dirError := ioutil.TempDir(dir, "openfaas-test-source-")
+	if dirError != nil {
+		return "", dirError
+	}
+
+	// create n files inside the created folder
+	for i := 1; i <= numberOfFiles; i++ {
+		srcFile := fmt.Sprintf("%s/test-file-%d", srcDir, i)
+		fileErr := ioutil.WriteFile(srcFile, data, os.FileMode(mode))
+		if fileErr != nil {
+			return "", fileErr
+		}
+	}
+
+	return srcDir, nil
+}
+
+func checkDestinationFiles(dir string, numberOfFiles, mode int) error {
+	// Check each file inside the destination folder
+	for i := 1; i <= numberOfFiles; i++ {
+		fileStat, err := os.Stat(fmt.Sprintf("%s/test-file-%d", dir, i))
+		if os.IsNotExist(err) {
+			return err
+		}
+		if fileStat.Mode() != os.FileMode(mode) {
+			return errors.New("Expected mode did not match")
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Signed-off-by: Ganessh Kumar R P <rpganesshkumar@gmail.com>

## Description
This is a fix to #253, where cp removes any execute permission on the file by using default `0660` on the destination file.

This commit reads the mode of the source file using `os.Stat(src)` and use the source file's permission on the destination file.  The destination file will have the same permission as the source file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([#253](https://github.com/openfaas/faas-cli/issues/253))

## How Has This Been Tested?
- [x] `go build` and `go test`
- [ ]  use the build fass-cli to check the file permission (yet to do)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- ~~My change requires a change to the documentation.~~
- ~~I have updated the documentation accordingly.~~
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- ~~I have added tests to cover my changes.~~
- [x] All ~~new and~~ existing tests passed.
