### PR TITLE
[WIP] Use rolling update instead of delete/create when function exists

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -82,8 +82,8 @@ via flags. Note: --replace and --update are mutually exclusive.`,
   faas-cli deploy -f ./samples.yml --label canary=true
   faas-cli deploy -f ./samples.yml --filter "*gif*" --secret dockerhuborg
   faas-cli deploy -f ./samples.yml --regex "fn[0-9]_.*"
-  faas-cli deploy -f ./samples.yml --replace=false
-  faas-cli deploy -f ./samples.yml --update=true
+  faas-cli deploy -f ./samples.yml --replace=false --update=true
+  faas-cli deploy -f ./samples.yml --replace=true --update=false
   faas-cli deploy --image=alexellis/faas-url-ping --name=url-ping
   faas-cli deploy --image=my_image --name=my_fn --handler=/path/to/fn/
                   --gateway=http://remote-site.com:8080 --lang=python

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -42,8 +42,8 @@ func init() {
 
 	deployCmd.Flags().StringArrayVarP(&labelOpts, "label", "l", []string{}, "Set one or more label (LABEL=VALUE)")
 
-	deployCmd.Flags().BoolVar(&replace, "replace", true, "Replace any existing function")
-	deployCmd.Flags().BoolVar(&update, "update", false, "Update existing functions")
+	deployCmd.Flags().BoolVar(&replace, "replace", false, "Replace any existing function")
+	deployCmd.Flags().BoolVar(&update, "update", true, "Update existing functions")
 
 	deployCmd.Flags().StringArrayVar(&constraints, "constraint", []string{}, "Apply a constraint to the function")
 	deployCmd.Flags().StringArrayVar(&secrets, "secret", []string{}, "Give the function access to a secure secret")

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -73,12 +73,7 @@ func Test_getGatewayURL(t *testing.T) {
 func Test_deploy(t *testing.T) {
 	s := test.MockHttpServer(t, []test.Request{
 		{
-			Method:             http.MethodDelete,
-			Uri:                "/system/functions",
-			ResponseStatusCode: http.StatusOK,
-		},
-		{
-			Method:             http.MethodPost,
+			Method:             http.MethodPut,
 			Uri:                "/system/functions",
 			ResponseStatusCode: http.StatusOK,
 		},
@@ -95,7 +90,7 @@ func Test_deploy(t *testing.T) {
 		faasCmd.Execute()
 	})
 
-	if found, err := regexp.MatchString(`(?m:Deployed)`, stdOut); err != nil || !found {
+	if found, err := regexp.MatchString(`(?m:Updated)`, stdOut); err != nil || !found {
 		t.Fatalf("Output is not as expected:\n%s", stdOut)
 	}
 

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -31,12 +31,10 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 
 	if update == true && statusCode == http.StatusNotFound {
 		// Re-run the function with update=false
-		update = false
-		Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
+		Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, false, secrets, labels, functionResourceRequest1)
 	}
 }
 
-// Call FaaS server to deploy a new function
 func Deploy(fprocess string, gateway string, functionName string, image string,
 	language string, replace bool, envVars map[string]string, network string,
 	constraints []string, update bool, secrets []string, labels map[string]string,

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -27,18 +27,17 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	constraints []string, update bool, secrets []string, labels map[string]string,
 	functionResourceRequest1 FunctionResourceRequest) {
 
-	statusCode := DeployFunctionImpl(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
+	statusCode := Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
 
 	if update == true && statusCode == http.StatusNotFound {
 		// Re-run the function with update=false
 		update = false
-		DeployFunctionImpl(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
+		Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
 	}
-
 }
 
-// DeployFunction call FaaS server to deploy a new function
-func DeployFunctionImpl(fprocess string, gateway string, functionName string, image string,
+// Call FaaS server to deploy a new function
+func Deploy(fprocess string, gateway string, functionName string, image string,
 	language string, replace bool, envVars map[string]string, network string,
 	constraints []string, update bool, secrets []string, labels map[string]string,
 	functionResourceRequest1 FunctionResourceRequest) int {
@@ -113,14 +112,14 @@ func DeployFunctionImpl(fprocess string, gateway string, functionName string, im
 	SetAuth(request, gateway)
 	if err != nil {
 		fmt.Println(err)
-		return -1
+		return http.StatusInternalServerError
 	}
 
 	res, err := client.Do(request)
 	if err != nil {
 		fmt.Println("Is FaaS deployed? Do you need to specify the --gateway flag?")
 		fmt.Println(err)
-		return -1
+		return http.StatusInternalServerError
 	}
 
 	if res.Body != nil {

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openfaas/faas-cli/test"
 )
 
-type DeployProxyTest struct {
+type deployProxyTest struct {
 	title               string
 	mockServerResponses []int
 	replace             bool
@@ -22,31 +22,7 @@ type DeployProxyTest struct {
 	expectedOutput      string
 }
 
-var DeployProxyTests = []DeployProxyTest{
-	{
-		title:               "200_Deploy",
-		mockServerResponses: []int{http.StatusOK, http.StatusOK},
-		replace:             true,
-		update:              false,
-		expectedOutput:      `(?m:Deployed.)`,
-	},
-	{
-		title:               "404_Deploy",
-		mockServerResponses: []int{http.StatusOK, http.StatusNotFound},
-		replace:             true,
-		update:              false,
-		expectedOutput:      `(?m:Unexpected status: 404)`,
-	},
-	{
-		title:               "UpdateFailedDeployed",
-		mockServerResponses: []int{http.StatusNotFound, http.StatusOK},
-		replace:             false,
-		update:              true,
-		expectedOutput:      `(?m:Deployed.)`,
-	},
-}
-
-func runDeployProxyTest(t *testing.T, deployTest DeployProxyTest) {
+func runDeployProxyTest(t *testing.T, deployTest deployProxyTest) {
 	s := test.MockHttpServerStatus(
 		t,
 		deployTest.mockServerResponses...,
@@ -78,7 +54,30 @@ func runDeployProxyTest(t *testing.T, deployTest DeployProxyTest) {
 }
 
 func Test_RunDeployProxyTests(t *testing.T) {
-	for _, tst := range DeployProxyTests {
+	var deployProxyTests = []deployProxyTest{
+		{
+			title:               "200_Deploy",
+			mockServerResponses: []int{http.StatusOK, http.StatusOK},
+			replace:             true,
+			update:              false,
+			expectedOutput:      `(?m:Deployed.)`,
+		},
+		{
+			title:               "404_Deploy",
+			mockServerResponses: []int{http.StatusOK, http.StatusNotFound},
+			replace:             true,
+			update:              false,
+			expectedOutput:      `(?m:Unexpected status: 404)`,
+		},
+		{
+			title:               "UpdateFailedDeployed",
+			mockServerResponses: []int{http.StatusNotFound, http.StatusOK},
+			replace:             false,
+			update:              true,
+			expectedOutput:      `(?m:Deployed.)`,
+		},
+	}
+	for _, tst := range deployProxyTests {
 		t.Run(tst.title, func(t *testing.T) {
 			runDeployProxyTest(t, tst)
 		})

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -46,10 +46,10 @@ var DeployProxyTests = []DeployProxyTest{
 	},
 }
 
-func runDeployProxyTest(t *testing.T, dpt DeployProxyTest) {
+func runDeployProxyTest(t *testing.T, deployTest DeployProxyTest) {
 	s := test.MockHttpServerStatus(
 		t,
-		dpt.mockServerResponses...,
+		deployTest.mockServerResponses...,
 	)
 	defer s.Close()
 
@@ -60,18 +60,18 @@ func runDeployProxyTest(t *testing.T, dpt DeployProxyTest) {
 			"function",
 			"image",
 			"language",
-			dpt.replace,
+			deployTest.replace,
 			nil,
 			"network",
 			[]string{},
-			dpt.update,
+			deployTest.update,
 			[]string{},
 			map[string]string{},
 			FunctionResourceRequest{},
 		)
 	})
 
-	r := regexp.MustCompile(dpt.expectedOutput)
+	r := regexp.MustCompile(deployTest.expectedOutput)
 	if !r.MatchString(stdout) {
 		t.Fatalf("Output not matched: %s", stdout)
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is to perform in-place update of functions rather than delete/create when the function already exists.

If the function does not already exist and we get 404, create the function.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#256 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing is improved in `proxy/deploy_test.go` by adding scaffolding with array-of-struct test cases.

We need to improve testing in this area by adding more test cases (hence why this is WIP).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
