### PR TITLE
[WIP] Re-factoring for errors

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -1,0 +1,4 @@
+// Copyright (c) OpenFaaS Project 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package builder

--- a/commands/bash_completion.go
+++ b/commands/bash_completion.go
@@ -4,8 +4,6 @@
 package commands
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -28,12 +26,12 @@ pending a merge of https://github.com/spf13/cobra/pull/520.`,
 
 func runBashcompletion(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("please provide filename for bash completion")
+		return ErrorBashCompletionFilename
 	}
 	fileName := args[0]
 	err := faasCmd.GenBashCompletionFile(fileName)
 	if err != nil {
-		return fmt.Errorf("unable to create bash completion file")
+		return ErrorBashCompletionFileUncreated
 	}
 
 	return nil

--- a/commands/build.go
+++ b/commands/build.go
@@ -89,13 +89,13 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		build(&services, parallel, shrinkwrap)
 	} else {
 		if len(image) == 0 {
-			return fmt.Errorf("please provide a valid --image name for your Docker image")
+			return ErrorInvalidImageFlag
 		}
 		if len(handler) == 0 {
-			return fmt.Errorf("please provide the full path to your function's handler")
+			return ErrorFunctionPath
 		}
 		if len(functionName) == 0 {
-			return fmt.Errorf("please provide the deployed --name of your function")
+			return ErrorMissingFunctionNameFlag
 		}
 		builder.BuildImage(image, handler, functionName, language, nocache, squash, shrinkwrap)
 	}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -108,7 +108,7 @@ func RunDeploy(
 		fmt.Println(`Cannot specify --update and --replace at the same time.
   --replace    removes an existing deployment before re-creating it
   --update     provides a rolling update to a new function image or configuration`)
-		return fmt.Errorf("cannot specify --update and --replace at the same time")
+		return ErrorExclusiveUpdateReplaceFlag
 	}
 
 	var services stack.Services
@@ -191,10 +191,10 @@ func RunDeploy(
 		}
 	} else {
 		if len(image) == 0 {
-			return fmt.Errorf("please provide a --image to be deployed")
+			return ErrorMissingImageFlag
 		}
 		if len(functionName) == 0 {
-			return fmt.Errorf("please provide a --name for your function as it will be deployed on FaaS")
+			return ErrorMissingFunctionNameFlag
 		}
 
 		envvars, err := parseMap(deployFlags.envvarOpts, "env")
@@ -270,7 +270,7 @@ func parseMap(envvars []string, keyName string) (map[string]string, error) {
 	for _, envvar := range envvars {
 		s := strings.SplitN(strings.TrimSpace(envvar), "=", 2)
 		if len(s) != 2 {
-			return nil, fmt.Errorf("label format is not correct, needs key=value")
+			return nil, ErrorInvalidLabel
 		}
 		envvarName := s[0]
 		envvarValue := s[1]

--- a/commands/errors.go
+++ b/commands/errors.go
@@ -1,0 +1,27 @@
+package commands
+
+import "errors"
+
+var (
+	ErrorStoreMissingFunctionName    = errors.New("please provide the function name")
+	ErrorMissingFunctionName         = errors.New("please provide a name for the function")
+	ErrorMissingFunctionNameFlag     = errors.New("please provide the function name with --name")
+	ErrorMissingImageFlag            = errors.New("please provide the image name with --image")
+	ErrorMissingUsername             = errors.New("must provide --username or -u")
+	ErrorPasswordStdinAndPassword    = errors.New("--password and --password-stdin are mutually exclusive")
+	ErrorMissingPassword             = errors.New("must provide a non-empty password via --password or --password-stdin")
+	ErrorMissingGateway              = errors.New("gateway cannot be an empty string")
+	ErrorUnauthorizedGateway         = errors.New("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+	ErrorInvalidYamlFile             = errors.New("you must supply a valid YAML file")
+	ErrorMissingLangFlagFile         = errors.New("you must supply a function language with the --lang flag")
+	ErrorInvalidImageFlag            = errors.New("please provide a valid image name with --image for your Docker image")
+	ErrorFunctionPath                = errors.New("please provide the full path to your function's handler")
+	ErrorMissingFunctionNameToDelete = errors.New("please provide the name of a function to delete")
+	ErrorUnavailableLanguageTemplate = errors.New("no language templates were found. Please run 'faas-cli template pull'")
+	ErrorExclusiveUpdateReplaceFlag  = errors.New("cannot specify --update and --replace at the same time")
+	ErrorGatewayUnsuccessfulLogin    = errors.New("unable to login, either username or password is incorrect")
+	ErrorInvalidLabel                = errors.New("label format is not correct, needs key=value")
+	ErrorBashCompletionFilename      = errors.New("please provide filename for bash completion")
+	ErrorBashCompletionFileUncreated = errors.New("unable to create bash completion file")
+	ErrorInvalidRepositoryURL        = errors.New("the repository URL must be a valid git repo uri")
+)

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -43,7 +43,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 	var services stack.Services
 
 	if len(args) < 1 {
-		return fmt.Errorf("please provide a name for the function")
+		return ErrorMissingFunctionName
 	}
 	var yamlGateway string
 	functionName = args[0]

--- a/commands/login_test.go
+++ b/commands/login_test.go
@@ -1,0 +1,28 @@
+package commands
+
+import "testing"
+
+func Test_runLogin_NoFlags(t *testing.T) {
+	err := runLogin(nil, nil)
+	if err != ErrorMissingUsername {
+		t.Errorf("'%s' is not the expected error '%s'", err, ErrorMissingUsername)
+	}
+}
+
+func Test_runLogin_MissingPassword(t *testing.T) {
+	username = "username_test"
+	err := runLogin(nil, nil)
+	if err != ErrorMissingPassword {
+		t.Errorf("'%s' is not the expected error '%s'", err, ErrorMissingPassword)
+	}
+}
+
+func Test_runLogin_PasswordStdinAndPasswordGiven(t *testing.T) {
+	username = "username_test"
+	password = "password_test"
+	passwordStdin = true
+	err := runLogin(nil, nil)
+	if err != ErrorPasswordStdinAndPassword {
+		t.Errorf("'%s' is not the expected error '%s'", err, ErrorPasswordStdinAndPassword)
+	}
+}

--- a/commands/logout.go
+++ b/commands/logout.go
@@ -21,13 +21,13 @@ var logoutCmd = &cobra.Command{
 	Use:     `logout [--gateway GATEWAY_URL]`,
 	Short:   "Log out from OpenFaaS gateway",
 	Long:    "Log out from OpenFaaS gateway.\nIf no gateway is specified, the default local one will be used.",
-	Example: `  faas-cli logout --gateway https://openfaas.mydomain.com`,
+	Example: `  faas-cli logout --gateway ` + defaultGateway,
 	RunE:    runLogout,
 }
 
 func runLogout(cmd *cobra.Command, args []string) error {
 	if len(gateway) == 0 {
-		return fmt.Errorf("gateway cannot be an empty string")
+		return ErrorMissingGateway
 	}
 
 	gateway = strings.TrimRight(strings.TrimSpace(gateway), "/")

--- a/commands/logout_test.go
+++ b/commands/logout_test.go
@@ -1,0 +1,11 @@
+package commands
+
+import "testing"
+
+func Test_runLogout_NoFlags(t *testing.T) {
+	gateway = ""
+	err := runLogout(nil, nil)
+	if err != ErrorMissingGateway {
+		t.Errorf("'%s' is not the expected error '%s'", err, ErrorMissingGateway)
+	}
+}

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -54,7 +54,7 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 		var availableTemplates []string
 
 		if templateFolders, err := ioutil.ReadDir(templateDirectory); err != nil {
-			return fmt.Errorf("no language templates were found. Please run 'faas-cli template pull'")
+			return ErrorUnavailableLanguageTemplate
 		} else {
 			for _, file := range templateFolders {
 				if file.IsDir() {
@@ -73,12 +73,12 @@ the "Dockerfile" lang type in your YAML file.
 	}
 
 	if len(args) < 1 {
-		return fmt.Errorf("please provide a name for the function")
+		return ErrorMissingFunctionName
 	}
 	functionName = args[0]
 
 	if len(lang) == 0 {
-		return fmt.Errorf("you must supply a function language with the --lang flag")
+		return ErrorMissingLangFlagFile
 	}
 
 	PullTemplates("")

--- a/commands/push.go
+++ b/commands/push.go
@@ -52,7 +52,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if len(services.Functions) > 0 {
 		pushStack(&services, parallel)
 	} else {
-		return fmt.Errorf("you must supply a valid YAML file")
+		return ErrorInvalidYamlFile
 	}
 	return nil
 }

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -67,7 +67,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	} else {
 		if len(args) < 1 {
-			return fmt.Errorf("please provide the name of a function to delete")
+			return ErrorMissingFunctionNameToDelete
 		}
 
 		functionName = args[0]

--- a/commands/store.go
+++ b/commands/store.go
@@ -144,7 +144,7 @@ func renderDescription(descr string) string {
 
 func runStoreInspect(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("please provide the function name")
+		return ErrorStoreMissingFunctionName
 	}
 
 	storeItems, err := storeList(storeAddress)
@@ -183,7 +183,7 @@ func renderStoreItem(item *schema.StoreItem) string {
 
 func runStoreDeploy(cmd *cobra.Command, args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("please provide the function name")
+		return ErrorStoreMissingFunctionName
 	}
 
 	storeItems, err := storeList(storeAddress)

--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -53,7 +53,7 @@ Currently supported verbs: %v`, supportedVerbs)
 
 			var validURL = regexp.MustCompile(gitRemoteRepoRegex)
 			if !validURL.MatchString(args[1]) {
-				return fmt.Errorf("The repository URL must be a valid git repo uri")
+				return ErrorInvalidRepositoryURL
 			}
 		}
 		return nil

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"regexp"
-	"strings"
 	"testing"
 )
 
@@ -69,8 +68,8 @@ func Test_templatePull(t *testing.T) {
 		faasCmd.SetOutput(&buf)
 		err := faasCmd.Execute()
 
-		if !strings.Contains(err.Error(), "The repository URL must be a valid git repo uri") {
-			t.Fatal("Output does not contain the required string", err.Error())
+		if err != ErrorInvalidRepositoryURL {
+			t.Fatalf("Output does not contain the required string: '%s'", err.Error())
 		}
 	})
 }

--- a/commands/update_gitignore.go
+++ b/commands/update_gitignore.go
@@ -15,7 +15,7 @@ func contains(s []string, e string) bool {
 	return false
 }
 
-func updateContent(content string) (updated_content string) {
+func updateContent(content string) (updatedContent string) {
 	// append files to ignore to file content if it is not already ignored
 
 	filesToIgnore := []string{"template", "build"}
@@ -28,9 +28,9 @@ func updateContent(content string) (updated_content string) {
 		}
 	}
 
-	updated_content = strings.Join(lines, "\n")
-	updated_content = strings.Trim(updated_content, "\n")
-	return updated_content
+	updatedContent = strings.Join(lines, "\n")
+	updatedContent = strings.Trim(updatedContent, "\n")
+	return updatedContent
 }
 
 func updateGitignore() (err error) {
@@ -48,10 +48,10 @@ func updateGitignore() (err error) {
 		return err
 	}
 
-	string_content := string(content[:])
-	write_content := updateContent(string_content)
+	stringContent := string(content[:])
+	writeContent := updateContent(stringContent)
 
-	_, err = f.WriteString(write_content + "\n")
+	_, err = f.WriteString(writeContent + "\n")
 	if err != nil {
 		return err
 	}

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -46,7 +46,7 @@ func DeleteFunction(gateway string, functionName string) error {
 	case http.StatusNotFound:
 		fmt.Println("No existing function to remove")
 	case http.StatusUnauthorized:
-		fmt.Println("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		fmt.Println(ErrorUnauthorizedGateway)
 	default:
 		var bodyReadErr error
 		bytesOut, bodyReadErr := ioutil.ReadAll(delRes.Body)

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -137,7 +137,7 @@ func Deploy(fprocess string, gateway string, functionName string, image string,
 		deployedURL := fmt.Sprintf("URL: %s/function/%s", gateway, functionName)
 		deployOutput += fmt.Sprintln(deployedURL)
 	case http.StatusUnauthorized:
-		deployOutput += fmt.Sprintln("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		deployOutput += fmt.Sprintln(ErrorUnauthorizedGateway)
 		/*
 			case http.StatusNotFound:
 				if replace && !update {

--- a/proxy/errors.go
+++ b/proxy/errors.go
@@ -1,0 +1,9 @@
+package proxy
+
+import "errors"
+
+var (
+	ErrorQueryFlag           = errors.New("the --query flags must take the form of key=value (= not found)")
+	ErrorEmptyQueryFlag      = errors.New("the --query flag must take the form of: key=value (empty value given, or value ends in =)")
+	ErrorUnauthorizedGateway = errors.New("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+)

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -61,7 +61,7 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 			return nil, fmt.Errorf("cannot read result from OpenFaaS on URL: %s %s", gateway, readErr)
 		}
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		return nil, ErrorUnauthorizedGateway
 	default:
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err == nil {
@@ -80,10 +80,10 @@ func buildQueryString(query []string) (string, error) {
 		for _, queryValue := range query {
 			qs = qs + queryValue + "&"
 			if strings.Contains(queryValue, "=") == false {
-				return "", fmt.Errorf("the --query flags must take the form of key=value (= not found)")
+				return "", ErrorQueryFlag
 			}
 			if strings.HasSuffix(queryValue, "=") {
-				return "", fmt.Errorf("the --query flag must take the form of: key=value (empty value given, or value ends in =)")
+				return "", ErrorEmptyQueryFlag
 			}
 		}
 		qs = strings.TrimRight(qs, "&")

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -51,7 +51,7 @@ func ListFunctions(gateway string) ([]requests.Function, error) {
 			return nil, fmt.Errorf("cannot parse result from OpenFaaS on URL: %s\n%s", gateway, jsonErr.Error())
 		}
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		return nil, ErrorUnauthorizedGateway
 	default:
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err == nil {

--- a/stack/errors.go
+++ b/stack/errors.go
@@ -1,0 +1,8 @@
+package stack
+
+import "errors"
+
+var (
+	ErrorMissingFilterOrRegexFlag = errors.New("no functions matching --filter/--regex were found in the YAML file")
+	ErrorExclusiveFilterRegexFlag = errors.New("pass in a regex or a filter, not both")
+)

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -47,7 +47,7 @@ func ParseYAMLData(fileData []byte, regex string, filter string) (*Services, err
 	err := yaml.Unmarshal(fileData, &services)
 	if err != nil {
 		fmt.Printf("Error with YAML file\n")
-		return nil, err
+		return nil, ErrorMissingFilterOrRegexFlag
 	}
 
 	if services.Provider.Name != providerName {
@@ -55,7 +55,7 @@ func ParseYAMLData(fileData []byte, regex string, filter string) (*Services, err
 	}
 
 	if regexExists && filterExists {
-		return nil, fmt.Errorf("pass in a regex or a filter, not both")
+		return nil, ErrorExclusiveFilterRegexFlag
 	}
 
 	if regexExists || filterExists {
@@ -79,7 +79,7 @@ func ParseYAMLData(fileData []byte, regex string, filter string) (*Services, err
 		}
 
 		if len(services.Functions) == 0 {
-			return nil, fmt.Errorf("no functions matching --filter/--regex were found in the YAML file")
+			return nil, ErrorMissingFilterOrRegexFlag
 		}
 
 	}

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -50,7 +50,6 @@ const TestData_2 string = `provider:
 
 `
 
-const noMatchesErrorMsg string = "no functions matching --filter/--regex were found in the YAML file"
 const invalidRegexErrorMsg string = "error parsing regexp"
 
 var ParseYAMLTests_Regex = []struct {
@@ -93,7 +92,7 @@ var ParseYAMLTests_Regex = []struct {
 		searchTerm:    "----",
 		functions:     []string{},
 		file:          TestData_1,
-		expectedError: noMatchesErrorMsg,
+		expectedError: ErrorMissingFilterOrRegexFlag.Error(),
 	},
 	{
 		title:         "Regex search for functions without dashes: '^[^-]+$'",
@@ -149,7 +148,7 @@ var ParseYAMLTests_Regex = []struct {
 		searchTerm:    "RANDOMREGEX",
 		functions:     []string{},
 		file:          TestData_1,
-		expectedError: noMatchesErrorMsg,
+		expectedError: ErrorMissingFilterOrRegexFlag.Error(),
 	},
 	{
 		title:         "Regex empty search term in empty YAML file: ",
@@ -214,7 +213,7 @@ var ParseYAMLTests_Filter = []struct {
 		searchTerm:    "RANDOMTEXT",
 		functions:     []string{},
 		file:          TestData_1,
-		expectedError: noMatchesErrorMsg,
+		expectedError: ErrorMissingFilterOrRegexFlag.Error(),
 	},
 	{
 		title:         "Wildcard empty search term in empty YAML file: ''",


### PR DESCRIPTION
## Motivation and Context
Currently errors are generated with `fmt.Errorf` which is not re-usable to compare errors in unit-test. Instead of creating errors with `fmt.Errorf`, we can pre-defined errors with `errors.New()` and we can re-use the errors everywhere in the package.

- [x] I have raised an issue to propose this change (fixes #259)

## How Has This Been Tested?
With current test suite

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement of quality of code

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
