### PR TITLE
Fix gateway overriding for faas-cli remove

### DIFF
--- a/commands/remove.go
+++ b/commands/remove.go
@@ -38,6 +38,8 @@ explicitly specifying a function name.`,
 
 func runDelete(cmd *cobra.Command, args []string) error {
 	var services stack.Services
+	var gatewayAddress string
+	var yamlGateway string
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
@@ -46,8 +48,11 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		if parsedServices != nil {
 			services = *parsedServices
+			yamlGateway = services.Provider.GatewayURL
 		}
 	}
+
+	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway)
 
 	if len(services.Functions) > 0 {
 		if len(services.Provider.Network) == 0 {
@@ -58,7 +63,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			function.Name = k
 			fmt.Printf("Deleting: %s.\n", function.Name)
 
-			proxy.DeleteFunction(services.Provider.GatewayURL, function.Name)
+			proxy.DeleteFunction(gatewayAddress, function.Name)
 		}
 	} else {
 		if len(args) < 1 {


### PR DESCRIPTION
## Description
fix #267

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested on Docker Swarm 17.09.1-ce with faas-swarm https://github.com/openfaas/faas/pull/460

Direct override
```
./faas-cli remove func_markdown --gateway=http://<GCP-IP>:8080
Deleting: func_markdown.
Removing old function.
```

Stack override
```
./faas-cli deploy -f ./sample/hmac.yml --gateway=http://<GCP-IP>:8080
Deploying: hmac.
No existing function to remove
Deployed.
200 OK

./faas-cli remove -f ./sample/hmac.yml --gateway=http://<GCP-IP>:8080
Deleting: hmac.
Removing old function.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.