### PR TITLE
Improve output for rolling updates

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -127,11 +127,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		for k, function := range services.Functions {
 
 			function.Name = k
-			if update {
-				fmt.Printf("Updating: %s.\n", function.Name)
-			} else {
-				fmt.Printf("Deploying: %s.\n", function.Name)
-			}
+			fmt.Printf("Deploying: %s.\n", function.Name)
 
 			var functionConstraints []string
 			if function.Constraints != nil {

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -27,24 +27,25 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	constraints []string, update bool, secrets []string, labels map[string]string,
 	functionResourceRequest1 FunctionResourceRequest) {
 
-	if update {
-		fmt.Printf("Attempting to update function: %s\n", functionName)
-	}
-
-	statusCode := Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
+	rollingUpdateInfo := fmt.Sprintf("Function %s already exists, attempting rolling-update.", functionName)
+	statusCode, deployOutput := Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, update, secrets, labels, functionResourceRequest1)
 
 	if update == true && statusCode == http.StatusNotFound {
-		fmt.Println("\nFunction not found, attempting deployment.")
 		// Re-run the function with update=false
-		Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, false, secrets, labels, functionResourceRequest1)
+		_, deployOutput = Deploy(fprocess, gateway, functionName, image, language, replace, envVars, network, constraints, false, secrets, labels, functionResourceRequest1)
+	} else if statusCode == http.StatusOK {
+		fmt.Println(rollingUpdateInfo)
 	}
+	fmt.Println()
+	fmt.Println(deployOutput)
 }
 
 func Deploy(fprocess string, gateway string, functionName string, image string,
 	language string, replace bool, envVars map[string]string, network string,
 	constraints []string, update bool, secrets []string, labels map[string]string,
-	functionResourceRequest1 FunctionResourceRequest) int {
+	functionResourceRequest1 FunctionResourceRequest) (int, string) {
 
+	var deployOutput string
 	// Need to alter Gateway to allow nil/empty string as fprocess, to avoid this repetition.
 	var fprocessTemplate string
 	if len(fprocess) > 0 {
@@ -114,15 +115,15 @@ func Deploy(fprocess string, gateway string, functionName string, image string,
 	request, err = http.NewRequest(method, gateway+"/system/functions", reader)
 	SetAuth(request, gateway)
 	if err != nil {
-		fmt.Println(err)
-		return http.StatusInternalServerError
+		deployOutput += fmt.Sprintln(err)
+		return http.StatusInternalServerError, deployOutput
 	}
 
 	res, err := client.Do(request)
 	if err != nil {
-		fmt.Println("Is FaaS deployed? Do you need to specify the --gateway flag?")
-		fmt.Println(err)
-		return http.StatusInternalServerError
+		deployOutput += fmt.Sprintln("Is FaaS deployed? Do you need to specify the --gateway flag?")
+		deployOutput += fmt.Sprintln(err)
+		return http.StatusInternalServerError, deployOutput
 	}
 
 	if res.Body != nil {
@@ -131,23 +132,24 @@ func Deploy(fprocess string, gateway string, functionName string, image string,
 
 	switch res.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
-		if update {
-			fmt.Println("Deployed (updated)")
-		} else {
-			fmt.Println("Deployed")
-		}
+		deployOutput += fmt.Sprintf("Deployed. %s.\n", res.Status)
 
-		deployedURL := fmt.Sprintf("URL: %s/function/%s\n", gateway, functionName)
-		fmt.Println(deployedURL)
+		deployedURL := fmt.Sprintf("URL: %s/function/%s", gateway, functionName)
+		deployOutput += fmt.Sprintln(deployedURL)
 	case http.StatusUnauthorized:
-		fmt.Println("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		deployOutput += fmt.Sprintln("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		/*
+			case http.StatusNotFound:
+				if replace && !update {
+					deployOutput += fmt.Sprintln("Could not delete-and-replace function because it is not found (404)")
+				}
+		*/
 	default:
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err == nil {
-			fmt.Printf("Unexpected status: %d, message: %s\n", res.StatusCode, string(bytesOut))
+			deployOutput += fmt.Sprintf("Unexpected status: %d, message: %s\n", res.StatusCode, string(bytesOut))
 		}
 	}
 
-	fmt.Println(res.Status)
-	return res.StatusCode
+	return res.StatusCode, deployOutput
 }


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The purpose of this PR is to make the output for `faas-cli deploy` more clear when a rolling update is triggered, or when a rolling update fails and a regular 'create' deploy is triggered.

The output now looks like:

Function already exists:
```
$ faas-cli deploy --name echo --image functions/faas-echo:latest --gateway $gw

Function echo already exists, attempting rolling-update.
Deployed (updated)
URL: http://192.168.99.100:8080/function/echo

200 OK
```

Function does not yet exist:

```
$ faas-cli deploy --name echo --image functions/faas-echo:latest --gateway $gw

Function not found, attempting deployment.
Deployed
URL: http://192.168.99.100:8080/function/echo

200 OK
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This change was proposed by Alex here: https://github.com/openfaas/faas-cli/pull/257#issuecomment-354670227

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests pass, only change here is to output messages, no implementation changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
