### PR TITLE
Append http prefix to the gateway URL

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -299,6 +299,11 @@ func getGatewayURL(argumentURL string, defaultURL string, yamlURL string) string
 		gatewayURL = defaultURL
 	}
 
+	gatewayURL = strings.ToLower(strings.TrimRight(gatewayURL, "/"))
+	if !strings.HasPrefix(gatewayURL, "http") {
+		gatewayURL = fmt.Sprintf("http://%s", gatewayURL)
+	}
+
 	return gatewayURL
 }
 


### PR DESCRIPTION
fix #279

## Description
This PR allows the gateway URL to be specified in the `IP:PORT` format without HTTP/S.
If a protocol is not specified then HTTP will be used.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Tested on GKE with HTTP, HTTPS and IP:PORT

Before the fix:

```
./faas-cli login -u test -p test --gateway=163.172.143.209:31112
Calling the OpenFaaS server to validate the credentials...
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x12de642]
```

After the fix:

```
./faas-cli login -u test -p test --gateway=163.172.143.209:31112
Calling the OpenFaaS server to validate the credentials...
Cannot connect to OpenFaaS on URL: http://163.172.143.209:31112
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.