### PR TITLE
[WIP]Updated help and error text for deploy

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -43,8 +43,8 @@ func init() {
 
 	deployCmd.Flags().StringArrayVarP(&deployFlags.labelOpts, "label", "l", []string{}, "Set one or more label (LABEL=VALUE)")
 
-	deployCmd.Flags().BoolVar(&deployFlags.replace, "replace", false, "Replace any existing function")
-	deployCmd.Flags().BoolVar(&deployFlags.update, "update", true, "Update existing functions")
+	deployCmd.Flags().BoolVar(&deployFlags.replace, "replace", false, "Remove and re-create existing function(s)")
+	deployCmd.Flags().BoolVar(&deployFlags.update, "update", true, "Perform rolling update on existing function(s)")
 
 	deployCmd.Flags().StringArrayVar(&deployFlags.constraints, "constraint", []string{}, "Apply a constraint to the function")
 	deployCmd.Flags().StringArrayVar(&deployFlags.secrets, "secret", []string{}, "Give the function access to a secure secret")
@@ -105,9 +105,9 @@ func RunDeploy(
 ) error {
 
 	if deployFlags.update && deployFlags.replace {
-		fmt.Println(`Cannot specify --update and --replace at the same time.
+		fmt.Println(`Cannot specify --update and --replace at the same time. One of --update or --replace must be false.
   --replace    removes an existing deployment before re-creating it
-  --update     provides a rolling update to a new function image or configuration`)
+  --update     performs a rolling update to a new function image or configuration (default true)`)
 		return fmt.Errorf("cannot specify --update and --replace at the same time")
 	}
 


### PR DESCRIPTION
Updated the help text for deploy around the `--update` and `--replace` flags to help avoid confusion. This came up as a question in the Slack contributors channel by Vivek

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a note to the error messaging indicating that either the update or replace flag needs to be set to false
Also updated the `--help` text to indicate that `--update` was default to true to make it clearer

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- No github issue, but mentioned in Slack channel as an improvement 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
