### PR TITLE
Fix bug to allow plain urls for git repos

### DIFF
--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	gitRemoteRepoRegex = `(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)(\/?|\#[-\d\w._]+?)$`
+	gitRemoteRepoRegex = `(?:git|ssh|https?|git@[-\w.]+):(\/\/)?(.*?)(\.git)?(\/?|\#[-\d\w._]+?)$`
 )
 
 var (

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -83,12 +83,14 @@ func Test_repositoryUrlRemoteRegExp(t *testing.T) {
 		url  string
 	}{
 		{name: "git protocol with sha", url: "git://github.com/openfaas/faas.git#ff78lf9h"},
+		{name: "git protocol without .git suffix", url: "git://host.xz/path/to/repo"},
 		{name: "git protocol with branch", url: "git://github.com/openfaas/faas.git#master"},
 		{name: "git protocol", url: "git://host.xz/path/to/repo.git/"},
 		{name: "scp style with ip address", url: "git@192.168.101.127:user/project.git"},
 		{name: "scp style with hostname", url: "git@github.com:user/project.git"},
 		{name: "http protocol with ip address", url: "http://192.168.101.127/user/project.git"},
 		{name: "http protocol", url: "http://github.com/user/project.git"},
+		{name: "http protocol without .git suffix", url: "http://github.com/user/project"},
 		{name: "https protocol with ip address", url: "https://192.168.101.127/user/project.git"},
 		{name: "https protocol with hostname", url: "https://github.com/user/project.git"},
 		{name: "https protocol with basic auth", url: "https://username:password@github.com/username/repository.git"},


### PR DESCRIPTION
## Description
Update the git url regex used in the `template pull` command to allow repo urls that do not have a `.git` suffix
Fixes #292 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Via unit tests, locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
