### PR TITLE
Remove submodule in testdata

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "commands/testdata/templates"]
-	path = commands/testdata/templates
-	url = https://github.com/openfaas/templates.git

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -19,16 +19,7 @@ const SuccessMsg = `(?m:Function created in folder)`
 const InvalidYAMLMsg = `is not valid YAML`
 const InvalidYAMLMap = `map is empty`
 const ListOptionOutput = `Languages available as templates:
-- csharp
 - dockerfile
-- go
-- go-armhf
-- node
-- node-arm64
-- node-armhf
-- python
-- python-armhf
-- python3
 - ruby`
 
 const LangNotExistsOutput = `(?m:is unavailable or not supported)`

--- a/commands/testdata/templates/template/dockerfile/function/Dockerfile
+++ b/commands/testdata/templates/template/dockerfile/function/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:3.6
+# Use any image as your base image, or "scratch"
+# Add fwatchdog binary via https://github.com/openfaas/faas/releases/
+# Then set fprocess to the process you want to invoke per request - i.e. "cat" or "my_binary"
+
+ADD https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog /usr/bin
+RUN chmod +x /usr/bin/fwatchdog
+
+# Populate example here - i.e. "cat", "sha512sum" or "node index.js"
+ENV fprocess="wc -l"
+
+HEALTHCHECK --interval=5s CMD [ -e /tmp/.lock ] || exit 1
+CMD [ "fwatchdog" ]

--- a/commands/testdata/templates/template/dockerfile/template.yml
+++ b/commands/testdata/templates/template/dockerfile/template.yml
@@ -1,0 +1,1 @@
+language: dockerfile

--- a/commands/testdata/templates/template/ruby/Dockerfile
+++ b/commands/testdata/templates/template/ruby/Dockerfile
@@ -1,0 +1,24 @@
+FROM ruby:2.4-alpine3.6
+
+# Alternatively use ADD https:// (which will not be cached by Docker builder)
+RUN apk --no-cache add curl \ 
+    && echo "Pulling watchdog binary from Github." \
+    && curl -sSL https://github.com/openfaas/faas/releases/download/0.6.9/fwatchdog > /usr/bin/fwatchdog \
+    && chmod +x /usr/bin/fwatchdog \
+    && apk del curl --no-cache
+
+WORKDIR /root/
+
+COPY Gemfile		.
+COPY index.rb           .
+COPY function           function
+RUN bundle install 
+
+WORKDIR /root/function/
+RUN bundle install 
+
+WORKDIR /root/
+ENV fprocess="ruby index.rb"
+HEALTHCHECK --interval=2s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]

--- a/commands/testdata/templates/template/ruby/Gemfile
+++ b/commands/testdata/templates/template/ruby/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+

--- a/commands/testdata/templates/template/ruby/function/Gemfile
+++ b/commands/testdata/templates/template/ruby/function/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+

--- a/commands/testdata/templates/template/ruby/function/handler.rb
+++ b/commands/testdata/templates/template/ruby/function/handler.rb
@@ -1,0 +1,5 @@
+class Handler
+    def run(req)
+        return "Hello world from the Ruby template"
+    end
+end

--- a/commands/testdata/templates/template/ruby/index.rb
+++ b/commands/testdata/templates/template/ruby/index.rb
@@ -1,0 +1,11 @@
+# Copyright (c) Alex Ellis 2017. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+require_relative 'function/handler'
+
+req = ARGF.read
+
+handler = Handler.new
+res = handler.run req
+
+puts res

--- a/commands/testdata/templates/template/ruby/template.yml
+++ b/commands/testdata/templates/template/ruby/template.yml
@@ -1,0 +1,2 @@
+language: ruby
+fprocess: ruby index.rb


### PR DESCRIPTION
Introduced by #275
closes #299 

git submodule is removed, 2 test templates are added to the `testdata` dir: ruby & dockerfile
The test directory is copied to a temporary directory then git init is called to setup a local repo which will be used during tests
