### PR TITLE
ensure that the handler path is valid before building

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -27,16 +27,16 @@ func BuildImage(image string, handler string, functionName string, language stri
 			}
 
 			tempPath = handler
-			if _, err := os.Stat(handler); err != nil {
-				fmt.Printf("Unable to build %s, %s is an invalid path\n", image, handler)
-				fmt.Printf("Image: %s not built.\n", image)
-
+			if err := ensureHandlerPath(image, handler); err != nil {
 				return
 			}
 			fmt.Printf("Building: %s with Dockerfile. Please wait..\n", image)
 
 		} else {
 
+			if err := ensureHandlerPath(image, handler); err != nil {
+				return
+			}
 			tempPath = createBuildTemplate(functionName, handler, language)
 			fmt.Printf("Building: %s with %s template. Please wait..\n", image, language)
 
@@ -79,7 +79,7 @@ func createBuildTemplate(functionName string, handler string, language string) s
 	CopyFiles("./template/"+language, tempPath)
 
 	// Overlay in user-function
-	CopyFiles(handler, tempPath+"function/")
+	CopyFiles(handler, functionPath)
 
 	return tempPath
 }
@@ -104,4 +104,15 @@ func buildFlagString(nocache bool, squash bool, httpProxy string, httpsProxy str
 	}
 
 	return buildFlags
+}
+
+func ensureHandlerPath(image string, handler string) error {
+	if _, err := os.Stat(handler); err != nil {
+		fmt.Printf("Unable to build %s, %s is an invalid path\n", image, handler)
+		fmt.Printf("Image: %s not built.\n", image)
+
+		return err
+	}
+
+	return nil
 }

--- a/builder/build.go
+++ b/builder/build.go
@@ -27,14 +27,20 @@ func BuildImage(image string, handler string, functionName string, language stri
 			}
 
 			tempPath = handler
-			if err := ensureHandlerPath(image, handler); err != nil {
+			if err := ensureHandlerPath(handler); err != nil {
+				fmt.Printf("Unable to build %s, %s is an invalid path\n", image, handler)
+				fmt.Printf("Image: %s not built.\n", image)
+
 				return
 			}
 			fmt.Printf("Building: %s with Dockerfile. Please wait..\n", image)
 
 		} else {
 
-			if err := ensureHandlerPath(image, handler); err != nil {
+			if err := ensureHandlerPath(handler); err != nil {
+				fmt.Printf("Unable to build %s, %s is an invalid path\n", image, handler)
+				fmt.Printf("Image: %s not built.\n", image)
+
 				return
 			}
 			tempPath = createBuildTemplate(functionName, handler, language)
@@ -106,11 +112,8 @@ func buildFlagString(nocache bool, squash bool, httpProxy string, httpsProxy str
 	return buildFlags
 }
 
-func ensureHandlerPath(image string, handler string) error {
+func ensureHandlerPath(handler string) error {
 	if _, err := os.Stat(handler); err != nil {
-		fmt.Printf("Unable to build %s, %s is an invalid path\n", image, handler)
-		fmt.Printf("Image: %s not built.\n", image)
-
 		return err
 	}
 


### PR DESCRIPTION
## Description
Currently, when the handler path is not valid, build passes with the `function` directory coming from template, we need to validate the handler path so that the build will stop if the function path is not correct.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Should I raise an issue?
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
