### PR TITLE
[Review] Prefer user supplied parameter for remove and deploy

### DIFF
--- a/commands/faas.go
+++ b/commands/faas.go
@@ -16,6 +16,8 @@ const (
 	defaultGateway = "http://127.0.0.1:8080"
 	defaultNetwork = ""
 	defaultYAML    = "stack.yml"
+	argumentSource = "arguments"
+	yamlSource     = "yaml"
 )
 
 // Flags that are to be added to all commands.

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -226,6 +226,7 @@ func Test_duplicateFunctionName(t *testing.T) {
 	const functionLang = "ruby"
 
 	defer func() {
+		appendFile = ""
 		if _, err := os.Stat(functionName + ".yml"); err == nil {
 			err := os.Remove(functionName + ".yml")
 			if err != nil {

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -30,3 +30,12 @@ func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) stri
 
 	return gatewayURL
 }
+
+func getFunctionSource(functionName string) (string, error) {
+	if len(functionName) > 0 {
+		return argumentSource, nil
+	} else if len(yamlFile) > 0 {
+		return yamlSource, nil
+	}
+	return "", fmt.Errorf("no function name or YAML file specified")
+}

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -41,7 +41,19 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	var services stack.Services
 	var gatewayAddress string
 	var yamlGateway string
-	if len(yamlFile) > 0 {
+	var functionSource string
+	var err error
+
+	if len(args) > 0 {
+		functionSource, err = getFunctionSource(args[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		functionSource = yamlSource
+	}
+
+	if functionSource == yamlSource {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
 		if err != nil {
 			return err
@@ -66,14 +78,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 			proxy.DeleteFunction(gatewayAddress, function.Name)
 		}
-	} else {
-		if len(args) < 1 {
-			return fmt.Errorf("please provide the name of a function to delete")
-		}
-
+	} else if functionSource == argumentSource {
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
 		proxy.DeleteFunction(gatewayAddress, functionName)
+	} else {
+		return fmt.Errorf("please provide the name of a function to delete")
 	}
 
 	return nil


### PR DESCRIPTION
Prefer user supplied parameter for remove and deploy

Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change is to prefer the user-supplied function name when performing the `faas-cli deploy` and `faas-cli remove` operations. Currently, if a `stack.yml` file is present in your working directory (which is designated by `faas-cli` as the default filename for a function stack), and you specify a function name (e.g. `faas-cli remove myFunc`), the contents of the `stack.yml` file will be operated on. This is unpredictable behavior and may be confusing to some users.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas-cli/issues/280

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests were created for `deploy` and `remove` to ensure proper functionality. Tests were created prior to making the changes to the business logic.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
