### PR TITLE
Fix warnings from csharp template build

### DIFF
--- a/template/csharp/Dockerfile
+++ b/template/csharp/Dockerfile
@@ -4,10 +4,6 @@ ENV DOTNET_CLI_TELEMETRY_OPTOUT 1
 
 # Optimize for Docker builder caching by adding projects first.
 
-RUN mkdir -p /root/src/function
-WORKDIR /root/src/function
-COPY ./function/Function.csproj  .
-
 WORKDIR /root/src/
 COPY ./root.csproj  .
 RUN dotnet restore ./root.csproj

--- a/template/csharp/root.csproj
+++ b/template/csharp/root.csproj
@@ -1,9 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
-  <ItemGroup>
-    <ProjectReference Include="function\Function.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>


### PR DESCRIPTION
Resolves #305

Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the `FunctionHandler.csproj` from the `root.csproj` and removed the `COPY` of the function folder from the Dockerfile as there is a `COPY . .` that will include that folder already.

There is no need for the `FunctionHandler.csproj` file. It _could_ really be removed, but leaving it there for now as someone may want to compile the library that is only the Function without the code in the root.

Also, with the `FunctionHandler.csproj` removed, when running `dotnet run` in the generated template folder (in the example below it would be `./tester`) the error output shows `Couldn't find project to run`, where with it included, the error message reads `Unable to run your project ... The current OutputType is 'Library'` - much more understandable in my opinion

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
There is a warning that is output from `faas build` when building a function from the csharp template

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run `faas new tester --lang csharp`
Run `faas build -f tester.yml`
Verify the output no longer contains the warning message
Verify that the deployed function still functions as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
