### PR TITLE
Provide better error message when templates are missing in faas-cli deploy of non-Dockerfile language

### DIFF
--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_build(t *testing.T) {
+	defer tearDownFetchTemplates(t)
 
 	aTests := [][]string{
 		{"build"},

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -186,6 +186,7 @@ func RunDeploy(
 				var fprocessErr error
 				function.FProcess, fprocessErr = deriveFprocess(function)
 				if fprocessErr != nil {
+					fmt.Printf("Language not found: %s\n", function.Language)
 					return fprocessErr
 				}
 			}

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -98,3 +98,21 @@ func Test_deploy(t *testing.T) {
 		t.Fatalf("Output is not as expected:\n%s", stdOut)
 	}
 }
+
+func Test_deploy_withYAML_withoutTemplates(t *testing.T) {
+	yamlFile = "./testdata/stack-files/stack1.yml"
+	defer func() {
+		yamlFile = ""
+	}()
+
+	stdOut := test.CaptureStdout(func() {
+		faasCmd.SetArgs([]string{
+			"deploy",
+		})
+		faasCmd.Execute()
+	})
+
+	if found, err := regexp.MatchString(`(?m:Language not found: )`, stdOut); err != nil || !found {
+		t.Fatalf("Output is not as expected:\n%s", stdOut)
+	}
+}

--- a/commands/testdata/stack-files/stack1.yml
+++ b/commands/testdata/stack-files/stack1.yml
@@ -1,0 +1,15 @@
+provider:
+  name: faas
+  gateway: http://localhost:8080  # can be a remote server
+  network: "func_functions"       # this is optional and defaults to func_functions
+
+functions:
+  url-ping:
+    lang: python
+    handler: ../../../sample/url-ping
+    image: alexellis/faas-url-ping
+    limits:
+      memory: 10m
+    requests:
+      memory: 10m
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An question was asked in the Slack channel about the confusing error message that you get when you try to deploy a function that uses a non-Dockerfile language and you don't have the `template/` folder in your present working directory. This change seeks to provide a better error message.

Before this change:

```
$ faas-cli deploy
Deploying: telegram-gif-bot.
Stat ./template/node/template.yml: no such file or directory
```

After this change:

```
$ faas-cli deploy
Deploying: telegram-gif-bot.
Deployment error: Couldn't get fprocess for function telegram-gif-bot. Make sure the language template for node is present in the ./template/ directory.
Stat ./template/node/template.yml: no such file or directory
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas-cli/issues/307

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A test is added to `commands/deploy_test.go` to exercise this code path.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
