### PR TITLE
fix uppercase bug for Dockerfile template

### DIFF
--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -107,6 +107,9 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("got unexpected error while updating .gitignore file: %s", err)
 	}
 
+	if lang == "Dockerfile" {
+		lang = "dockerfile"
+	}
 	builder.CopyFiles(filepath.Join("template", lang, "function"), functionName)
 
 	var stackYaml string

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -48,8 +48,14 @@ var NewFunctionTests = []NewFunctionTest{
 		expectedMsg: SuccessMsg,
 	},
 	{
-		title:       "new_2",
-		funcName:    "new-test-2",
+		title:       "lowercase-dockerfile",
+		funcName:    "lowercase-dockerfile",
+		funcLang:    "dockerfile",
+		expectedMsg: SuccessMsg,
+	},
+	{
+		title:       "uppercase-dockerfile",
+		funcName:    "uppercase-dockerfile",
 		funcLang:    "dockerfile",
 		expectedMsg: SuccessMsg,
 	},
@@ -82,13 +88,20 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 
 	faasCmd.SetArgs(cmdParameters)
 	fmt.Println("Executing command")
-	stdOut := faasCmd.Execute()
+	execErr := faasCmd.Execute()
 
 	if nft.expectedMsg == SuccessMsg {
 
 		// Make sure that the folder and file was created:
 		if _, err := os.Stat("./" + funcName); os.IsNotExist(err) {
 			t.Fatalf("%s/ directory was not created", funcName)
+		}
+
+		// Check that the Dockerfile was created
+		if funcLang == "Dockerfile" || funcLang == "dockerfile" {
+			if _, err := os.Stat("./" + funcName + "/Dockerfile"); os.IsNotExist(err) {
+				t.Fatalf("Dockerfile language should create a Dockerfile for you", funcName)
+			}
 		}
 
 		if _, err := os.Stat(funcYAML); os.IsNotExist(err) {
@@ -115,8 +128,8 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 		}
 	} else {
 		// Validate new function output
-		if found, err := regexp.MatchString(nft.expectedMsg, stdOut.Error()); err != nil || !found {
-			t.Fatalf("Output is not as expected: %s\n", stdOut)
+		if found, err := regexp.MatchString(nft.expectedMsg, execErr.Error()); err != nil || !found {
+			t.Fatalf("Output is not as expected: %s\n", execErr)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a change to address the `Dockerfile` issue pointed out by issue #317 

This is a minimal fix which adds error handling around the `builder.CopyFiles()` call in `commands/new_function.go`. This PR was written with TDD as the tests were written first, then the minimal change was applied to get the tests to turn green.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#317 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests in `new_function_test.go` are expanded to cover lowercase as well as uppercase usage of `Dockerfile`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
