### PR TITLE
Check for username, ip, or registry on faas push

### DIFF
--- a/commands/push.go
+++ b/commands/push.go
@@ -111,11 +111,8 @@ func pushStack(services *stack.Services, queueDepth int) {
 func validateImages(services *stack.Services) string {
 	errMsg := make([]string, 0)
 	for name, function := range services.Functions {
-		if function.SkipBuild {
-			continue
-		}
 
-		if !strings.Contains(function.Image, `/`) {
+		if !function.SkipBuild && !strings.Contains(function.Image, `/`) {
 			errMsg = append(errMsg, fmt.Sprintf(" - %s", name))
 		}
 	}

--- a/commands/push.go
+++ b/commands/push.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 	"sync"
 
@@ -55,7 +54,11 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if len(services.Functions) > 0 {
 		invalidImages := validateImages(&services)
 		if len(invalidImages) > 0 {
-			return fmt.Errorf("Unable to push one or more of your functions to Docker Hub\n" + invalidImages + "\n\nYou must provide a username or registry prefix to the Function's image such as user1/function1.\nIf you need a Docker Hub account, you can sign up here: https://hub.docker.com")
+			return fmt.Errorf(`
+Unable to push one or more of your functions to Docker Hub
+` + invalidImages + `
+
+You must provide a username or registry prefix to the Function's image such as user1/function1`)
 		}
 
 		pushStack(&services, parallel)
@@ -111,11 +114,8 @@ func validateImages(services *stack.Services) string {
 		if function.SkipBuild {
 			continue
 		}
-		ip := "(\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\b)(:\\d+)?"
-		re := regexp.MustCompile("([a-z].+)\\/|" + ip + "\\/")
-		ma := re.FindAllString(function.Image, 1)
 
-		if len(ma) < 1 {
+		if !strings.Contains(function.Image, `/`) {
 			errMsg = append(errMsg, fmt.Sprintf(" - %s", name))
 		}
 	}

--- a/commands/push.go
+++ b/commands/push.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"regexp"
 	"sync"
 
 	"github.com/morikuni/aec"
@@ -74,10 +75,12 @@ func pushStack(services *stack.Services, queueDepth int) {
 				fmt.Printf(aec.YellowF.Apply("[%d] > Pushing %s.\n"), index, function.Name)
 				if len(function.Image) == 0 {
 					fmt.Println("Please provide a valid Image value in the YAML file.")
+				} else if !validImageString(function.Image) {
+					fmt.Printf("Unable to push %s. You must provide a username or registry prefix such as user1/function.\nIf you need a Docker Hub account, you can sign up here: https://hub.docker.com\n", function.Name)
 				} else {
 					pushImage(function.Image)
+					fmt.Printf(aec.YellowF.Apply("[%d] < Pushing %s done.\n"), index, function.Name)
 				}
-				fmt.Printf(aec.YellowF.Apply("[%d] < Pushing %s done.\n"), index, function.Name)
 			}
 
 			fmt.Printf(aec.YellowF.Apply("[%d] worker done.\n"), index)
@@ -94,4 +97,11 @@ func pushStack(services *stack.Services, queueDepth int) {
 
 	wg.Wait()
 
+}
+
+func validImageString(image string) bool {
+	ip := "(\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\b)(:\\d+)?"
+	re := regexp.MustCompile("([a-z].+)\\/|" + ip + "\\/")
+	ma := re.FindAllString(image, 1)
+	return len(ma) >= 1
 }


### PR DESCRIPTION
Signed-off-by: Burton Rheutan <rheutan7@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Added a check before calling `docker push` to ensure that the `image` field in the `.yml` file contains a repository by looking for `/`.

## Description
<!--- Describe your changes in detail -->
Added new function to `push.go` to validate that the image contains a repository by looking for `/` in the image string

Added output message with list of failed function names with message to indicate the failure (and an example of the correct usage)

I also moved the `"Pushing function1 done"` message into the else block that calls the `docker push` command. I thought it confusing to have that message show when the `push` never actually happened...

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #329 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built the CLI locally and ran `./faas-cli push -f test.yml` with 3 functions defined. One with a repository `burtonr/movies:0.2`, one with `skip_build: true`, and one without a repository `ecs-cli:latest`. Verified that the push was blocked (in both synchronous and `--parallel`). Updated the `.yml` file to ensure both functions without `skip_build` had the repository in the image. Ran `./faas-cli push -f test.yml` again, and ensured that the push happened. See example `.yml` below. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

I did not add any tests as I'm not very familiar with go tests and there were no existing tests for the `push.go` file. I don't feel as I have the skills needed to add a new test file and avoid running the `docker push` command for the test.

Here is a sample .yml file I used while testing:
```yaml
provider:
  name: faas
  gateway: http://localhost:8080

functions:
  movies:
    lang: node
    handler: ./movies
    image: burtonr/movies:0.1

  stronghash:
    skip_build: true
    image: alpine:latest
    fprocess: "sha512sum"

  ecs-cli:
    lang: Dockerfile
    handler: ./ecs-cli
    image: ecs-cli:latest
```

and the output (notice the "stronghash" function has `skip_build: true` and `ecs-cli` has no repository)
```bash
[0] % ./faas-cli push -f image-test.yml --parallel 3

Unable to push one or more of your functions to Docker Hub
 - ecs-cli

You must provide a username or registry prefix to the Function's image such as user1/function1
```