### PR TITLE
[Ready to merge] implement --header -H flag for faas-cli invoke

### DIFF
--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -16,6 +16,7 @@ import (
 var (
 	contentType string
 	query       []string
+	headers     []string
 )
 
 func init() {
@@ -25,17 +26,20 @@ func init() {
 
 	invokeCmd.Flags().StringVar(&contentType, "content-type", "text/plain", "The content-type HTTP header such as application/json")
 	invokeCmd.Flags().StringArrayVar(&query, "query", []string{}, "pass query-string options")
+	invokeCmd.Flags().StringArrayVarP(&headers, "header", "H", []string{}, "pass HTTP request header")
 
 	faasCmd.AddCommand(invokeCmd)
 }
 
 var invokeCmd = &cobra.Command{
-	Use:   `invoke FUNCTION_NAME [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE] [--query PARAM=VALUE]`,
+	Use:   `invoke FUNCTION_NAME [--gateway GATEWAY_URL] [--content-type CONTENT_TYPE] [--query PARAM=VALUE] [--header PARAM=VALUE]`,
 	Short: "Invoke an OpenFaaS function",
 	Long:  `Invokes an OpenFaaS function and reads from STDIN for the body of the request`,
 	Example: `  faas-cli invoke echo --gateway https://domain:port
   faas-cli invoke echo --gateway https://domain:port --content-type application/json
-  faas-cli invoke env --query repo=faas-cli --query org=openfaas`,
+  faas-cli invoke env --query repo=faas-cli --query org=openfaas
+  faas-cli invoke env --header X-Ping-Url=http://request.bin/etc
+  faas-cli invoke env -H X-Ping-Url=http://request.bin/etc`,
 	RunE: runInvoke,
 }
 
@@ -72,7 +76,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to read standard input: %s", err.Error())
 	}
 
-	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType, query)
+	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType, query, headers)
 	if err != nil {
 		return err
 	}

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -25,6 +25,7 @@ func Test_InvokeFunction(t *testing.T) {
 		&bytesIn,
 		"text/plain",
 		[]string{},
+		[]string{},
 	)
 
 	if err != nil {
@@ -42,6 +43,7 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 		"function",
 		&bytesIn,
 		"text/plain",
+		[]string{},
 		[]string{},
 	)
 
@@ -63,6 +65,7 @@ func Test_InvokeFunction_MissingURLPrefix(t *testing.T) {
 		"function",
 		&bytesIn,
 		"text/plain",
+		[]string{},
 		[]string{},
 	)
 


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

Fixes https://github.com/openfaas/faas-cli/issues/333

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It is required to add --header or -H flag to pass headers as key=value for invoke command.
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
