### PR TITLE
OPENFAAS_URL env-var for gateway and IPv4 defaults

### DIFF
--- a/MANUAL_CLI.md
+++ b/MANUAL_CLI.md
@@ -51,7 +51,7 @@ $ faas-cli deploy \
 
 200 OK
 
-URL: http://localhost:8080/function/node_info
+URL: http://127.0.0.1:8080/function/node_info
 ```
 
 > This tool can be used to deploy any Docker image as a FaaS function, as long as it includes the watchdog binary as the `CMD` or `ENTRYPOINT` of the image.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ The main commands supported by the CLI are:
 * `faas-cli logout` - removes basic auth credentials for a given gateway
 * `faas-cli store` - allows browsing and deploying OpenFaaS store functions
 
+The default gateway URL of `127.0.0.1:8080` can be overriden in three places including an environmental variable.
+
+* 1st priority `--gateway` flag
+* 2nd priority `--yaml` / `-f` flag or `stack.yml` if in current directory
+* 3rd priority `OPENFAAS_URL` environmental variable
+
+For Kubernetes users you may want to set this in your `.bash_rc` file:
+
+```
+export OPENFAAS_URL=127.0.0.1:31112
+```
+
 Advanced commands:
 
 * `faas-cli template pull` - pull in templates from a remote GitHub repository [Detailed Documentation](guide/TEMPLATE.md)
@@ -141,6 +153,9 @@ Specify `lang: Dockerfile` if you want the faas-cli to execute a build or `skip_
 * If you are using a stack file add the `skip_build: true` attribute
 * Use one of the [samples as a basis](https://github.com/openfaas/faas/tree/master/sample-functions)
 
+Read the blog post/tutorial: [Turn Any CLI into a Function with OpenFaaS](https://blog.alexellis.io/cli-functions-with-openfaas/)
+
+
 ### Use a YAML stack file
 
 A YAML stack file groups functions together and also saves on typing.
@@ -152,7 +167,7 @@ Here is an example file using the `stack.yml` file included in the repository.
 ```yaml
 provider:
   name: faas
-  gateway: http://localhost:8080
+  gateway: http://127.0.0.1:8080
 
 functions:
   url-ping:
@@ -187,9 +202,21 @@ Now you can use the following command to deploy your function(s):
 $ faas-cli deploy -f ./stack.yml
 ```
 
-#### Managing secrets
+#### Secure secret management
 
-You can deploy secrets and configuration via environmental variables in-line or via external files.
+Secrets can be used with OpenFaaS when using Docker Swarm or Kubernetes, this means your data is encrypted at rest and is less likely to be leaked during logging / stack traces than with environmental variables.
+
+```yaml
+  secrets:
+    - secret-name-1
+    - secret-name-2
+```
+
+Secrets should be defined in the cluster ahead of time using `docker secret create` or `kubectl`.
+
+#### Managing environment/configuration
+
+You can deploy non-encrypted secrets and configuration via environmental variables set either in-line or via external (environment) files.
 
 > Note: external files take priority over in-line environmental variables. This allows you to specify a default and then have overrides within an external file.
 
@@ -289,12 +316,12 @@ You can initiate a HTTP POST via `curl`:
 * if you want to pass input from STDIN then use `--data-binary @-`
 
 ```
-$ curl -d '{"hello": "world"}' http://localhost:8080/function/nodejs-echo
+$ curl -d '{"hello": "world"}' http://127.0.0.1:8080/function/nodejs-echo
 { nodeVersion: 'v6.9.1', input: '{"hello": "world"}' }
 
-$ curl --data-binary @README.md http://localhost:8080/function/nodejs-echo
+$ curl --data-binary @README.md http://127.0.0.1:8080/function/nodejs-echo
 
-$ uname -a | curl http://localhost:8080/function/nodejs-echo--data-binary @-
+$ uname -a | curl http://127.0.0.1:8080/function/nodejs-echo--data-binary @-
 ```
 
 > For further instructions on the manual CLI flags (without using a YAML file) read [manual_cli.md](https://github.com/openfaas/faas-cli/blob/master/MANUAL_CLI.md)

--- a/commands/config_priority_test.go
+++ b/commands/config_priority_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"testing"
+)
+
+// Test_getGatewayURL tests for priority of URL for gateway over several sources
+func Test_getGatewayURL(t *testing.T) {
+	defaultValue := "http://127.0.0.1:8080"
+	testCases := []struct {
+		name       string
+		defaultURL string
+
+		yamlURL        string
+		argumentURL    string
+		environmentURL string
+		expectedURL    string
+	}{
+		{
+			name:        "Nothing provided",
+			defaultURL:  defaultValue,
+			yamlURL:     "",
+			argumentURL: "",
+			expectedURL: "http://127.0.0.1:8080",
+		},
+		{
+			name:        "Only YAML provided",
+			defaultURL:  defaultValue,
+			yamlURL:     "http://remote1:8080",
+			argumentURL: "",
+			expectedURL: "http://remote1:8080",
+		},
+		{
+			name:        "Only argument override",
+			defaultURL:  defaultValue,
+			yamlURL:     "",
+			argumentURL: "http://remote2:8080",
+			expectedURL: "http://remote2:8080",
+		},
+		{
+			name:        "Prioritize argument over YAML when argument is not default",
+			defaultURL:  defaultValue,
+			yamlURL:     "http://remote-yml:8080",
+			argumentURL: "http://remote-arg:8080",
+			expectedURL: "http://remote-arg:8080",
+		},
+		{
+			name:        "When argument is default use YAML",
+			defaultURL:  defaultValue,
+			yamlURL:     "http://remote-yml:8080",
+			argumentURL: defaultValue,
+			expectedURL: "http://remote-yml:8080",
+		},
+		{
+			name:           "YAML provided (with defaults) and env-var override",
+			defaultURL:     defaultValue,
+			yamlURL:        defaultValue,
+			environmentURL: "http://remote2:8080",
+			argumentURL:    "",
+			expectedURL:    "http://remote2:8080",
+		},
+	}
+
+	fails := 0
+	for _, testCase := range testCases {
+		url := getGatewayURL(testCase.argumentURL, testCase.defaultURL, testCase.yamlURL, testCase.environmentURL)
+		if url != testCase.expectedURL {
+			t.Logf("gatewayURL %s\nwant: %s, got: %s", testCase.name, testCase.expectedURL, url)
+			fails++
+		}
+	}
+	if fails > 0 {
+		t.Fail()
+	}
+}

--- a/commands/config_priority_test.go
+++ b/commands/config_priority_test.go
@@ -62,6 +62,14 @@ func Test_getGatewayURL(t *testing.T) {
 			argumentURL:    "",
 			expectedURL:    "http://remote2:8080",
 		},
+		{
+			name:           "ARG provided with env-var override",
+			defaultURL:     defaultValue,
+			yamlURL:        defaultValue,
+			environmentURL: "http://remote2:8080",
+			argumentURL:    "http://remote1:8080",
+			expectedURL:    "http://remote1:8080",
+		},
 	}
 
 	fails := 0

--- a/commands/config_priorty.go
+++ b/commands/config_priorty.go
@@ -1,0 +1,30 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+)
+
+func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) string {
+	var gatewayURL string
+
+	if len(argumentURL) > 0 && argumentURL != defaultURL {
+		gatewayURL = argumentURL
+	} else if len(yamlURL) > 0 && yamlURL != defaultURL {
+		gatewayURL = yamlURL
+	} else if len(environmentURL) > 0 {
+		gatewayURL = environmentURL
+	} else {
+		gatewayURL = defaultURL
+	}
+
+	gatewayURL = strings.ToLower(strings.TrimRight(gatewayURL, "/"))
+	if !strings.HasPrefix(gatewayURL, "http") {
+		gatewayURL = fmt.Sprintf("http://%s", gatewayURL)
+	}
+
+	return gatewayURL
+}

--- a/commands/config_priorty.go
+++ b/commands/config_priorty.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+const openFaaSURLEnvironment = "OPENFAAS_URL"
+
 func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) string {
 	var gatewayURL string
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -119,7 +119,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 			return err
 		}
 
-		parsedServices.Provider.GatewayURL = getGatewayURL(gateway, defaultGateway, parsedServices.Provider.GatewayURL, os.Getenv("OPENFAAS_URL"))
+		parsedServices.Provider.GatewayURL = getGatewayURL(gateway, defaultGateway, parsedServices.Provider.GatewayURL, os.Getenv(openFaaSURLEnvironment))
 
 		// Override network if passed
 		if len(network) > 0 && network != defaultNetwork {

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -119,7 +119,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 			return err
 		}
 
-		parsedServices.Provider.GatewayURL = getGatewayURL(gateway, defaultGateway, parsedServices.Provider.GatewayURL)
+		parsedServices.Provider.GatewayURL = getGatewayURL(gateway, defaultGateway, parsedServices.Provider.GatewayURL, os.Getenv("OPENFAAS_URL"))
 
 		// Override network if passed
 		if len(network) > 0 && network != defaultNetwork {
@@ -301,25 +301,6 @@ func mergeMap(i map[string]string, j map[string]string) map[string]string {
 		merged[k] = v
 	}
 	return merged
-}
-
-func getGatewayURL(argumentURL string, defaultURL string, yamlURL string) string {
-	var gatewayURL string
-
-	if len(argumentURL) > 0 && argumentURL != defaultURL {
-		gatewayURL = argumentURL
-	} else if len(yamlURL) > 0 {
-		gatewayURL = yamlURL
-	} else {
-		gatewayURL = defaultURL
-	}
-
-	gatewayURL = strings.ToLower(strings.TrimRight(gatewayURL, "/"))
-	if !strings.HasPrefix(gatewayURL, "http") {
-		gatewayURL = fmt.Sprintf("http://%s", gatewayURL)
-	}
-
-	return gatewayURL
 }
 
 func compileEnvironment(envvarOpts []string, yamlEnvironment map[string]string, fileEnvironment map[string]string) (map[string]string, error) {

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -11,65 +11,6 @@ import (
 	"github.com/openfaas/faas-cli/test"
 )
 
-func Test_getGatewayURL(t *testing.T) {
-	defaultValue := "http://localhost:8080"
-	testCases := []struct {
-		name        string
-		defaultURL  string
-		yamlURL     string
-		argumentURL string
-		expectedURL string
-	}{
-		{
-			name:        "Nothing provided",
-			defaultURL:  defaultValue,
-			yamlURL:     "",
-			argumentURL: "",
-			expectedURL: "http://localhost:8080",
-		},
-		{
-			name:        "Only YAML provided",
-			defaultURL:  defaultValue,
-			yamlURL:     "http://remote1:8080",
-			argumentURL: "",
-			expectedURL: "http://remote1:8080",
-		},
-		{
-			name:        "Only argument override",
-			defaultURL:  defaultValue,
-			yamlURL:     "",
-			argumentURL: "http://remote2:8080",
-			expectedURL: "http://remote2:8080",
-		},
-		{
-			name:        "Prioritize argument over YAML when argument is not default",
-			defaultURL:  defaultValue,
-			yamlURL:     "http://remote-yml:8080",
-			argumentURL: "http://remote-arg:8080",
-			expectedURL: "http://remote-arg:8080",
-		},
-		{
-			name:        "When argument is default use YAML",
-			defaultURL:  defaultValue,
-			yamlURL:     "http://remote-yml:8080",
-			argumentURL: defaultValue,
-			expectedURL: "http://remote-yml:8080",
-		},
-	}
-
-	fails := 0
-	for _, testCase := range testCases {
-		url := getGatewayURL(testCase.argumentURL, testCase.defaultURL, testCase.yamlURL)
-		if url != testCase.expectedURL {
-			t.Logf("gatewayURL %s\nwant: %s, got: %s", testCase.name, testCase.expectedURL, url)
-			fails++
-		}
-	}
-	if fails > 0 {
-		t.Fail()
-	}
-}
-
 func Test_deploy(t *testing.T) {
 	s := test.MockHttpServer(t, []test.Request{
 		{

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultGateway = "http://localhost:8080"
+	defaultGateway = "http://127.0.0.1:8080"
 	defaultNetwork = "func_functions"
 	defaultYAML    = "stack.yml"
 )

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -70,7 +70,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv("OPENFAAS_URL"))
+	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) != 0 {

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -70,7 +70,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway)
+	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv("OPENFAAS_URL"))
 
 	stat, _ := os.Stdin.Stat()
 	if (stat.Mode() & os.ModeCharDevice) != 0 {

--- a/commands/list.go
+++ b/commands/list.go
@@ -51,7 +51,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv("OPENFAAS_URL"))
+	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
 	functions, err := proxy.ListFunctions(gatewayAddress)
 	if err != nil {

--- a/commands/list.go
+++ b/commands/list.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/stack"
@@ -30,7 +31,7 @@ var listCmd = &cobra.Command{
 	Short:   "List OpenFaaS functions",
 	Long:    `Lists OpenFaaS functions either on a local or remote gateway`,
 	Example: `  faas-cli list
-  faas-cli list --gateway https://localhost:8080 --verbose`,
+  faas-cli list --gateway https://127.0.0.1:8080 --verbose`,
 	RunE: runList,
 }
 
@@ -50,7 +51,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway)
+	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv("OPENFAAS_URL"))
 
 	functions, err := proxy.ListFunctions(gatewayAddress)
 	if err != nil {

--- a/commands/login.go
+++ b/commands/login.go
@@ -35,7 +35,7 @@ var loginCmd = &cobra.Command{
 	Use:   `login [--username USERNAME] [--password PASSWORD] [--gateway GATEWAY_URL]`,
 	Short: "Log in to OpenFaaS gateway",
 	Long:  "Log in to OpenFaaS gateway.\nIf no gateway is specified, the default local one will be used.",
-	Example: `  faas-cli login -u user -p password --gateway http://localhost:8080
+	Example: `  faas-cli login -u user -p password --gateway http://127.0.0.1:8080
   cat ~/faas_pass.txt | faas-cli login -u user --password-stdin --gateway https://openfaas.mydomain.com`,
 	RunE: runLogin,
 }
@@ -76,7 +76,9 @@ func runLogin(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Calling the OpenFaaS server to validate the credentials...")
-	gateway = getGatewayURL(gateway, "", "")
+
+	gateway = getGatewayURL(gateway, "", "", os.Getenv("OPENFAAS_URL"))
+
 	if err := validateLogin(gateway, username, password); err != nil {
 		return err
 	}

--- a/commands/login.go
+++ b/commands/login.go
@@ -77,7 +77,7 @@ func runLogin(cmd *cobra.Command, args []string) error {
 
 	fmt.Println("Calling the OpenFaaS server to validate the credentials...")
 
-	gateway = getGatewayURL(gateway, "", "", os.Getenv("OPENFAAS_URL"))
+	gateway = getGatewayURL(gateway, "", "", os.Getenv(openFaaSURLEnvironment))
 
 	if err := validateLogin(gateway, username, password); err != nil {
 		return err

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -53,7 +53,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv("OPENFAAS_URL"))
+	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
 	if len(services.Functions) > 0 {
 		if len(services.Provider.Network) == 0 {

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/stack"
@@ -52,7 +53,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway)
+	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv("OPENFAAS_URL"))
 
 	if len(services.Functions) > 0 {
 		if len(services.Provider.Network) == 0 {

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -43,7 +43,7 @@ var storeDeployCmd = &cobra.Command{
 	Long:  `Same as faas-cli deploy except that function is pre-loaded with arguments from the store`,
 	Example: `  faas-cli store deploy figlet
   faas-cli store deploy figlet \
-    --gateway=http://localhost:8080 \
+    --gateway=http://127.0.0.1:8080 \
     --env=MYVAR=myval`,
 	RunE: runStoreDeploy,
 }

--- a/commands/validate_test.go
+++ b/commands/validate_test.go
@@ -1,0 +1,21 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestValidateLanguageFlag_dockerfile(t *testing.T) {
+	_, err := validateLanguageFlag("dockerfile")
+	if err != nil {
+		t.Logf("Received unexpected error for lang: %s, %s", "dockerfile", err)
+		t.Fail()
+	}
+}
+
+func TestValidateLanguageFlag_Dockerfile(t *testing.T) {
+	_, err := validateLanguageFlag("Dockerfile")
+	if err == nil {
+		t.Logf("Should have received error for lang: %s, %s", "Dockerfile", err)
+		t.Fail()
+	}
+}

--- a/deploy_samples.sh
+++ b/deploy_samples.sh
@@ -8,13 +8,13 @@ sleep 5
 curl -SL https://raw.githubusercontent.com/openfaas/faas/master/sample-functions/ResizeImageMagick/gordon.png > gordon.png
 
 echo "Testing nodejs-echo"
-curl -sd "This was the input string." http://localhost:8080/function/nodejs-echo
+curl -sd "This was the input string." http://127.0.0.1:8080/function/nodejs-echo
 echo
 
 echo "Testing url-ping"
-curl -sd "https://shop.pimoroni.com" http://localhost:8080/function/url-ping
+curl -sd "https://shop.pimoroni.com" http://127.0.0.1:8080/function/url-ping
 echo
 
 echo "Testing shrink-image"
-curl -d "" http://localhost:8080/function/shrink-image --data-binary @gordon.png > small_gordon.png
+curl -d "" http://127.0.0.1:8080/function/shrink-image --data-binary @gordon.png > small_gordon.png
 echo

--- a/sample/hmac.yml
+++ b/sample/hmac.yml
@@ -1,6 +1,6 @@
 provider:
   name: faas
-  gateway: http://localhost:8080
+  gateway: http://127.0.0.1:8080
 
 functions:
   hmac:

--- a/stack.yml
+++ b/stack.yml
@@ -1,6 +1,6 @@
 provider:
   name: faas
-  gateway: http://localhost:8080  # can be a remote server
+  gateway: http://127.0.0.1:8080  # can be a remote server
   network: "func_functions"       # this is optional and defaults to func_functions
 
 functions:
@@ -31,7 +31,7 @@ functions:
     requests:
       memory: 30m
 
-  # curl localhost:8080/function/shrink-image --data-binary @big.png > smaller.png
+  # curl 127.0.0.1:8080/function/shrink-image --data-binary @big.png > smaller.png
   shrink-image:
     lang: dockerfile
     handler: ./sample/imagemagick

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -12,7 +12,7 @@ import (
 
 const TestData_1 string = `provider:
   name: faas
-  gateway: http://localhost:8080
+  gateway: http://127.0.0.1:8080
   network: "func_functions"
 
 functions:
@@ -45,7 +45,7 @@ functions:
 
 const TestData_2 string = `provider:
   name: faas
-  gateway: http://localhost:8080
+  gateway: http://127.0.0.1:8080
   network: "func_functions"
 
 `


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

* Adds `OPENFAAS_URL` env-var for gateway
* Moves to `127.0.0.1` over `localhost` to enforce IPv4 default and avoid clashes with systems that use IPv6 and hang when accessing `localhost` from Go

Signed-off-by: Alex Ellis (VMware) alexellis2@gmail.com <alexellis2@gmail.com>

This change fixes #345 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Tested with override at env-var level
* Tested with YAML override
* Unit tests added

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
