### PR TITLE
Add OPENFAAS_URL to store_deploy

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -84,10 +85,7 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		network = item.Network
 	}
 
-	return deployImage(
-		item.Image,
-		item.Fprocess,
-		item.Name,
-		storeDeployFlags,
-	)
+	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
+
+	return deployImage(item.Image, item.Fprocess, item.Name, storeDeployFlags)
 }


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
This change adds a call to getGatewayURL immediately prior to heading into deploy image.

## Motivation and Context
- [x] I have raised an issue to propose this change - fixes #359
The recently added feature to draw the gateway from an ENV var to save users having to repeatedly use -g was missed from the store's deploy feature.  This meant that even if the ENV var was set the CLI would still try to use the default.

## How Has This Been Tested?
- Existing unit tests pass.
- Post-Build testing:

Use local binary:
```
$ chmod +x faas-cli-darwin
```
No argument passed & OPENFAAS_URL not set.  Expect to use defaultGateway:
```
$ ./faas-cli-darwin store deploy figlet
Function figlet already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet
```
Invalid argument passed & OPENFAAS_URL not set.  Expect to use argument & fail to deploy:
```
$ ./faas-cli-darwin store deploy figlet -g http://123.123.123.123:8080

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://123.123.123.123:8080/system/functions: net/http: request canceled while waiting for connection
 (Client.Timeout exceeded while awaiting headers)
```
Valid argument passed & OPENFAAS_URL not set.  Expect to use argument & deploy successfully:
```
$ ./faas-cli-darwin store deploy figlet -g http://127.0.0.1:8080
Function figlet already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet
```
Set OPENFAAS_URL:
```
$ export OPENFAAS_URL=http://invalidurl:8080
```
No argument passed & OPENFAAS_URL set.  Expect to use OPENFAAS_URL & fail to deploy:
```
$ ./faas-cli-darwin store deploy figlet

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://invalidurl:8080/system/functions: net/http: request canceled while waiting for connection (Cli
ent.Timeout exceeded while awaiting headers)
```
Argument passed is same as defaultGateway & OPENFAAS_URL set.  Expect to use OPENFAAS_URL & fail to deploy:
```
$ ./faas-cli-darwin store deploy figlet -g http://127.0.0.1:8080

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://invalidurl:8080/system/functions: net/http: request canceled while waiting for connection (Cli
ent.Timeout exceeded while awaiting headers)
```
Argument passed is not the same as defaultGateway & OPENFAAS_URL set.  Expect to use argument & fail to deploy:
```
$ ./faas-cli-darwin store deploy figlet -g http://123.123.123.1:8080

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://123.123.123.1:8080/system/functions: net/http: request canceled while waiting for connection (
Client.Timeout exceeded while awaiting headers)
```
Confirm OPENFAAS_URL is still set:
```
$ echo $OPENFAAS_URL
http://invalidurl:8080
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
