### PR TITLE
Set defaultNetwork to empty value

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -122,7 +122,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 		parsedServices.Provider.GatewayURL = getGatewayURL(gateway, defaultGateway, parsedServices.Provider.GatewayURL, os.Getenv(openFaaSURLEnvironment))
 
 		// Override network if passed
-		if len(network) > 0 && network != defaultNetwork {
+		if len(network) > 0 {
 			parsedServices.Provider.Network = network
 		}
 
@@ -132,6 +132,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 	}
 
 	if len(services.Functions) > 0 {
+
 		if len(services.Provider.Network) == 0 {
 			services.Provider.Network = defaultNetwork
 		}

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	defaultGateway = "http://127.0.0.1:8080"
-	defaultNetwork = "func_functions"
+	defaultNetwork = ""
 	defaultYAML    = "stack.yml"
 )
 


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
A recent change to faas-swarm means that if a network value isn't provided then the provider will try to ascertain the target network by looking for a label of openfaas=true within the network meta data.

This change will set the CLI defaultNetwork value to blank so that users who have not used the default network name will still attain desirable results when using the store & will no longer have to provide a network over-ride from the CLI.

**This is a breaking change and requires 0.7.3 or greater of the gateway.**

## Motivation and Context

- [x] I have raised an issue to propose this change - fixes #352

With the changes in openfaas/faas-swarm@e36f90b a default network is no longer required. Instead the network to be used will default to the swarm network labelled with openfaas during deployment.

## How Has This Been Tested?

Started with a clean server
Edited faas/docker-compose.yml to change the name of the network to openfaas
Ran faas/deploy_stack.sh
Confirmed that `func_openfaas` exists using `docker network ls`
Created a new function using the CLI
Built the function using the CLI
Deployed the function without specifying a network
Ran `docker service ls` to confirm the service deployed
Ran `docker service inspect` to confirm the function was on the `func_openfaas` network.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
