### PR TITLE
Add build-arg flag to build command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **/node_modules/
-build/
+build
 !contrib/bash/faas-cli
 faas-cli
 faas-cli-darwin
@@ -20,5 +20,3 @@ obj
 .idea
 .DS_Store
 
-template
-build

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ obj
 
 .idea
 .DS_Store
+
+template
+build

--- a/builder/build.go
+++ b/builder/build.go
@@ -13,7 +13,7 @@ import (
 )
 
 // BuildImage construct Docker image from function parameters
-func BuildImage(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool) {
+func BuildImage(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string) {
 
 	if stack.IsValidTemplate(language) {
 
@@ -53,7 +53,7 @@ func BuildImage(image string, handler string, functionName string, language stri
 			}
 		}
 
-		flagStr := buildFlagString(nocache, squash, os.Getenv("http_proxy"), os.Getenv("https_proxy"))
+		flagStr := buildFlagString(nocache, squash, os.Getenv("http_proxy"), os.Getenv("https_proxy"), buildArgMap)
 		builder := strings.Split(fmt.Sprintf("docker build %s-t %s .", flagStr, image), " ")
 		ExecCommand(tempPath, builder)
 		fmt.Printf("Image: %s built.\n", image)
@@ -93,7 +93,7 @@ func createBuildTemplate(functionName string, handler string, language string) s
 	return tempPath
 }
 
-func buildFlagString(nocache bool, squash bool, httpProxy string, httpsProxy string) string {
+func buildFlagString(nocache bool, squash bool, httpProxy string, httpsProxy string, buildArgMap map[string]string) string {
 
 	buildFlags := ""
 
@@ -110,6 +110,10 @@ func buildFlagString(nocache bool, squash bool, httpProxy string, httpsProxy str
 
 	if len(httpsProxy) > 0 {
 		buildFlags += fmt.Sprintf("--build-arg https_proxy=%s ", httpsProxy)
+	}
+
+	for k, v := range buildArgMap {
+		buildFlags += fmt.Sprintf("--build-arg %s=%s ", k, v)
 	}
 
 	return buildFlags

--- a/commands/build.go
+++ b/commands/build.go
@@ -79,26 +79,40 @@ via flags.`,
 func preRunBuild(cmd *cobra.Command, args []string) error {
 	language, _ = validateLanguageFlag(language)
 
-	buildArgMap = make(map[string]string)
+	mapped, err := parseBuildArgs(buildArgs)
 
-	for _, kvp := range buildArgs {
-		values := strings.Split(kvp, "=")
-		if len(values) != 2 {
-			return fmt.Errorf("each build-arg must take the form key=value")
-		}
-		k := strings.TrimSpace(values[0])
-		v := strings.TrimSpace(values[1])
-		if len(k) == 0 {
-			return fmt.Errorf("build-arg must have a non-empty key")
-		}
-		if len(v) == 0 {
-			return fmt.Errorf("build-arg must have a non-empty value")
-		}
-
-		buildArgMap[k] = v
+	if err == nil {
+		buildArgMap = mapped
 	}
 
-	return nil
+	return err
+}
+
+func parseBuildArgs(args []string) (map[string]string, error) {
+	mapped := make(map[string]string)
+
+	for _, kvp := range args {
+		index := strings.Index(kvp, "=")
+		if index == -1 {
+			return nil, fmt.Errorf("each build-arg must take the form key=value")
+		}
+
+		values := []string{kvp[0:index], kvp[index+1:]}
+
+		k := strings.TrimSpace(values[0])
+		v := strings.TrimSpace(values[1])
+
+		if len(k) == 0 {
+			return nil, fmt.Errorf("build-arg must have a non-empty key")
+		}
+		if len(v) == 0 {
+			return nil, fmt.Errorf("build-arg must have a non-empty value")
+		}
+
+		mapped[k] = v
+	}
+
+	return mapped, nil
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -23,3 +23,54 @@ func Test_build(t *testing.T) {
 		}
 	}
 }
+
+func Test_parseBuildArgs_ValidParts(t *testing.T) {
+	mapped, err := parseBuildArgs([]string{"k=v"})
+
+	if err != nil {
+		t.Errorf("err was supposed to be nil but was: %s", err.Error())
+		t.Fail()
+	}
+
+	if mapped["k"] != "v" {
+		t.Errorf("value for 'k', want: %s got: %s", "v", mapped["k"])
+		t.Fail()
+	}
+}
+
+func Test_parseBuildArgs_NoSeparator(t *testing.T) {
+	_, err := parseBuildArgs([]string{"kv"})
+
+	want := "each build-arg must take the form key=value"
+	if err != nil && err.Error() != want {
+		t.Errorf("Expected an error due to missing seperator")
+		t.Fail()
+	}
+}
+
+func Test_parseBuildArgs_EmptyKey(t *testing.T) {
+	_, err := parseBuildArgs([]string{"=v"})
+
+	want := "build-arg must have a non-empty key"
+	if err == nil {
+		t.Errorf("Expected an error due to missing key")
+		t.Fail()
+	} else if err.Error() != want {
+		t.Errorf("missing key error want: %s, got: %s", want, err.Error())
+		t.Fail()
+	}
+}
+
+func Test_parseBuildArgs_MultipleSeparators(t *testing.T) {
+	mapped, err := parseBuildArgs([]string{"k=v=z"})
+
+	if err != nil {
+		t.Errorf("Expected second separator to be included in value")
+		t.Fail()
+	}
+
+	if mapped["k"] != "v=z" {
+		t.Errorf("value for 'k', want: %s got: %s", "v=z", mapped["k"])
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Enables build-flag to be passed through to the Docker CLI for
use with secrets or build-time configuration.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #363 and referenced issues.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with plain Dockerfile template and adding an argument in
to be written to a file during a read-stage. That successfully
was captured in a file and read back at run-time showing the
change works. I also added validation for empty k/v or a lack of
separator (=).

Also tested with scenario quoted in issue. Existing tests pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
