### PR TITLE
Add faas-cli version information into Your Environment section

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,8 +9,8 @@
 <!--- If suggesting a change/improvement, explain the difference from current behavior -->
 
 ## Possible Solution
-<!--- Not obligatory, but suggest a fix/reason for the bug, -->
-<!--- or ideas how to implement the addition or change -->
+<!--- Not obligatory, but suggest a fix/reason for the bug with details on how you -->
+<!--- arrived at your diagnosis, or ideas how to implement the addition or change -->
 
 ## Steps to Reproduce (for bugs)
 <!--- Provide a link to a live example, or an unambiguous set of steps to -->
@@ -26,9 +26,11 @@
 
 ## Your Environment
 <!--- Include as many relevant details about the environment you experienced the bug in -->
-* Docker version `docker version` (e.g. Docker 17.0.05 ):
+* FaaS-CLI version ( Full output from: `faas-cli version` ):
 
-* Are you using Docker Swarm or Kubernetes (FaaS-netes)?
+* Docker version ( Full output from: `docker version` ):
+
+* Are you using Docker Swarm (FaaS-swarm ) or Kubernetes (FaaS-netes)?
 
 * Operating System and version (e.g. Linux, Windows, MacOS):
 


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Changes to the issue template to request output from `faas-cli version`

## Motivation and Context
Its a need to know detail.  Asking up-front saves a feedback cycle.

## How Has This Been Tested?
Its an issue template change

## Types of changes

- [x] Issue Template

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
