### PR TITLE
Added --build-arg documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ functions:
 
 Use environmental variables for setting tokens and configuration.
 
+#### Custom build arguments with Docker
+
+If you want to pass a build-time argument to Docker you can do so with `faas-cli build --build-arg name=value`.
+
 #### Access functions with `curl`
 
 You can initiate a HTTP POST via `curl`:

--- a/README.md
+++ b/README.md
@@ -312,6 +312,8 @@ Use environmental variables for setting tokens and configuration.
 
 If you want to pass a build-time argument to Docker you can do so with `faas-cli build --build-arg name=value`.
 
+Read more on the Docker docs: https://docs.docker.com/engine/reference/commandline/build/
+
 #### Access functions with `curl`
 
 You can initiate a HTTP POST via `curl`:


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

--build-arg can now be used with faas-cli build
to pass a secret to the Docker build.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Needed to cover new feature merged in PR: #364 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Documentation - already tested in PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.