### PR TITLE
Exit+throw error on version not found in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -1,4 +1,14 @@
 version=$(curl -s https://api.github.com/repos/openfaas/faas-cli/releases/latest | grep 'tag_name' | cut -d\" -f4)
+if [[ ! $version ]]; then
+    echo "Failed while attempting to install faas-cli. Please manually install:"
+    echo ""
+    echo "1. Open your web browser and go to https://github.com/openfaas/faas-cli/releases"
+    echo "2. Download the latest release for your platform. Call it 'faas-cli'."
+    echo "3. chmod +x ./faas-cli"
+    echo "4. mv ./faas-cli /usr/local/bin"
+    echo "5. ln -sf /usr/local/bin/faas-cli /usr/local/bin/faas"
+    exit 1
+fi
 
 hasCli() {
  


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The quick-install script should throw an error if it doesn't successfully get the latest version of `faas-cli` available. This can be caused by Github API's [rate limiter](https://developer.github.com/v3/#rate-limiting).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas-cli/issues/377

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Checked that the `if` statement works correctly when the `$version` variable is null.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
