### PR TITLE
Fix yaml case sensitivity around Dockerfile templates

### DIFF
--- a/stack/language_template.go
+++ b/stack/language_template.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"strings"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -49,6 +50,8 @@ func ParseYAMLDataForLanguageTemplate(fileData []byte) (*LanguageTemplate, error
 
 func IsValidTemplate(lang string) bool {
 	var found bool
+
+	lang = strings.ToLower(lang)
 
 	if _, err := os.Stat("./template/" + lang); err == nil {
 		templateYAMLPath := "./template/" + lang + "/template.yml"


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Added a lowercase conversion within `IsValidTemplate()` so that `BuildImage()` can still enter into the top section of `if stack.IsValidTemplate(language)` when an uppercase Dockerfile is used in the yaml definition.

## Motivation and Context
Previously changes were made to accommodate `Dockerfile` and `dockerfile` as languages.  One case overlooked was where `Dockerfile` is specified in the yaml definition.  This may occur where a user has a pre-existing yam file.
- [x] I have raised an issue to propose this change [On the FaaS repo](https://github.com/openfaas/faas/issues/655)

## How Has This Been Tested?
Small change tested in the community by @viveksyngh 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
