### PR TITLE
Validate new function names

### DIFF
--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -46,9 +47,38 @@ language or type in --list for a list of languages available.`,
 	RunE:    runNewFunction,
 }
 
+// validateFunctionName provides least-common-denominator validation - i.e. only allows valid Kubernetes services names
+func validateFunctionName(functionName string) error {
+	// Regex for RFC-1123 validation:
+	// 	k8s.io/kubernetes/pkg/util/validation/validation.go
+	var validDNS = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+	matched := validDNS.MatchString(functionName)
+	if matched {
+		return nil
+	}
+	return fmt.Errorf(`function name can only contain a-z, 0-9 and dashes`)
+}
+
 // preRunNewFunction validates args & flags
 func preRunNewFunction(cmd *cobra.Command, args []string) error {
 	language, _ = validateLanguageFlag(language)
+
+	if list == true {
+		return nil
+	}
+
+	if len(args) < 1 {
+		return fmt.Errorf("please provide a name for the function")
+	}
+	if len(language) == 0 {
+		return fmt.Errorf("you must supply a function language with the --lang flag")
+	}
+
+	functionName = args[0]
+
+	if err := validateFunctionName(functionName); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -72,16 +102,6 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Languages available as templates:\n%s\n", printAvailableTemplates(availableTemplates))
 
 		return nil
-	}
-
-	if len(args) < 1 {
-		return fmt.Errorf("please provide a name for the function")
-	}
-
-	functionName = args[0]
-
-	if len(language) == 0 {
-		return fmt.Errorf("you must supply a function language with the --lang flag")
 	}
 
 	PullTemplates(DefaultTemplateRepository)

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -19,6 +19,7 @@ import (
 const SuccessMsg = `(?m:Function created in folder)`
 const InvalidYAMLMsg = `is not valid YAML`
 const InvalidYAMLMap = `map is empty`
+const IncludeUpperCase = "function name can only contain a-z, 0-9 and dashes"
 const ListOptionOutput = `Languages available as templates:
 - dockerfile
 - ruby`
@@ -78,6 +79,12 @@ var NewFunctionTests = []NewFunctionTest{
 		funcName:    "new-test-invalid-1",
 		funcLang:    "dockerfilee",
 		expectedMsg: LangNotExistsOutput,
+	},
+	{
+		title:       "test_Uppercase",
+		funcName:    "test_Uppercase",
+		funcLang:    "dockerfile",
+		expectedMsg: IncludeUpperCase,
 	},
 }
 
@@ -195,7 +202,7 @@ func Test_languageNotExists(t *testing.T) {
 	// Attempt to create a function with a non-existing language
 	cmdParameters := []string{
 		"new",
-		"sampleName",
+		"samplename",
 		"--lang=bash",
 		"--gateway=" + defaultGateway,
 		"--list=false",
@@ -215,7 +222,7 @@ func Test_duplicateFunctionName(t *testing.T) {
 	defer tearDownFetchTemplates(t)
 	defer tearDownNewFunction(t)
 
-	const functionName = "sampleFunc"
+	const functionName = "samplefunc"
 	const functionLang = "ruby"
 
 	defer func() {


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Makes sure new function names are valid to RFC-1123 DNS names [0]
This is to ensure that functions created can be built and
deployed on Kubernetes and Docker Swarm.

s8sg originally started this work in PR #375

[0] k8s.io/kubernetes/pkg/util/validation/validation.go

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #374

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with unit test coverage via @s8sg and through a local build:

```
$ go build && ./faas-cli new --lang go Alex
Function name can only contain a-z, 0-9 and dashes
```

Also tested with a positive test of `alex` as the function name.

This change further restricts function names to be compatible with Kubernetes as a default which will not allow `-` characters. This will not cause breakage since it only affects new functions but should be back-ported to the code that loads and validates a YAML stack file too.

@rgee0 thoughts?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Documentation updated via error message.
