### PR TITLE
Make registryAuth sending optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ scoop install faas-cli
 Note: The `scoop` release may not run the latest minor release but is updated regularly.
 
 #### Build from source
+
 > the [contributing guide](CONTRIBUTING.md) has instructions for building from source and for configuring a Golang development environment.
 
 ### Run the CLI
@@ -156,6 +157,17 @@ Specify `lang: Dockerfile` if you want the faas-cli to execute a build or `skip_
 
 Read the blog post/tutorial: [Turn Any CLI into a Function with OpenFaaS](https://blog.alexellis.io/cli-functions-with-openfaas/)
 
+### Private registries
+
+* For Kubernetes
+
+Create a named image pull secret and add the secret name to the `secrets` section of your YAML file or your deployment arguments with `--secret`.
+
+Alternatively you can assign a secret to the node to allow it to pull from your private registry. In this case you do not need to assign the secret to your function.
+
+* For Docker Swarm
+
+For Docker Swarm use the `--send-registry-auth` flag or its shorthand `-a` which will look up your registry credentials in your local credentials store and then transmit them over the wire to the deploy command on the API Gateway. Make sure HTTPS/TLS is enabled before attempting this.
 
 ### Use a YAML stack file
 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Introduces flag --send-registry-auth due to concerns raised about
enabling this user-experience by default. 

## Motivation and Context

See also: #386 and #387
which explains why we do not want to send credentials by default.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with unit tests and local build of the CLI with a remote
Linux host on a MacOS client system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Closes #387 
Closes #386
