### PR TITLE
[Needs testing] Refactor deploy proxy to only call deployment once

### DIFF
--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -14,7 +14,12 @@ import (
 func Test_deploy(t *testing.T) {
 	s := test.MockHttpServer(t, []test.Request{
 		{
-			Method:             http.MethodPut,
+			Method:             http.MethodGet,
+			Uri:                "/system/functions",
+			ResponseStatusCode: http.StatusOK,
+		},
+		{
+			Method:             http.MethodPost,
 			Uri:                "/system/functions",
 			ResponseStatusCode: http.StatusOK,
 		},

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -36,7 +36,7 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	if update {
 		update = existing
 	} else if !update && existing {
-		fmt.Printf("Function %s already exists, you must either remove it first, or update it", functionName)
+		fmt.Printf("Function %s already exists, you must either remove it first, or update it\n", functionName)
 		return
 	}
 

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -58,14 +58,14 @@ func Test_RunDeployProxyTests(t *testing.T) {
 	var deployProxyTests = []deployProxyTest{
 		{
 			title:               "200_Deploy",
-			mockServerResponses: []int{http.StatusOK, http.StatusOK},
+			mockServerResponses: []int{http.StatusOK, http.StatusOK, http.StatusOK},
 			replace:             true,
 			update:              false,
 			expectedOutput:      `(?m:Deployed)`,
 		},
 		{
 			title:               "404_Deploy",
-			mockServerResponses: []int{http.StatusOK, http.StatusNotFound},
+			mockServerResponses: []int{http.StatusOK, http.StatusOK, http.StatusNotFound},
 			replace:             true,
 			update:              false,
 			expectedOutput:      `(?m:Unexpected status: 404)`,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This change is to prevent the deployment call from happening twice
if a function does not yet exist. 

## Description
<!--- Describe your changes in detail -->
When calling the `deploy` function in the proxy, we first call the `ListFunctions` command to see what's deployed to the gateway to know whether or not it should be an update. 

If the update flag is set to true, but the function does not yet exist, we change the update flag to false to prevent errors. 

Also, if the update flag is set to false and the function _does_ exist, we display an error and exit. This prevents the current behavior that the request returns an error:
```
Unexpected status: 400, message: Deployment error: Error response from daemon: rpc error: code = Unknown desc = name conflicts with an existing object
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This was causing warning messages to be displayed twice and resulted in a poor developer experience.
Resolves #387 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Quick first round testing so. Will add more soon...
* Deploy new function (from blank template)
* Deploy same function again
* Remove that function
* Deploy same function again (essentially a new function)

~Here's where the `[WIP]` flag comes in. I'll need to run the unit tests. Update them, and potentially add a new one to cover this new functionality. Just putting this here to get some feedback while I work through the tests.~

I've added unit tests to cover my changes, and also had to update one of the existing ones to account for the slight change in behavior.
 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
