### PR TITLE
[WIP] Accomodate spaces in --build-arg value

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -53,9 +53,11 @@ func BuildImage(image string, handler string, functionName string, language stri
 			}
 		}
 
-		flagStr := buildFlagString(nocache, squash, os.Getenv("http_proxy"), os.Getenv("https_proxy"), buildArgMap)
-		builder := strings.Split(fmt.Sprintf("docker build %s-t %s .", flagStr, image), " ")
-		ExecCommand(tempPath, builder)
+		flagSlice := buildFlagSlice(nocache, squash, os.Getenv("http_proxy"), os.Getenv("https_proxy"), buildArgMap)
+		spaceSafeCmdLine := []string{"docker", "build"}
+		spaceSafeCmdLine = append(spaceSafeCmdLine, flagSlice...)
+		spaceSafeCmdLine = append(spaceSafeCmdLine, "-t", image, ".")
+		ExecCommand(tempPath, spaceSafeCmdLine)
 		fmt.Printf("Image: %s built.\n", image)
 
 	} else {
@@ -93,30 +95,30 @@ func createBuildTemplate(functionName string, handler string, language string) s
 	return tempPath
 }
 
-func buildFlagString(nocache bool, squash bool, httpProxy string, httpsProxy string, buildArgMap map[string]string) string {
+func buildFlagSlice(nocache bool, squash bool, httpProxy string, httpsProxy string, buildArgMap map[string]string) []string {
 
-	buildFlags := ""
+	var spaceSafeBuildFlags []string
 
 	if nocache {
-		buildFlags += "--no-cache "
+		spaceSafeBuildFlags = append(spaceSafeBuildFlags, "--no-cache")
 	}
 	if squash {
-		buildFlags += "--squash "
+		spaceSafeBuildFlags = append(spaceSafeBuildFlags, "--squash")
 	}
 
 	if len(httpProxy) > 0 {
-		buildFlags += fmt.Sprintf("--build-arg http_proxy=%s ", httpProxy)
+		spaceSafeBuildFlags = append(spaceSafeBuildFlags, "--build-arg", fmt.Sprintf("http_proxy=%s", httpProxy))
 	}
 
 	if len(httpsProxy) > 0 {
-		buildFlags += fmt.Sprintf("--build-arg https_proxy=%s ", httpsProxy)
+		spaceSafeBuildFlags = append(spaceSafeBuildFlags, "--build-arg", fmt.Sprintf("https_proxy=%s", httpsProxy))
 	}
 
 	for k, v := range buildArgMap {
-		buildFlags += fmt.Sprintf("--build-arg %s=%s ", k, v)
+		spaceSafeBuildFlags = append(spaceSafeBuildFlags, "--build-arg", fmt.Sprintf("%s=%s", k, v))
 	}
 
-	return buildFlags
+	return spaceSafeBuildFlags
 }
 
 func ensureHandlerPath(handler string) error {

--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -1,0 +1,144 @@
+package builder
+
+import (
+	"testing"
+)
+
+func Test_buildFlagSlice(t *testing.T) {
+
+	var buildFlagOpts = []struct {
+		title         string
+		nocache       bool
+		squash        bool
+		httpProxy     string
+		httpsProxy    string
+		buildArgMap   map[string]string
+		expectedSlice []string
+	}{
+		{
+			title:         "no cache only",
+			nocache:       true,
+			squash:        false,
+			httpProxy:     "",
+			httpsProxy:    "",
+			buildArgMap:   make(map[string]string),
+			expectedSlice: []string{"--no-cache"},
+		},
+		{
+			title:         "no cache & squash only",
+			nocache:       true,
+			squash:        true,
+			httpProxy:     "",
+			httpsProxy:    "",
+			buildArgMap:   make(map[string]string),
+			expectedSlice: []string{"--no-cache", "--squash"},
+		},
+		{
+			title:         "no cache & squash & http proxy only",
+			nocache:       true,
+			squash:        true,
+			httpProxy:     "192.168.0.1",
+			httpsProxy:    "",
+			buildArgMap:   make(map[string]string),
+			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1"},
+		},
+		{
+			title:         "no cache & squash & https-proxy only",
+			nocache:       true,
+			squash:        true,
+			httpProxy:     "",
+			httpsProxy:    "127.0.0.1",
+			buildArgMap:   make(map[string]string),
+			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "https_proxy=127.0.0.1"},
+		},
+		{
+			title:         "no cache & squash & http-proxy & https-proxy only",
+			nocache:       true,
+			squash:        true,
+			httpProxy:     "192.168.0.1",
+			httpsProxy:    "127.0.0.1",
+			buildArgMap:   make(map[string]string),
+			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
+		},
+		{
+			title:         "http-proxy & https-proxy only",
+			nocache:       false,
+			squash:        false,
+			httpProxy:     "192.168.0.1",
+			httpsProxy:    "127.0.0.1",
+			buildArgMap:   make(map[string]string),
+			expectedSlice: []string{"--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
+		},
+		{
+			title:      "build arg map no spaces",
+			nocache:    false,
+			squash:     false,
+			httpProxy:  "",
+			httpsProxy: "",
+			buildArgMap: map[string]string{
+				"muppet": "ernie",
+			},
+			expectedSlice: []string{"--build-arg", "muppet=ernie"},
+		},
+		{
+			title:      "build arg map with spaces",
+			nocache:    false,
+			squash:     false,
+			httpProxy:  "",
+			httpsProxy: "",
+			buildArgMap: map[string]string{
+				"muppets": "burt and ernie",
+			},
+			expectedSlice: []string{"--build-arg", "muppets=burt and ernie"},
+		},
+		{
+			title:      "multiple build arg map with spaces",
+			nocache:    false,
+			squash:     false,
+			httpProxy:  "",
+			httpsProxy: "",
+			buildArgMap: map[string]string{
+				"muppets":    "burt and ernie",
+				"playschool": "Jemima",
+			},
+			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
+		},
+		{
+			title:      "no-cache and squash with multiple build arg map with spaces",
+			nocache:    true,
+			squash:     true,
+			httpProxy:  "",
+			httpsProxy: "",
+			buildArgMap: map[string]string{
+				"muppets":    "burt and ernie",
+				"playschool": "Jemima",
+			},
+			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
+		},
+	}
+
+	for _, test := range buildFlagOpts {
+
+		t.Run(test.title, func(t *testing.T) {
+
+			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap)
+
+			if len(flagSlice) != len(test.expectedSlice) {
+				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedSlice), len(flagSlice))
+			}
+
+			//map iteration is non-deterministic so dont compare values if the buildArgMap is > 1
+			if len(test.buildArgMap) <= 1 {
+				for i, val := range flagSlice {
+
+					if val != test.expectedSlice[i] {
+						t.Errorf("Slices differ in values - wanted: %s, found %s", test.expectedSlice[i], val)
+					}
+
+				}
+			}
+
+		})
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
With the recent addition of --build-arg no provision for the potential for spaces
was made.  This was a problem as the slice that is passed into exec.command() was being
generated via a strings.Split() on space which meant values with spaces were split
across slice elements.

This change alters this behaviour by returning a slice of strings from the buildFlag function
which obviates the need for string.Split further downstream and so removes the potential for
mis-handling of spaces.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (fixes #392)

## How Has This Been Tested?
Much of the testing so far was performed through debugging the issue.
Added a test for the changed method `buildFlagSlice`

### Test method to exercise original issue:
* Export a variable containing a private key
* Amend the relevant template Dockerfile to accept an `ARG` and add `ARG DEPLOY_KEY=${DEPLOY_KEY}`
* Run the build - `./faas-cli-darwin build hello-python --build-arg DEPLOY_KEY="$DEPLOY_KEY" -f hello-python.yml`
* Run the resulting image `docker run -ti hello-python:latest /bin/sh`
* Inside the container check `env` for existence of `DEPLOY_KEY`

**Further testing is required, particularly by third parties.**

Seeking feedback on approach.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
