### PR TITLE
PR code review 396

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -121,12 +121,6 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 		return fmt.Errorf("cannot specify --update and --replace at the same time")
 	}
 
-	dockerConfig := configFile{}
-	err := readDockerConfig(&dockerConfig)
-	if err != nil {
-		log.Println("Unable to read the docker config - %v", err.Error())
-	}
-
 	var services stack.Services
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
@@ -169,6 +163,13 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 			}
 
 			if deployFlags.sendRegistryAuth {
+
+				dockerConfig := configFile{}
+				err := readDockerConfig(&dockerConfig)
+				if err != nil {
+					log.Printf("Unable to read the docker config - %v", err.Error())
+				}
+
 				function.RegistryAuth = getRegistryAuth(&dockerConfig, function.Image)
 			}
 
@@ -219,6 +220,12 @@ Error: %s`, fprocessErr.Error())
 
 		var registryAuth string
 		if deployFlags.sendRegistryAuth {
+			dockerConfig := configFile{}
+			err := readDockerConfig(&dockerConfig)
+			if err != nil {
+				log.Printf("Unable to read the docker config - %v\n", err.Error())
+			}
+
 			gateway = getGatewayURL(gateway, defaultGateway, gateway, os.Getenv(openFaaSURLEnvironment))
 			registryAuth = getRegistryAuth(&dockerConfig, image)
 		}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -254,7 +254,7 @@ func deployImage(
 
 	functionResourceRequest1 := proxy.FunctionResourceRequest{}
 	proxy.DeployFunction(fprocess, gateway, functionName,
-		registryAuth, image, language,
+		image, registryAuth, language,
 		deployFlags.replace, envvars, network,
 		deployFlags.constraints, deployFlags.update, deployFlags.secrets,
 		labelMap, functionResourceRequest1)

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -123,7 +123,7 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 		// Check that the Dockerfile was created
 		if funcLang == "Dockerfile" || funcLang == "dockerfile" {
 			if _, err := os.Stat("./" + funcName + "/Dockerfile"); os.IsNotExist(err) {
-				t.Fatalf("Dockerfile language should create a Dockerfile for you", funcName)
+				t.Fatalf("Dockerfile language should create a Dockerfile for you: %s", funcName)
 			}
 		}
 

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -56,12 +56,6 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please provide the function name")
 	}
 
-	dockerConfig := configFile{}
-	err := readDockerConfig(&dockerConfig)
-	if err != nil {
-		log.Printf("Unable to read the docker config - %v\n", err.Error())
-	}
-
 	storeItems, err := storeList(storeAddress)
 	if err != nil {
 		return err
@@ -95,6 +89,13 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	var registryAuth string
 	if storeDeployFlags.sendRegistryAuth {
+
+		dockerConfig := configFile{}
+		err := readDockerConfig(&dockerConfig)
+		if err != nil {
+			log.Printf("Unable to read the docker config - %v\n", err.Error())
+		}
+
 		registryAuth = getRegistryAuth(&dockerConfig, item.Image)
 	}
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -30,7 +30,7 @@ func Test_ListFunctions(t *testing.T) {
 	}
 	for k, v := range result {
 		if expectedListFunctionsResponse[k] != v {
-			t.Fatal("Expeceted: %#v - Actual: %#v", expectedListFunctionsResponse[k], v)
+			t.Fatalf("Expeceted: %#v - Actual: %#v", expectedListFunctionsResponse[k], v)
 		}
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Moved Docker config into the section of code where it is first
used to prevent loading when not required.

Updated bad usage of println/printf which create build errors
when running in Go 1.10 and newer.

Closes #396 via Vivek Syngh

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* `faas-cli-deploy`

For a negative test I pushed functions/alpine:latest as a new tag to a private Docker Hub repo then removed the image locally. Next I deployed without auth and saw that the service in Swarm was not scheduled.

For a positive test I passed the --send-registry-auth flag which allowed the function to be deployed.

* `faas store deploy`

I tested the default case to make sure it didn't send auth.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.