### PR TITLE
Added --name flag to faas-cli store deploy

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -15,6 +15,7 @@ func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
 	storeDeployCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	storeDeployCmd.Flags().StringVar(&network, "network", "", "Name of the network")
+	storeDeployCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function (overriding name from the store)")
 	// Setup flags that are used only by deploy command (variables defined above)
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.envvarOpts, "env", "e", []string{}, "Adds one or more environment variables to the defined ones by store (ENVVAR=VALUE)")
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.labelOpts, "label", "l", []string{}, "Set one or more label (LABEL=VALUE)")
@@ -32,6 +33,7 @@ func init() {
 
 var storeDeployCmd = &cobra.Command{
 	Use: `deploy (FUNCTION_NAME|FUNCTION_TITLE)
+						[--name FUNCTION_NAME]
                         [--gateway GATEWAY_URL]
                         [--network NETWORK_NAME]
                         [--env ENVVAR=VALUE ...]
@@ -87,6 +89,12 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		network = item.Network
 	}
 
+	itemName := item.Name
+
+	if functionName != "" {
+		itemName = functionName
+	}
+
 	var registryAuth string
 	if storeDeployFlags.sendRegistryAuth {
 
@@ -98,7 +106,8 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 		registryAuth = getRegistryAuth(&dockerConfig, item.Image)
 	}
+
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	return deployImage(item.Image, item.Fprocess, item.Name, registryAuth, storeDeployFlags)
+	return deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags)
 }

--- a/commands/store_deploy_test.go
+++ b/commands/store_deploy_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/openfaas/faas-cli/test"
+)
+
+func Test_storeDeploy_withNameFlag(t *testing.T) {
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			Method:             http.MethodPut,
+			Uri:                "/system/functions",
+			ResponseStatusCode: http.StatusOK,
+		},
+	})
+	defer s.Close()
+
+	stdOut := test.CaptureStdout(func() {
+		faasCmd.SetArgs([]string{
+			"store",
+			"deploy",
+			"test-function",
+			"--gateway=" + s.URL,
+			"--name=foo",
+		})
+		faasCmd.Execute()
+	})
+
+	if found, err := regexp.MatchString(`(?m:Deployed)`, stdOut); err != nil || !found {
+		t.Fatalf("Output is not as expected:\n%s", stdOut)
+	}
+
+	if found, err := regexp.MatchString(`(?m:200 OK)`, stdOut); err != nil || !found {
+		t.Fatalf("Output is not as expected:\n%s", stdOut)
+	}
+
+	if found, err := regexp.MatchString(`(?m:/function/foo)`, stdOut); err != nil || !found {
+		t.Fatalf("Wrong function name (should be `foo`):\n%s", stdOut)
+	}
+
+	// cleaning after test
+	functionName = ""
+}
+
+func Test_storeDeploy_withoutNameFlag(t *testing.T) {
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			Method:             http.MethodPut,
+			Uri:                "/system/functions",
+			ResponseStatusCode: http.StatusOK,
+		},
+	})
+	defer s.Close()
+
+	stdOut := test.CaptureStdout(func() {
+		faasCmd.SetArgs([]string{
+			"store",
+			"deploy",
+			"test-function",
+			"--gateway=" + s.URL,
+		})
+		faasCmd.Execute()
+	})
+
+	if found, err := regexp.MatchString(`(?m:Deployed)`, stdOut); err != nil || !found {
+		t.Fatalf("Output is not as expected:\n%s", stdOut)
+	}
+
+	if found, err := regexp.MatchString(`(?m:200 OK)`, stdOut); err != nil || !found {
+		t.Fatalf("Output is not as expected:\n%s", stdOut)
+	}
+
+	if found, err := regexp.MatchString(`(?m:/function/foo)`, stdOut); err != nil || found {
+		t.Fatalf("Wrong function name (should not be `foo`):\n%s", stdOut)
+	}
+}


### PR DESCRIPTION
Closing #395. Added --name flag to "faas-cli store deploy" which works exactly the same as a "faas-cli deploy" so you can use "faas-cli store deploy --name" like "faas-cli deploy --name"

Signed-off-by: Bart Smykla <bartek@smykla.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I rebased with master so this could be merged. Contains Bart's original fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Checked a fresh build could deploy to an overriden name

```
alexellis-a01:faas-cli alexellis$ ./faas-cli store deploy figlet
Function figlet already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet

alexellis-a01:faas-cli alexellis$ ./faas-cli store deploy figlet --name figlet2

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/figlet2
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Closes #398
