### PR TITLE
Fix get.sh to work with sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -1,5 +1,5 @@
 version=$(curl -s https://api.github.com/repos/openfaas/faas-cli/releases/latest | grep 'tag_name' | cut -d\" -f4)
-if [[ ! $version ]]; then
+if [ ! $version ]; then
     echo "Failed while attempting to install faas-cli. Please manually install:"
     echo ""
     echo "1. Open your web browser and go to https://github.com/openfaas/faas-cli/releases"


### PR DESCRIPTION
Signed-off-by: Eric Stoekl <ems5311@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
Currently the rate limiting condition in the get.sh script only works with `bash`. This simple fix updates it to improve compatibility with other shells such as `sh`.

## Description
<!--- Describe your changes in detail -->
Use a single `[` if statement rather than `[[`. In this case, there is no advantage to the double-square bracket anyway.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
https://github.com/openfaas/faas-cli/issues/377

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested by hitting the rate limit, and making sure that the proper message gets printed when the `$version` variable is missing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
