### PR TITLE
Redirect Derek file to openfaas/faas file

### DIFF
--- a/.DEREK.yml
+++ b/.DEREK.yml
@@ -1,15 +1,1 @@
-curators:
- - alexellis
- - johnmccabe
- - rgee0
- - ericstoekl
- - itscaro
- - kenfdev
- - dungeonmaster18
- - stefanprodan
- - iyovcheva
- - viveksyngh
-
-features:
- - dco_check
- - comments
+redirect: https://raw.githubusercontent.com/openfaas/faas/master/.DEREK.yml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Redirect this repos `derek.yml` file to the main `faas` repo's `derek.yml`

## Description
<!--- Describe your changes in detail -->
This change redirects the derek file to the main openfaas/faas repo to allow us to maintain
a single source of authorized derek users at the main repository.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Discussed with Alex via Slack.

faas and faas-cli (and others) are closely related, so it makes sense to consolidate derek access
to make maintenance easier when adding or removing users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
