### PR TITLE
Add support in templates for building native modules i.e. C/C++

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -1,7 +1,10 @@
 package builder
 
 import (
+	"strings"
 	"testing"
+
+	"github.com/openfaas/faas-cli/stack"
 )
 
 func Test_buildFlagSlice(t *testing.T) {
@@ -13,6 +16,7 @@ func Test_buildFlagSlice(t *testing.T) {
 		httpProxy     string
 		httpsProxy    string
 		buildArgMap   map[string]string
+		buildPackages []string
 		expectedSlice []string
 	}{
 		{
@@ -22,6 +26,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "",
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache"},
 		},
 		{
@@ -31,6 +36,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "",
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash"},
 		},
 		{
@@ -40,6 +46,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "192.168.0.1",
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1"},
 		},
 		{
@@ -49,6 +56,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "",
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -58,6 +66,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "192.168.0.1",
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -67,6 +76,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpProxy:     "192.168.0.1",
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -78,6 +88,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			buildArgMap: map[string]string{
 				"muppet": "ernie",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "muppet=ernie"},
 		},
 		{
@@ -89,6 +100,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			buildArgMap: map[string]string{
 				"muppets": "burt and ernie",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie"},
 		},
 		{
@@ -101,6 +113,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"muppets":    "burt and ernie",
 				"playschool": "Jemima",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
 		{
@@ -113,6 +126,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"muppets":    "burt and ernie",
 				"playschool": "Jemima",
 			},
+			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
 	}
@@ -121,7 +135,7 @@ func Test_buildFlagSlice(t *testing.T) {
 
 		t.Run(test.title, func(t *testing.T) {
 
-			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap)
+			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap, test.buildPackages)
 
 			if len(flagSlice) != len(test.expectedSlice) {
 				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedSlice), len(flagSlice))
@@ -142,3 +156,201 @@ func Test_buildFlagSlice(t *testing.T) {
 	}
 
 }
+
+func Test_getPackages(t *testing.T) {
+	var buildOpts = []struct {
+		title                 string
+		availableBuildOptions []stack.BuildOption
+		requestedBuildOptions []string
+		expectedPackages      []string
+	}{
+		{
+			title: "Single Option",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+			},
+			requestedBuildOptions: []string{"dev"},
+			expectedPackages:      []string{"jq", "hw", "ke"},
+		},
+		{
+			title: "Two Options one chosen",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+				stack.BuildOption{Name: "debug",
+					Packages: []string{"lr", "kt", "jy"}},
+			},
+			requestedBuildOptions: []string{"dev"},
+			expectedPackages:      []string{"jq", "hw", "ke"},
+		},
+		{
+			title: "Two Options two chosen",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+				stack.BuildOption{Name: "debug",
+					Packages: []string{"lr", "kt", "jy"}},
+			},
+			requestedBuildOptions: []string{"dev", "debug"},
+			expectedPackages:      []string{"jq", "hw", "ke", "lr", "kt", "jy"},
+		},
+		{
+			title: "Two Options two chosen with overlaps",
+			availableBuildOptions: []stack.BuildOption{
+				stack.BuildOption{Name: "dev",
+					Packages: []string{"jq", "hw", "ke"}},
+				stack.BuildOption{Name: "debug",
+					Packages: []string{"lr", "jq", "hw"}},
+			},
+			requestedBuildOptions: []string{"dev", "debug"},
+			expectedPackages:      []string{"jq", "hw", "ke", "lr"},
+		},
+	}
+	for _, test := range buildOpts {
+
+		t.Run(test.title, func(t *testing.T) {
+
+			buildOptPackages, _ := getPackages(test.availableBuildOptions, test.requestedBuildOptions)
+
+			if len(buildOptPackages) != len(test.expectedPackages) {
+				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedPackages), len(buildOptPackages))
+			}
+			for _, expectedOptPackage := range test.expectedPackages {
+				found := false
+				for _, buildOptPackage := range buildOptPackages {
+					if buildOptPackage == expectedOptPackage {
+						found = true
+						break
+					}
+				}
+				if found == false {
+
+					t.Errorf("Slices differ in values  - wanted: %s, found %s", strings.Join(test.expectedPackages, " "), strings.Join(buildOptPackages, " "))
+				}
+			}
+		})
+	}
+}
+
+func Test_deDuplicate(t *testing.T) {
+	var stringOpts = []struct {
+		title           string
+		inputStrings    []string
+		expectedStrings []string
+	}{
+		{
+			title:           "No Duplicates",
+			inputStrings:    []string{"jq", "hw", "ke"},
+			expectedStrings: []string{"jq", "hw", "ke"},
+		},
+		{
+			title:           "Duplicates",
+			inputStrings:    []string{"jq", "hw", "ke", "jq", "hw", "ke"},
+			expectedStrings: []string{"jq", "hw", "ke"},
+		},
+	}
+	for _, test := range stringOpts {
+
+		t.Run(test.title, func(t *testing.T) {
+
+			uniqueStrings := deDuplicate(test.inputStrings)
+
+			if len(uniqueStrings) != len(test.expectedStrings) {
+				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedStrings), len(uniqueStrings))
+			}
+
+			for _, expectedString := range test.expectedStrings {
+
+				found := false
+
+				for _, uniqueString := range uniqueStrings {
+
+					if expectedString == uniqueString {
+						found = true
+						break
+					}
+				}
+				if found == false {
+
+					t.Errorf("Slices differ in values  - wanted: %s, found %s", strings.Join(test.expectedStrings, " "), strings.Join(uniqueStrings, " "))
+				}
+			}
+		})
+	}
+}
+
+/*func Test_validateBuildOption(t *testing.T) {
+
+	buildOptions := []struct {
+		buildOption           string
+		expectedBuildArgValue string
+	}{
+		{
+			buildOption:           "dev",
+			expectedBuildArgValue: "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev musl-dev libffi-dev",
+		},
+
+		{
+			buildOption:           "undefined",
+			expectedBuildArgValue: "",
+		},
+	}
+
+	os.MkdirAll("template/python3", os.ModePerm)
+	python3_template_yml, err := os.Create("template/python3/template.yml")
+	if err != nil {
+		t.Errorf("Error creating template/python3/template.yml file")
+	}
+
+	_, err = python3_template_yml.WriteString("language: python3\n" +
+		"fprocess: python3 index.py\n" +
+		"build_options: \n" +
+		"  - name: dev\n" +
+		"    packages: \n" +
+		"      - make\n" +
+		"      - automake\n" +
+		"      - gcc\n" +
+		"      - g++\n" +
+		"      - subversion\n" +
+		"      - python3-dev\n" +
+		"      - musl-dev\n" +
+		"      - libffi-dev\n")
+
+	if err != nil {
+		t.Errorf("Error writing to template/python3/template.yml file")
+	}
+
+	os.MkdirAll("template/unsupported", os.ModePerm)
+	unsupported_template_yml, err := os.Create("template/unsupported/template.yml")
+	if err != nil {
+		t.Errorf("Error creating template/unsupported/template.yml file")
+	}
+
+	_, err = unsupported_template_yml.WriteString("language: python3\n" +
+		"fprocess: python3 index.py\n")
+
+	if err != nil {
+		t.Errorf("Error writing to template/pythunsupportedon3/template.yml file")
+	}
+
+	for _, test := range buildOptions {
+		t.Run(test.buildOption, func(t *testing.T) {
+			res, _, _ := validateBuildOption(test.buildOption, "python3")
+			_, isValid, _ := validateBuildOption(test.buildOption, "unsupported")
+
+			if res != test.expectedBuildArgValue {
+				t.Errorf("validateBuildOption failed for build-option %s. Expected to return %s, but returned %s",
+					test.buildOption, test.expectedBuildArgValue, res)
+			}
+
+			if isValid && test.buildOption == "dev" {
+				t.Errorf("validateBuildOption failed for build-option %s and unsupported language. Expected validation to fail, but it was successful",
+					test.buildOption)
+			}
+		})
+	}
+
+	os.RemoveAll("template")
+}
+*/

--- a/commands/build.go
+++ b/commands/build.go
@@ -24,7 +24,10 @@ var (
 	shrinkwrap  bool
 	buildArgs   []string
 	buildArgMap map[string]string
+	buildOption string
 )
+
+const additionalPackageBuildArg = "ADDITIONAL_PACKAGE"
 
 func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
@@ -43,6 +46,8 @@ func init() {
 
 	buildCmd.Flags().StringArrayVarP(&buildArgs, "build-arg", "b", []string{}, "Add a build-arg for Docker (KEY=VALUE)")
 
+	buildCmd.Flags().StringVar(&buildOption, "build-option", "", "Set a build option, e.g. dev")
+
 	// Set bash-completion.
 	_ = buildCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
 
@@ -60,13 +65,15 @@ var buildCmd = &cobra.Command{
                  [--regex "REGEX"]
 				 [--filter "WILDCARD"]
 				 [--parallel PARALLEL_DEPTH]
-				 [--build-arg KEY=VALUE]`,
+				 [--build-arg KEY=VALUE]
+				 [--build-option VALUE]`,
 	Short: "Builds OpenFaaS function containers",
 	Long: `Builds OpenFaaS function containers either via the supplied YAML config using
 the "--yaml" flag (which may contain multiple function definitions), or directly
 via flags.`,
 	Example: `  faas-cli build -f https://domain/path/myfunctions.yml
   faas-cli build -f ./stack.yml --no-cache --build-arg NPM_VERSION=0.2.2
+  faas-cli build -f ./stack.yml --build-option dev
   faas-cli build -f ./stack.yml --filter "*gif*"
   faas-cli build -f ./stack.yml --regex "fn[0-9]_.*"
   faas-cli build --image=my_image --lang=python --handler=/path/to/fn/ 
@@ -78,6 +85,14 @@ via flags.`,
 // preRunBuild validates args & flags
 func preRunBuild(cmd *cobra.Command, args []string) error {
 	language, _ = validateLanguageFlag(language)
+
+	if buildOption != "" {
+		arg, validBuildOption, err := validateBuildOption(buildOption, language)
+
+		if validBuildOption && err == nil {
+			buildArgs = append(buildArgs, arg)
+		}
+	}
 
 	mapped, err := parseBuildArgs(buildArgs)
 
@@ -109,10 +124,70 @@ func parseBuildArgs(args []string) (map[string]string, error) {
 			return nil, fmt.Errorf("build-arg must have a non-empty value")
 		}
 
-		mapped[k] = v
+		if k == additionalPackageBuildArg && len(mapped[k]) > 0 {
+			mapped[k] = mapped[k] + " " + v
+		} else {
+			mapped[k] = v
+		}
 	}
 
 	return mapped, nil
+}
+
+func validateBuildOption(buildOption string, language string) (string, bool, error) {
+
+	buildOptions, err := deriveBuildOptions(language)
+
+	if err != nil {
+		return "", false, err
+	}
+
+	foundOption, isFound := findBuildOption(buildOptions, buildOption)
+
+	if isFound {
+		buildOptionPackages := strings.Join(foundOption.Packages, " ")
+		return additionalPackageBuildArg + "=" + buildOptionPackages, isFound, err
+	}
+
+	err = fmt.Errorf("ERROR! You're using a wrong build option. Please check the  template/language/template.yml for supported build options.")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	return "", false, err
+}
+
+func deriveBuildOptions(language string) ([]stack.BuildOption, error) {
+	var buildOptions = []stack.BuildOption{}
+
+	pathToTemplateYAML := "./template/" + language + "/template.yml"
+	if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
+		return buildOptions, err
+	}
+
+	var langTemplate stack.LanguageTemplate
+	parsedLangTemplate, err := stack.ParseYAMLForLanguageTemplate(pathToTemplateYAML)
+
+	if err != nil {
+		return buildOptions, err
+	}
+
+	if parsedLangTemplate != nil {
+		langTemplate = *parsedLangTemplate
+		buildOptions = langTemplate.BuildOptions
+	}
+
+	return buildOptions, nil
+}
+
+func findBuildOption(buildOptions []stack.BuildOption, requiredBuildOption string) (stack.BuildOption, bool) {
+	for _, option := range buildOptions {
+		if option.Name == requiredBuildOption {
+			return option, true
+		}
+	}
+
+	return stack.BuildOption{}, false
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"os"
 	"testing"
 )
 
@@ -73,4 +74,78 @@ func Test_parseBuildArgs_MultipleSeparators(t *testing.T) {
 		t.Errorf("value for 'k', want: %s got: %s", "v=z", mapped["k"])
 		t.Fail()
 	}
+}
+
+func Test_validateBuildOption(t *testing.T) {
+
+	buildOptions := []struct {
+		buildOption           string
+		expectedBuildArgValue string
+	}{
+		{
+			buildOption:           "dev",
+			expectedBuildArgValue: "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev musl-dev libffi-dev",
+		},
+
+		{
+			buildOption:           "undefined",
+			expectedBuildArgValue: "",
+		},
+	}
+
+	os.MkdirAll("template/python3", os.ModePerm)
+	python3_template_yml, err := os.Create("template/python3/template.yml")
+	if err != nil {
+		t.Errorf("Error creating template/python3/template.yml file")
+	}
+
+	_, err = python3_template_yml.WriteString("language: python3\n" +
+		"fprocess: python3 index.py\n" +
+		"build_options: \n" +
+		"  - name: dev\n" +
+		"    packages: \n" +
+		"      - make\n" +
+		"      - automake\n" +
+		"      - gcc\n" +
+		"      - g++\n" +
+		"      - subversion\n" +
+		"      - python3-dev\n" +
+		"      - musl-dev\n" +
+		"      - libffi-dev\n")
+
+	if err != nil {
+		t.Errorf("Error writing to template/python3/template.yml file")
+	}
+
+	os.MkdirAll("template/unsupported", os.ModePerm)
+	unsupported_template_yml, err := os.Create("template/unsupported/template.yml")
+	if err != nil {
+		t.Errorf("Error creating template/unsupported/template.yml file")
+	}
+
+	_, err = unsupported_template_yml.WriteString("language: python3\n" +
+		"fprocess: python3 index.py\n")
+
+	if err != nil {
+		t.Errorf("Error writing to template/pythunsupportedon3/template.yml file")
+	}
+
+	for _, test := range buildOptions {
+		t.Run(test.buildOption, func(t *testing.T) {
+			res, _, _ := validateBuildOption(test.buildOption, "python3")
+			_, isValid, _ := validateBuildOption(test.buildOption, "unsupported")
+
+			if res != test.expectedBuildArgValue {
+				t.Errorf("validateBuildOption failed for build-option %s. Expected to return %s, but returned %s",
+					test.buildOption, test.expectedBuildArgValue, res)
+			}
+
+			if isValid && test.buildOption == "dev" {
+				t.Errorf("validateBuildOption failed for build-option %s and unsupported language. Expected validation to fail, but it was successful",
+					test.buildOption)
+			}
+		})
+	}
+
+	os.RemoveAll("template")
 }

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -4,7 +4,6 @@
 package commands
 
 import (
-	"os"
 	"testing"
 )
 
@@ -74,78 +73,4 @@ func Test_parseBuildArgs_MultipleSeparators(t *testing.T) {
 		t.Errorf("value for 'k', want: %s got: %s", "v=z", mapped["k"])
 		t.Fail()
 	}
-}
-
-func Test_validateBuildOption(t *testing.T) {
-
-	buildOptions := []struct {
-		buildOption           string
-		expectedBuildArgValue string
-	}{
-		{
-			buildOption:           "dev",
-			expectedBuildArgValue: "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev musl-dev libffi-dev",
-		},
-
-		{
-			buildOption:           "undefined",
-			expectedBuildArgValue: "",
-		},
-	}
-
-	os.MkdirAll("template/python3", os.ModePerm)
-	python3_template_yml, err := os.Create("template/python3/template.yml")
-	if err != nil {
-		t.Errorf("Error creating template/python3/template.yml file")
-	}
-
-	_, err = python3_template_yml.WriteString("language: python3\n" +
-		"fprocess: python3 index.py\n" +
-		"build_options: \n" +
-		"  - name: dev\n" +
-		"    packages: \n" +
-		"      - make\n" +
-		"      - automake\n" +
-		"      - gcc\n" +
-		"      - g++\n" +
-		"      - subversion\n" +
-		"      - python3-dev\n" +
-		"      - musl-dev\n" +
-		"      - libffi-dev\n")
-
-	if err != nil {
-		t.Errorf("Error writing to template/python3/template.yml file")
-	}
-
-	os.MkdirAll("template/unsupported", os.ModePerm)
-	unsupported_template_yml, err := os.Create("template/unsupported/template.yml")
-	if err != nil {
-		t.Errorf("Error creating template/unsupported/template.yml file")
-	}
-
-	_, err = unsupported_template_yml.WriteString("language: python3\n" +
-		"fprocess: python3 index.py\n")
-
-	if err != nil {
-		t.Errorf("Error writing to template/pythunsupportedon3/template.yml file")
-	}
-
-	for _, test := range buildOptions {
-		t.Run(test.buildOption, func(t *testing.T) {
-			res, _, _ := validateBuildOption(test.buildOption, "python3")
-			_, isValid, _ := validateBuildOption(test.buildOption, "unsupported")
-
-			if res != test.expectedBuildArgValue {
-				t.Errorf("validateBuildOption failed for build-option %s. Expected to return %s, but returned %s",
-					test.buildOption, test.expectedBuildArgValue, res)
-			}
-
-			if isValid && test.buildOption == "dev" {
-				t.Errorf("validateBuildOption failed for build-option %s and unsupported language. Expected validation to fail, but it was successful",
-					test.buildOption)
-			}
-		})
-	}
-
-	os.RemoveAll("template")
 }

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -68,6 +68,12 @@ type Services struct {
 
 // LanguageTemplate read from template.yml within root of a language template folder
 type LanguageTemplate struct {
-	Language string `yaml:"language"`
-	FProcess string `yaml:"fprocess"`
+	Language     string        `yaml:"language"`
+	FProcess     string        `yaml:"fprocess"`
+	BuildOptions []BuildOption `yaml:"build_options"`
+}
+
+type BuildOption struct {
+	Name     string   `yaml:"name"`
+	Packages []string `yaml:"packages"`
 }

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -47,6 +47,9 @@ type Function struct {
 
 	// Requests of resources requested by function
 	Requests *FunctionResources `yaml:"requests"`
+
+	// BuildOptions to determine native packages
+	BuildOptions []string `yaml:"build_options"`
 }
 
 // FunctionResources Memory and CPU


### PR DESCRIPTION
This change adds a `build-option` flag to `faas-cli build`,
e.g. `faas-cli  build  -f  stack.yml --build-option=dev`.

If  the function  language  template  has  applied  `build_options` specification in its `template.yml` file, i.e.
```
build_options:
  - name: dev
    packages:
      - musl-dev
      - gcc
      - make
```
then `ADDITIONAL_PACKAGE` agrument will be passed by `build-arg`.

This allows the listed packages to be built by the template's `Dockerfile` if it is edited to support the feature.

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

[templates/#28](https://github.com/openfaas/templates/issues/28)

## How Has This Been Tested?
1. Cloned @kenfdev's function from [kenfdev/faas-pandas-example](https://github.com/kenfdev/faas-pandas-example)
2. Changed python3 template with the changes from [templates/#30](https://github.com/openfaas/templates/pull/30)
3. Successfully built the function with `faas-cli-darwin build --lang=python3 --build-option dev`
4. Successfully built the function with `faas-cli-darwin build --build-arg "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev"`
5. Successfully built a simple python3 function without `--build-option` and `--build-arg "ADDITIONAL_PACKAGE=<packages>"`
6. Successfully built faas-pandas with `faas-cli-darwin build --lang=python3 --build-option dev --build-arg "ADDITIONAL_PACKAGE=make automake gcc g++"` where `template.yml` contains only `subversion`,  `python3-dev` and  `musl-dev`.
7. Successfully built a simple python3 function with `faas-cli-darwin build -f test.yml --build-arg TEST=somevalue`
8. Successfully built faas-pandas with `faas-cli-darwin build --build-arg TEST=somevalue --build-arg "ADDITIONAL_PACKAGE=make automake gcc g++ subversion python3-dev"`
9. Built with `bcrypt` in `requirements.txt`. Requires `libffi-dev` module.
10. Built with `bcrypt` and yaml config / yaml + cmd flag / yaml + `--build-arg ADDITIONAL_PACKAGE=libffi-dev` / yaml with a wrong (not available in `template.yml`) build option value / cmd flag with a wrong build option value

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. - TODO
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## How to test

- `cd ~/go/src/github.com/openfaas/faas-cli && git fetch origin pull/414/head:dev_build`
- `git checkout dev_build`
- `./build_redist.sh`
- `cd ~/go/src/github.com/openfaas/tempates && git fetch origin pull/30/head:py3_build_native_c_modules`
- `git checkout py3_build_native_c_modules`
- `git clone git@github.com:kenfdev/faas-pandas-example.git`
- `rm -rf faas-pandas-example/template && cp template faas-pandas-example/template && cd faas-pandas-example`
- `~/go/src/github.com/openfaas/faas-cli/faas-cli-darwin build --lang=python3 --build-option dev`

You can also test with 4-10 from "How Has This Been Tested?"