### PR TITLE
 Add `cloud` sub-command for sealing secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ obj
 
 
 template
+
+*.pem
+secrets.yml

--- a/README.md
+++ b/README.md
@@ -341,6 +341,28 @@ $ uname -a | curl http://127.0.0.1:8080/function/nodejs-echo--data-binary @-
 
 > For further instructions on the manual CLI flags (without using a YAML file) read [manual_cli.md](https://github.com/openfaas/faas-cli/blob/master/MANUAL_CLI.md)
 
+### OpenFaaS Cloud (extensions)
+
+[OpenFaaS Cloud](https://github.com/openfaas/openfaas-cloud) provides a GitOps experience for functions on Kubernetes.
+
+Commands:
+
+* `seal`
+
+You can use the CLI to seal a secret for usage on public Git repo. The pre-requisite is that you have installed [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) and exported your public key from your cluster as `pub-cert.pem`.
+
+```
+$ faas-cli cloud seal --name alexellis-github --literal hmac-secret=1234 --cert=pub-cert.pem
+```
+
+Exporting the `SealedSecrets` public key:
+
+```
+kubeseal --fetch-cert pub-cert.pem
+```
+
+You can then place the `secrets.yml` file in any public Git repo without others being able to read the contents.
+
 ### FaaS-CLI Developers / Contributors
 
 See [contributing guide](https://github.com/openfaas/faas-cli/blob/master/CONTRIBUTING.md).

--- a/commands/cloud.go
+++ b/commands/cloud.go
@@ -1,0 +1,125 @@
+// Copyright (c) OpenFaaS Project. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+
+	"github.com/openfaas/faas-cli/schema"
+	"github.com/spf13/cobra"
+)
+
+var (
+	namespace  string
+	name       string
+	literal    *[]string
+	outputFile string
+	certFile   string
+)
+
+func init() {
+	faasCmd.AddCommand(cloudCmd)
+
+	cloudSealCmd.Flags().StringVar(&name, "name", "", "Secret name")
+
+	cloudSealCmd.Flags().StringVarP(&namespace, "namespace", "n", "openfaas-fn", "Secret name")
+	cloudSealCmd.Flags().StringVarP(&certFile, "cert", "c", "pub-cert.pem", "Filename of public certificate")
+
+	cloudSealCmd.Flags().StringVarP(&outputFile, "output-file", "o", "secrets.yml", "Output file for secrets")
+	literal = cloudSealCmd.Flags().StringArrayP("literal", "l", []string{}, "Secret literal key-value data")
+
+	cloudCmd.AddCommand(cloudSealCmd)
+}
+
+var cloudCmd = &cobra.Command{
+	Use:   `cloud`,
+	Short: "OpenFaaS Cloud commands",
+	Long:  "Commands for operating with OpenFaaS Cloud",
+}
+
+var cloudSealCmd = &cobra.Command{
+	Use:     `seal [--name secret-name] [--literal k=v] [--namespace openfaas-fn]`,
+	Short:   "Seal a secret for usage with OpenFaaS Cloud",
+	Example: `  faas-cli cloud seal --name alexellis-github --literal hmac-secret=c4488af0c158e8c`,
+	RunE:    runCloudSeal,
+}
+
+func runCloudSeal(cmd *cobra.Command, args []string) error {
+	if len(name) == 0 {
+		return fmt.Errorf("--name is required")
+	}
+
+	fmt.Printf("Sealing secret: %s in namepsace: %s\n", name, namespace)
+	fmt.Printf("Literals:\n")
+	if literal != nil {
+		args, _ := parseBuildArgs(*literal)
+
+		for k := range args {
+			fmt.Printf("- %s\n", k)
+		}
+	} else {
+		fmt.Println("")
+	}
+	fmt.Println("")
+
+	enc := base64.StdEncoding
+
+	secret := schema.KubernetesSecret{
+		ApiVersion: "v1",
+		Kind:       "Secret",
+		Metadata: schema.KubernetesSecretMetadata{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: make(map[string]string),
+	}
+
+	if literal != nil {
+		args, _ := parseBuildArgs(*literal)
+
+		for k, v := range args {
+			secret.Data[k] = enc.EncodeToString([]byte(v))
+		}
+	}
+
+	sec, err := json.Marshal(secret)
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := os.Stat(certFile); err != nil {
+		return fmt.Errorf("unable to load public certificate %s", certFile)
+	}
+
+	kubeseal := exec.Command("kubeseal", "--format=yaml", "--cert="+certFile)
+
+	stdin, stdinErr := kubeseal.StdinPipe()
+	if stdinErr != nil {
+		panic(stdinErr)
+	}
+
+	stdin.Write(sec)
+	stdin.Close()
+
+	out, err := kubeseal.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("unable to start \"kubeseal\", check it is installed, error: %s", err.Error())
+	}
+
+	writeErr := ioutil.WriteFile(outputFile, out, 0755)
+
+	if writeErr != nil {
+		return fmt.Errorf("unable to write secret: %s to %s", name, outputFile)
+	}
+
+	fmt.Printf("%s written.\n", outputFile)
+
+	return nil
+
+}

--- a/schema/secret.go
+++ b/schema/secret.go
@@ -1,0 +1,13 @@
+package schema
+
+type KubernetesSecret struct {
+	Kind       string                   `json:"kind"`
+	ApiVersion string                   `json:"apiVersion"`
+	Metadata   KubernetesSecretMetadata `json:"metadata"`
+	Data       map[string]string        `json:"data"`
+}
+
+type KubernetesSecretMetadata struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Add `cloud` sub-command for sealing secrets

## Description
<!--- Describe your changes in detail -->

Adds new command to seal a secret for use in OpenFaaS Cloud with
new subcommand "cloud". A sealed secret can be pushed into a
public Git repo without others being able to decrypt it.

The `kubeseal` CLI provides the implementation of the sealing
via exec - this is much less code and bloat than vendoring since
the kubeseal client API includes the Kubernetes Go client.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/openfaas/openfaas-cloud/issues/20

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Command tested with SealedSecrets running on Kubernetes with
kubeadm and the faas-cli running on MacOS.

See README.md for usage and more instructions.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.