### PR TITLE
Add build artifact hashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ after_success:
 
 before_deploy:
   - make build_redist
+  - for f in faas-cli*; do shasum -a 256 ./$f | awk '{print $1}' > ./$f.sha256; done
 
 deploy:
   provider: releases
@@ -47,6 +48,11 @@ deploy:
   - faas-cli-armhf
   - faas-cli.exe
   - faas-cli-arm64
+  - faas-cli.sha256
+  - faas-cli-darwin.sha256
+  - faas-cli-armhf.sha256
+  - faas-cli.exe.sha256
+  - faas-cli-arm64.sha256
   skip_cleanup: true
   on:
     tags: true

--- a/build_redist.sh
+++ b/build_redist.sh
@@ -14,3 +14,4 @@ docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_p
  docker cp faas-cli:/root/faas-cli-arm64 . && \
  docker cp faas-cli:/root/faas-cli.exe . && \
  docker rm -f faas-cli
+


### PR DESCRIPTION
Signed-off-by: rgee0 <richard@technologee.co.uk>

## Description
Adds a command to .travis.yml to pipe the output of shasum against each file to respective files suffixed with .sha256.
This has been added to the before_deploy stage after build_redist has run.

## Motivation and Context
Fixes #422.
- [x] I have raised an issue to propose this change

## How Has This Been Tested?
Ran the command in the script section to confirm that travis accepts it.  Ran successfully.
Moved to the before_deploy stage which is only executed on tagged commits.  
Created a new branch and within that branch changed the secret so it was able to write to my forked repo. 
Created a release against this branch.  
The output is here: https://github.com/rgee0/faas-cli/releases/tag/0.4.2
Downloaded the arm64 files & ran `shasum -a 256 <filename>` against the executable and compared the output to the `.sha256` file:

```
$ shasum -a 256 faas-cli-arm64
c11c46b9c827b5638fac1c7d1f6c9296308af574426e14f19f050acd8f2d85f5  faas-cli-arm64
$ cat faas-cli-arm64.sha256 
c11c46b9c827b5638fac1c7d1f6c9296308af574426e14f19f050acd8f2d85f5
```


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
