### PR TITLE
Add graceful degradation for sha_cmd in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -30,12 +30,20 @@ hasCli() {
     fi
 }
 
+
 checkHash(){
-    if [ -x "$(command -v shasum)" ]; then
+
+    sha_cmd="sha256sum"
+
+    if [ ! -x "$(command -v $sha_cmd)" ]; then
+    sha_cmd="shasum -a 256"
+    fi
+
+    if [ -x "$(command -v $sha_cmd)" ]; then
 
     targetFileDir=${targetFile%/*}
 
-    (cd $targetFileDir && curl -sSL $url.sha256|shasum -c -s)
+    (cd $targetFileDir && curl -sSL $url.sha256|$sha_cmd -c -s)
    
         if [ "$?" != "0" ]; then
             rm $targetFile
@@ -108,7 +116,7 @@ getPackage() {
         else
 
             echo
-            echo "Running as root - Attemping to move faas-cli to /usr/local/bin"
+            echo "Running as root - Attempting to move faas-cli to /usr/local/bin"
 
             mv $targetFile /usr/local/bin/faas-cli
         


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This change defaults the command to be used to sha256sum and reverts to
shasum -a 256 if the default isnt found.

Also fixed a typo in the console output `attemping` --> `attempting`. 

## Motivation and Context
The earlier choice of using shasum was made for broadest support reasons.  However
the breadth of support could be broader still by introducing graceful degradation
to get.sh.  
- [x] I have raised an issue to propose this change (Addendum to #422 & #425 )

## How Has This Been Tested?
Small change.  Tested on MacOS and PWD (where the earlier script was failing) and verified that the command was correctly switching by adding a temporary echo `$sha_cmd`
* PWD
```

Running as root - Attemping to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
Creating alias 'faas' for 'faas-cli'.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

Commit: d33cb5cdc128b75fc7a9856c30fc0eded39fec1e
Version: 0.6.12
[node1] (local) root@192.168.0.58 ~
$ sudo ./get.sh

You already have the faas-cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

x86_64
Downloading package https://github.com/openfaas/faas-cli/releases/download/0.6.12/faas-cli as /tmp/faas-cli
sha256sum
Download complete.

Running as root - Attemping to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

Commit: d33cb5cdc128b75fc7a9856c30fc0eded39fec1e
Version: 0.6.12
```
* MacOS
```
$ ./get.sh

You already have the faas-cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/openfaas/faas-cli/releases/download/0.6.12/faas-cli-darwin as /Users/rgee0/go/src/git
hub.com/rgee0/faas-cli/faas-cli-darwin
shasum -a 256
Download complete.

=========================================================
==    As the script was run as a non-root user the     ==
==    following commands may need to be run manually   ==
=========================================================

  sudo cp faas-cli-darwin /usr/local/bin/faas-cli
  sudo ln -sf /usr/local/bin/faas-cli /usr/local/bin/faas

$ sudo ./get.sh

You already have the faas-cli!
Overwriting in 1 seconds.. Press Control+C to cancel.

Downloading package https://github.com/openfaas/faas-cli/releases/download/0.6.12/faas-cli-darwin as /tmp/faas-cli-darwin
shasum -a 256
Download complete.

Running as root - Attemping to move faas-cli to /usr/local/bin
New version of faas-cli installed to /usr/local/bin
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

Commit: d33cb5cdc128b75fc7a9856c30fc0eded39fec1e
Version: 0.6.12
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
