### PR TITLE
Add ReadOnlyRootFilesystem to the schema

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -53,8 +53,8 @@
 [[projects]]
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
-  revision = "262b0afda7a0161d3ee4b3dafdcc085128b215df"
-  version = "0.6.16"
+  revision = "31810a4cf29a3f583c8d69b54c1eab038549ce6a"
+  version = "0.8.6"
 
 [[projects]]
   name = "github.com/ryanuber/go-glob"
@@ -95,6 +95,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5669b5e9e64a448d63296ffa1ebb81bb8c619a8203c4bd3149f0cb5e7e851613"
+  inputs-digest = "d91bfc3d3c0b00080584d751d3f6e5b98d366610349d109fb37ee78b4b08e73a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas"
-  version = "0.6.16"
+  version = "0.8.6"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -25,13 +25,14 @@ import (
 
 // DeployFlags holds flags that are to be added to commands.
 type DeployFlags struct {
-	envvarOpts       []string
-	replace          bool
-	update           bool
-	constraints      []string
-	secrets          []string
-	labelOpts        []string
-	sendRegistryAuth bool
+	envvarOpts             []string
+	replace                bool
+	update                 bool
+	readOnlyRootFilesystem bool
+	constraints            []string
+	secrets                []string
+	labelOpts              []string
+	sendRegistryAuth       bool
 }
 
 var deployFlags DeployFlags
@@ -56,6 +57,7 @@ func init() {
 
 	deployCmd.Flags().StringArrayVar(&deployFlags.constraints, "constraint", []string{}, "Apply a constraint to the function")
 	deployCmd.Flags().StringArrayVar(&deployFlags.secrets, "secret", []string{}, "Give the function access to a secure secret")
+	deployCmd.Flags().BoolVar(&deployFlags.readOnlyRootFilesystem, "readonly", false, "Force the root container filesystem to be read only")
 
 	deployCmd.Flags().BoolVarP(&deployFlags.sendRegistryAuth, "send-registry-auth", "a", false, "send registryAuth from Docker credentials manager with the request")
 
@@ -82,7 +84,8 @@ var deployCmd = &cobra.Command{
                   [--constraint PLACEMENT_CONSTRAINT ...]
                   [--regex "REGEX"]
                   [--filter "WILDCARD"]
-                  [--secret "SECRET_NAME"]`,
+				  [--secret "SECRET_NAME"]
+				  [--readonly=false]`,
 
 	Short: "Deploy OpenFaaS functions",
 	Long: `Deploys OpenFaaS function containers either via the supplied YAML config using
@@ -212,7 +215,12 @@ Error: %s`, fprocessErr.Error())
 				Limits:   function.Limits,
 				Requests: function.Requests,
 			}
-			statusCode := proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.RegistryAuth, function.Language, deployFlags.replace, allEnvironment, services.Provider.Network, functionConstraints, deployFlags.update, deployFlags.secrets, allLabels, functionResourceRequest1)
+
+			if deployFlags.readOnlyRootFilesystem {
+				function.ReadOnlyRootFilesystem = deployFlags.readOnlyRootFilesystem
+			}
+
+			statusCode := proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.RegistryAuth, function.Language, deployFlags.replace, allEnvironment, services.Provider.Network, functionConstraints, deployFlags.update, deployFlags.secrets, allLabels, functionResourceRequest1, function.ReadOnlyRootFilesystem)
 			if badStatusCode(statusCode) {
 				failedStatusCodes[k] = statusCode
 			}
@@ -259,6 +267,9 @@ func deployImage(
 ) (error, int) {
 
 	var statusCode int
+	// default to a readable filesystem until we get more input about the expected behavior
+	// and if we want to add another flag for this case
+	readOnlyRootFilesystem := false
 	envvars, err := parseMap(deployFlags.envvarOpts, "env")
 
 	if err != nil {
@@ -276,7 +287,7 @@ func deployImage(
 		image, registryAuth, language,
 		deployFlags.replace, envvars, network,
 		deployFlags.constraints, deployFlags.update, deployFlags.secrets,
-		labelMap, functionResourceRequest1)
+		labelMap, functionResourceRequest1, readOnlyRootFilesystem)
 
 	return nil, statusCode
 }

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -45,6 +45,7 @@ func runDeployProxyTest(t *testing.T, deployTest deployProxyTest) {
 			[]string{},
 			map[string]string{},
 			FunctionResourceRequest{},
+			false,
 		)
 	})
 
@@ -104,6 +105,7 @@ func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 			[]string{},
 			map[string]string{},
 			FunctionResourceRequest{},
+			false,
 		)
 	})
 

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -48,6 +48,9 @@ type Function struct {
 	// Requests of resources requested by function
 	Requests *FunctionResources `yaml:"requests"`
 
+	// ReadOnlyRootFilesystem is used to set the container filesystem to read-only
+	ReadOnlyRootFilesystem bool `yaml:"readOnlyRootFilesystem"`
+
 	// BuildOptions to determine native packages
 	BuildOptions []string `yaml:"build_options"`
 }

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -41,6 +41,10 @@ type CreateFunctionRequest struct {
 
 	// Requests of resources requested by function
 	Requests *FunctionResources `json:"requests"`
+
+	// ReadOnlyRootFilesystem removes write-access from the root filesystem
+	// mount-point.
+	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
 }
 
 // FunctionResources Memory and CPU
@@ -56,6 +60,9 @@ type Function struct {
 	InvocationCount float64 `json:"invocationCount"` // TODO: shouldn't this be int64?
 	Replicas        uint64  `json:"replicas"`
 	EnvProcess      string  `json:"envProcess"`
+
+	// AvailableReplicas is the count of replicas ready to receive invocations as reported by the back-end
+	AvailableReplicas uint64 `json:"availableReplicas"`
 
 	// Labels are metadata for functions which may be used by the
 	// back-end for making scheduling or routing decisions


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add the ReadOnlyRootFilesystem option to the stack schema
- Pass the value of ReadOnlyRootFilesystem to the create function
request
- Update the vendor lock to bunp the faas version
- Update the vendor lock to include docker-credential-helper because it
was required to build correctly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)

Closes openfaas/faas#590

This will be parsed into the add function request and then to the
orchestration layer so that the function container is created with a
read-only filesystem at /)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I am posting this to get it in the pipeline and ready for testing, I will start testing it as soon as I have the companion pull requests in swarm and netes ready.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
