### PR TITLE
Replace shorthand status flag with long verion in get.sh

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -43,7 +43,7 @@ checkHash(){
 
     targetFileDir=${targetFile%/*}
 
-    (cd $targetFileDir && curl -sSL $url.sha256|$sha_cmd -c -s)
+    (cd $targetFileDir && curl -sSL $url.sha256|$sha_cmd -c >/dev/null)
    
         if [ "$?" != "0" ]; then
             rm $targetFile


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This change replaces the -s option for shasum, which suppresses output, in favour of redirection to /dev/null.

## Motivation and Context
As part of the graceful degradation change use of sha256sum was introduced.
On Ubuntu 16.04 the shorthand flag for status does not exist which results in
a failure when verifying the checksum.  Further, support for -s & the long --status flag
is inconsistent across distros. 
- [x] I have raised an issue to propose this change (Further addendum to #422 & #425)

## How Has This Been Tested?
Pre-tested on Ubuntu 16.04 to validate reported issue
Post-tested on Ubuntu 16.04, MacOS and PWD to get a broad coverage of scenarios.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
