### PR TITLE
Add exit code 1 for functions that exit with status different than 200 or 202

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -120,7 +121,6 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
   --update     performs a rolling update to a new function image or configuration (default true)`)
 		return fmt.Errorf("cannot specify --update and --replace at the same time")
 	}
-
 	var services stack.Services
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
@@ -140,6 +140,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 		}
 	}
 
+	var failedStatusCodes = make(map[string]int)
 	if len(services.Functions) > 0 {
 
 		if len(services.Provider.Network) == 0 {
@@ -211,8 +212,10 @@ Error: %s`, fprocessErr.Error())
 				Limits:   function.Limits,
 				Requests: function.Requests,
 			}
-
-			proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.RegistryAuth, function.Language, deployFlags.replace, allEnvironment, services.Provider.Network, functionConstraints, deployFlags.update, deployFlags.secrets, allLabels, functionResourceRequest1)
+			statusCode := proxy.DeployFunction(function.FProcess, services.Provider.GatewayURL, function.Name, function.Image, function.RegistryAuth, function.Language, deployFlags.replace, allEnvironment, services.Provider.Network, functionConstraints, deployFlags.update, deployFlags.secrets, allLabels, functionResourceRequest1)
+			if badStatusCode(statusCode) {
+				failedStatusCodes[k] = statusCode
+			}
 		}
 	} else {
 		if len(image) == 0 || len(functionName) == 0 {
@@ -230,10 +233,17 @@ Error: %s`, fprocessErr.Error())
 			gateway = getGatewayURL(gateway, defaultGateway, gateway, os.Getenv(openFaaSURLEnvironment))
 			registryAuth = getRegistryAuth(&dockerConfig, image)
 		}
-
-		if err := deployImage(image, fprocess, functionName, registryAuth, deployFlags); err != nil {
+		err, statusCode := deployImage(image, fprocess, functionName, registryAuth, deployFlags)
+		if err != nil {
 			return err
 		}
+		if badStatusCode(statusCode) {
+			failedStatusCodes[functionName] = statusCode
+		}
+	}
+
+	if err := deployFailed(failedStatusCodes); err != nil {
+		return err
 	}
 
 	return nil
@@ -246,28 +256,29 @@ func deployImage(
 	functionName string,
 	registryAuth string,
 	deployFlags DeployFlags,
-) error {
+) (error, int) {
 
+	var statusCode int
 	envvars, err := parseMap(deployFlags.envvarOpts, "env")
 
 	if err != nil {
-		return fmt.Errorf("error parsing envvars: %v", err)
+		return fmt.Errorf("error parsing envvars: %v", err), statusCode
 	}
 
 	labelMap, labelErr := parseMap(deployFlags.labelOpts, "label")
 
 	if labelErr != nil {
-		return fmt.Errorf("error parsing labels: %v", labelErr)
+		return fmt.Errorf("error parsing labels: %v", labelErr), statusCode
 	}
 
 	functionResourceRequest1 := proxy.FunctionResourceRequest{}
-	proxy.DeployFunction(fprocess, gateway, functionName,
+	statusCode = proxy.DeployFunction(fprocess, gateway, functionName,
 		image, registryAuth, language,
 		deployFlags.replace, envvars, network,
 		deployFlags.constraints, deployFlags.update, deployFlags.secrets,
 		labelMap, functionResourceRequest1)
 
-	return nil
+	return nil, statusCode
 }
 
 func mergeSlice(values []string, overlay []string) []string {
@@ -475,4 +486,21 @@ func getRegistryAuth(config *configFile, image string) string {
 	}
 
 	return ""
+}
+
+func deployFailed(status map[string]int) error {
+	if len(status) == 0 {
+		return nil
+	} else {
+		var allErrors []string
+		for funcName, funcStatus := range status {
+			err := fmt.Errorf("Function '%s' failed to deploy with status code: %d", funcName, funcStatus)
+			allErrors = append(allErrors, err.Error())
+		}
+		return fmt.Errorf(strings.Join(allErrors, "\n"))
+	}
+}
+
+func badStatusCode(statusCode int) bool {
+	return statusCode != http.StatusAccepted && statusCode != http.StatusOK
 }

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -6,6 +6,8 @@ package commands
 import (
 	"net/http"
 	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/openfaas/faas-cli/test"
@@ -112,6 +114,54 @@ func Test_getRegistryAuth_NotRequiredForLocalImage(t *testing.T) {
 
 	if result != "" {
 		t.Errorf("want %s (empty), got %s", wantAuth, result)
+		t.Fail()
+	}
+}
+
+func Test_deployFailed(t *testing.T) {
+
+	var failedDeploy = make(map[string]int)
+	var containedErrorsCount int
+	failedDeploy["example1"] = 100
+	failedDeploy["example2"] = 300
+	failedDeploy["example3"] = 400
+	failedDeploy["example4"] = 500
+	err := deployFailed(failedDeploy)
+	if err == nil {
+		t.Errorf("\nHad to exit with errors!")
+		t.Fail()
+	}
+	for _, theErrorCode := range failedDeploy {
+		if strings.Contains(err.Error(), strconv.Itoa(theErrorCode)) {
+			containedErrorsCount++
+		}
+	}
+	if containedErrorsCount != len(failedDeploy) {
+		t.Errorf("\nWanted: %d number of errors and got: %d!", len(failedDeploy), containedErrorsCount)
+		t.Fail()
+	}
+}
+func Test_deploySucceeded(t *testing.T) {
+	var succededDeploy = make(map[string]int)
+	if err := deployFailed(succededDeploy); err != nil {
+		t.Errorf("\nHad to exit with no errors!")
+		t.Fail()
+	}
+}
+func Test_badStatusCOde(t *testing.T) {
+	okStatusCode := 200
+	if badStatusCode(okStatusCode) {
+		t.Errorf("\nUnexpected status code - wanted:%d OK!", okStatusCode)
+		t.Fail()
+	}
+	acceptedStatusCode := 202
+	if badStatusCode(acceptedStatusCode) {
+		t.Errorf("\nUnexpected status code - wanted:%d Accepted!", acceptedStatusCode)
+		t.Fail()
+	}
+	badStatusC := 300
+	if !(badStatusCode(badStatusC)) {
+		t.Errorf("\nUnexpected status code - wanted: %d but got %d or %d", badStatusC, acceptedStatusCode, okStatusCode)
 		t.Fail()
 	}
 }

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -109,5 +109,6 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	return deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags)
+	err, _ = deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags)
+	return err
 }

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -27,7 +27,7 @@ type FunctionResourceRequest struct {
 func DeployFunction(fprocess string, gateway string, functionName string, image string,
 	registryAuth string, language string, replace bool, envVars map[string]string,
 	network string, constraints []string, update bool, secrets []string,
-	labels map[string]string, functionResourceRequest1 FunctionResourceRequest) {
+	labels map[string]string, functionResourceRequest1 FunctionResourceRequest) int {
 
 	rollingUpdateInfo := fmt.Sprintf("Function %s already exists, attempting rolling-update.", functionName)
 	warnInsecureGateway := true
@@ -37,12 +37,13 @@ func DeployFunction(fprocess string, gateway string, functionName string, image 
 	if update == true && statusCode == http.StatusNotFound {
 		// Re-run the function with update=false
 
-		_, deployOutput = Deploy(fprocess, gateway, functionName, image, registryAuth, language, replace, envVars, network, constraints, false, secrets, labels, functionResourceRequest1, warnInsecureGateway)
+		statusCode, deployOutput = Deploy(fprocess, gateway, functionName, image, registryAuth, language, replace, envVars, network, constraints, false, secrets, labels, functionResourceRequest1, warnInsecureGateway)
 	} else if statusCode == http.StatusOK {
 		fmt.Println(rollingUpdateInfo)
 	}
 	fmt.Println()
 	fmt.Println(deployOutput)
+	return statusCode
 }
 
 // Deploy a function to an OpenFaaS gateway over REST


### PR DESCRIPTION
This commit adds feature that lets faas-cli to exit
with code 1 when function exit with status 200 or 202

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Extends faas-cli functionality to return proper exit status on codes that are 
different than 200 or 202

## Description
<!--- Describe your changes in detail -->

Extends deploy function to return status code and use that to determine
the exit status of the command 1 if the code is different than 200 or 202

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

It references https://github.com/openfaas/faas-cli/issues/443 and https://github.com/openfaas/faas-cli/issues/401

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
When OpenFaas is not deployed and the machine is not part of a swarm
```
$ /home/martindekov/go/src/github.com/openfaas/faas-cli/faas-cli deploy -f long-task.yml
Deploying: long-task.

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: getsockopt: connection refused

Deploying: hello-openfaas.

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: getsockopt: connection refused

Function 'long-task' returned status code: 500
Function 'hello-openfaas' returned status code: 500
$ echo $?
1
```
when faas-cli is not log in.
```
$ /home/martindekov/go/src/github.com/openfaas/faas-cli/faas-cli deploy -f long-task.yml
Deploying: long-task.

unauthorized access, run "faas-cli login" to setup authentication for this server

Deploying: hello-openfaas.

unauthorized access, run "faas-cli login" to setup authentication for this server

Function 'long-task' returned status code: 401
Function 'hello-openfaas' returned status code: 401
martindekov@ubuntu:~/go/src/github.com/openfaas/faas/functions$ echo $?
1
```
in fun.yml file are defined 3 functions which deploy directly from images like:
```
provider:
  name: faas
  gateway: http://127.0.0.1:8080

functions:
  hello-openfaas:
    lang: dockerfile
    handler: ./hello
    image: martindekov/hello-openfaas
  derek:
    lang: go
    handler: ./derek
    image: martindekov/derek
  astronaut-finder:
    lang: python
    handler: ./astronaut-finder
    image: martindekov/astronaut-finder
```
commenting out:```#image: martindekov/derek``` gives:
```
$ /home/martindekov/go/src/github.com/openfaas/faas-cli/faas-cli deploy -f fun.yml
Deploying: hello-openfaas.
Function hello-openfaas already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/hello-openfaas

Deploying: derek.

Unexpected status: 400, message: Update error: Error response from daemon: rpc error: code = InvalidArgument desc = ContainerSpec: image reference must be provided

Deploying: astronaut-finder.
Function astronaut-finder already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/astronaut-finder

Function 'derek' returned status code: 400
$ echo $?
1
```
commenting out ```#image: martindekov/astronaut-finder``` and ```#image:martindekov/derek``` (aka 2 and 3):
```
$ /home/martindekov/go/src/github.com/openfaas/faas-cli/faas-cli deploy -f fun.yml
Deploying: hello-openfaas.
Function hello-openfaas already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/hello-openfaas

Deploying: derek.

Unexpected status: 400, message: Update error: Error response from daemon: rpc error: code = InvalidArgument desc = ContainerSpec: image reference must be provided

Deploying: astronaut-finder.

Unexpected status: 400, message: Update error: Error response from daemon: rpc error: code = InvalidArgument desc = ContainerSpec: image reference must be provided

Function 'derek' returned status code: 400
Function 'astronaut-finder' returned status code: 400
$ echo $?
1
```
and if we comment out ```image: martindekov/hello-openfaas``` and ```image: martindekov/astronaut-finder```(aka 1 and 3) we get:
```
$ /home/martindekov/go/src/github.com/openfaas/faas-cli/faas-cli deploy -f fun.yml
Deploying: hello-openfaas.

Unexpected status: 400, message: Update error: Error response from daemon: rpc error: code = InvalidArgument desc = ContainerSpec: image reference must be provided

Deploying: derek.
Function derek already exists, attempting rolling-update.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/derek

Deploying: astronaut-finder.

Unexpected status: 400, message: Update error: Error response from daemon: rpc error: code = InvalidArgument desc = ContainerSpec: image reference must be provided

Function 'hello-openfaas' returned status code: 400
Function 'astronaut-finder' returned status code: 400
$ echo $?
1
```
scaling down gateway like 
```docker service scale func_gateway=0```
and then deploying directly from image:
```
$ /home/martindekov/go/src/github.com/openfaas/faas-cli/faas-cli deploy --image=martindekov/derek --name=derek

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: getsockopt: connection refused

Function 'derek' failed to deploy with status code: 500
$ echo $?
1
```
The function returns error for every number(status code) except 200 and 202 so I don't think testing for different error codes is necessary.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
