### PR TITLE
Fix registry auth for nested images in custom registry (Gitlab)

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -464,7 +464,7 @@ func getRegistryAuth(config *configFile, image string) string {
 		slashes := strings.Count(image, "/")
 		if slashes > 1 {
 			regS := strings.Split(image, "/")
-			registry = strings.Join(regS[:len(regS)-2], ", ")
+			registry = regS[0]
 		}
 
 		if registry != "" {

--- a/commands/deploy_test.go
+++ b/commands/deploy_test.go
@@ -70,6 +70,22 @@ func Test_getRegistryAuth_CustomRegistry_Found(t *testing.T) {
 	}
 }
 
+func Test_getRegistryAuth_NestedGitlabRegistry_Found(t *testing.T) {
+	wantAuth := "alexellis2-auth-str"
+	configFile1 := configFile{
+		AuthConfigs: map[string]authConfig{
+			"registry.gitlab.com": authConfig{Auth: wantAuth},
+		},
+	}
+
+	result := getRegistryAuth(&configFile1, "registry.gitlab.com/alexellis2/tester/function1")
+
+	if result != wantAuth {
+		t.Errorf("want %s, got %s", wantAuth, result)
+		t.Fail()
+	}
+}
+
 func Test_getRegistryAuth_DockerHub_Found(t *testing.T) {
 	wantAuth := "alexellis2-auth-str"
 	configFile1 := configFile{


### PR DESCRIPTION
## Description
This PR fixes the getRegistryAuth function so that it works correctly with images that exist in subdirs on custom docker registries, for example Gitlab.

Before this change the following image works as expected:

    registry.gitlab.com/johnmccabe/myfunctions

But an image nested under that namespace would fail to find any auth from the docker cached creds, for example this would fail:

    registry.gitlab.com/johnmccabe/myfunctions/coolfn

This fix address the underlying issue in the registry domain extraction so that both cases now work, I've tested with private registries on both Gitlab and Docker Hub successfully.

Have also added a test to catch the nested subdir image case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change (#452)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested **on OSX** with private registry on both Gitlab (hosted), and Docker Hub.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
