### PR TITLE
Removes warning println in version command

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -57,7 +57,6 @@ func runVersion(cmd *cobra.Command, args []string) {
 `, version.GitCommit, version.BuildVersion())
 		printServerVersions()
 	}
-
 }
 
 func printServerVersions() {
@@ -87,7 +86,6 @@ func printServerVersions() {
 
 	response, err := client.Do(req)
 	if err != nil {
-		fmt.Printf("Warning could not contact gateway for version information on %s %s\n", infoEndPoint, err.Error())
 		return
 	}
 


### PR DESCRIPTION
## Description
If the gateway is not reachable when executing the version command do
not log a warning, this is expected behaviour and might be confusing

## Motivation and Context
- [x] I have raised an issue to propose this change #451 

## How Has This Been Tested?
**Current behaviour before this PR, when no gateway is running**
```
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  6c28891cf648621ef120c802d9160cae7506b977
 version: 0.6.14
Warning could not contact gateway for version information on http://127.0.0.1:8080/system/info Get http://127.0.0.1:8080/system/info: dial tcp 127.0.0.1:8080: getsockopt: connection refused
```

**With this PR, Output when no gateway is running**
```
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  d703c207c4cecfdb0cb563daedb569a8c305d239
 version: dev
```
**With this PR, Output when gateway is running**
```
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  d703c207c4cecfdb0cb563daedb569a8c305d239
 version: dev

Gateway
 uri:     http://127.0.0.1:8080
 version: 0.8.5
 sha:     00ad00b651abeaa39dca82d32c26e9246d136951
 commit:  Push gateway image to both Quay.io and Docker Hub


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.3.5 
 sha:           b8cc399b5eadfb59956b8341a44ea3ba4acf1e7f
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
