### PR TITLE
Extend --tag=branch which tags image with branch and sha

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -34,7 +34,23 @@ func BuildImage(image string, handler string, functionName string, language stri
 			format = schema.SHAFormat
 		}
 
-		imageName := schema.BuildImageName(format, image, version, "master")
+		var branch string
+
+		if strings.ToLower(tag) == "branch" {
+			branch = GetGitBranch()
+			if len(branch) == 0 {
+				return fmt.Errorf("cannot tag image with Git branch and SHA as this is not a Git repository")
+
+			}
+			version = GetGitSHA()
+			if len(version) == 0 {
+				return fmt.Errorf("cannot tag image with Git SHA as this is not a Git repository")
+
+			}
+			format = schema.BranchAndSHAFormat
+		}
+
+		imageName := schema.BuildImageName(format, image, version, branch)
 
 		var tempPath string
 

--- a/builder/exec.go
+++ b/builder/exec.go
@@ -48,3 +48,13 @@ func GetGitSHA() string {
 
 	return sha
 }
+
+func GetGitBranch() string {
+	getBranchCommand := []string{"git", "rev-parse", "--symbolic-full-name", "--abbrev-ref", "HEAD"}
+	branch := ExecCommandWithOutput(getBranchCommand, true)
+	if strings.Contains(branch, "Not a git repository") {
+		return ""
+	}
+	branch = strings.TrimSuffix(branch, "\n")
+	return branch
+}

--- a/commands/build.go
+++ b/commands/build.go
@@ -72,6 +72,7 @@ via flags.`,
   faas-cli build -f ./stack.yml --no-cache --build-arg NPM_VERSION=0.2.2
   faas-cli build -f ./stack.yml --build-option dev
   faas-cli build -f ./stack.yml --tag=sha
+  faas-cli build -f ./stack.yml --tag=branch
   faas-cli build -f ./stack.yml --filter "*gif*"
   faas-cli build -f ./stack.yml --regex "fn[0-9]_.*"
   faas-cli build --image=my_image --lang=python --handler=/path/to/fn/ 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -105,6 +105,7 @@ via flags. Note: --replace and --update are mutually exclusive.`,
   faas-cli deploy -f ./stack.yml --replace=false --update=true
   faas-cli deploy -f ./stack.yml --replace=true --update=false
   faas-cli deploy -f ./stack.yml --tag=sha
+  faas-cli deploy -f ./stack.yml --tag=branch
   faas-cli deploy --image=alexellis/faas-url-ping --name=url-ping
   faas-cli deploy --image=my_image --name=my_fn --handler=/path/to/fn/
                   --gateway=http://remote-site.com:8080 --lang=python
@@ -229,8 +230,14 @@ Error: %s`, fprocessErr.Error())
 				sha = builder.GetGitSHA()
 				tagMode = schema.SHAFormat
 			}
+			var branch string
+			if strings.ToLower(tag) == "branch" {
+				branch = builder.GetGitBranch()
+				sha = builder.GetGitSHA()
+				tagMode = schema.BranchAndSHAFormat
+			}
 
-			function.Image = schema.BuildImageName(tagMode, function.Image, sha, "master")
+			function.Image = schema.BuildImageName(tagMode, function.Image, sha, branch)
 
 			if deployFlags.readOnlyRootFilesystem {
 				function.ReadOnlyRootFilesystem = deployFlags.readOnlyRootFilesystem

--- a/commands/push.go
+++ b/commands/push.go
@@ -37,7 +37,8 @@ These container images must already be present in your local image cache.`,
   faas-cli push -f ./stack.yml --parallel 4
   faas-cli push -f ./stack.yml --filter "*gif*"
   faas-cli push -f ./stack.yml --regex "fn[0-9]_.*"
-  faas-cli push -f ./stack.yml --tag=sha`,
+  faas-cli push -f ./stack.yml --tag=sha
+  faas-cli push -f ./stack.yml --tag=branch`,
 	RunE: runPush,
 }
 
@@ -92,8 +93,14 @@ func pushStack(services *stack.Services, queueDepth int, tag string) {
 					sha = builder.GetGitSHA()
 					tagMode = schema.SHAFormat
 				}
+				var branch string
+				if strings.ToLower(tag) == "branch" {
+					branch = builder.GetGitBranch()
+					sha = builder.GetGitSHA()
+					tagMode = schema.BranchAndSHAFormat
+				}
 
-				imageName := schema.BuildImageName(tagMode, function.Image, sha, "master")
+				imageName := schema.BuildImageName(tagMode, function.Image, sha, branch)
 
 				fmt.Printf(aec.YellowF.Apply("[%d] > Pushing %s [%s].\n"), index, function.Name, imageName)
 				if len(function.Image) == 0 {


### PR DESCRIPTION
With this commit the --tag is extended to include branch argument
which tags image not only with sha but branch-sha

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Extend the --tag with branch feature which tags image with branch and sha.

## Description
<!--- Describe your changes in detail -->

Added checks to see the --tag argument if its branch it calls not only
GetGitSha, but also new function which checks the branch we are in.
If we are not in a repo it fails and if we are in a repo it gets the branch
and adds it to the image name name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This references https://github.com/openfaas/faas-cli/issues/463.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by building pushing and deploying image with my change.
Example pushed images are found in this docker hub repo:
https://hub.docker.com/r/martindekov/gofun/tags/
Adding ```image:<example name>:<example replacement of latest>```
to check if latest will be appended in case the replacement exists.
Tried do build when not in a git repo with ```--tag=branch``` it returned error
```2018/07/24 02:09:14 ERROR - Could not execute command: [docker build -t martindekov/gofun:0.2-fatal: not a git repository (or any of the parent directories): .git-fatal: not a git repository (or any of the parent directories): .git .]```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
