### PR TITLE
Fix a possible race between wg.Add and wg.Wait

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -170,9 +170,9 @@ func build(services *stack.Services, queueDepth int, shrinkwrap bool) {
 
 	workChannel := make(chan stack.Function)
 
+	wg.Add(queueDepth)
 	for i := 0; i < queueDepth; i++ {
 		go func(index int) {
-			wg.Add(1)
 			for function := range workChannel {
 				fmt.Printf(aec.YellowF.Apply("[%d] > Building %s.\n"), index, function.Name)
 				if len(function.Language) == 0 {

--- a/commands/push.go
+++ b/commands/push.go
@@ -82,9 +82,9 @@ func pushStack(services *stack.Services, queueDepth int, tag string) {
 
 	workChannel := make(chan stack.Function)
 
+	wg.Add(queueDepth)
 	for i := 0; i < queueDepth; i++ {
 		go func(index int) {
-			wg.Add(1)
 			for function := range workChannel {
 				tagMode := schema.DefaultFormat
 				var sha string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Invoking WaitGroup.Add() from a go routine can cause a race between it and
WaitGroup.Wait(). Add should always be invoked from the same context as Wait.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #469 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Not tested yet.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
