### PR TITLE
Add `generate` command to create CRD YAML files

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -1,4 +1,4 @@
-// Copyright (c) OpenFaaS Author(s) 2017. All rights reserved.
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 package commands

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -1,0 +1,147 @@
+// Copyright (c) OpenFaaS Author(s) 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/openfaas/faas-cli/builder"
+	"github.com/openfaas/faas-cli/schema"
+	"github.com/openfaas/faas-cli/stack"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+	defaultFunctionNamespace = "openfaas-fn"
+	resourceKind             = "Function"
+	defaultAPIVersion        = "openfaas.com/v1alpha2"
+)
+
+var (
+	api               string
+	functionNamespace string
+)
+
+func init() {
+	generateCmd.Flags().StringVar(&api, "api", defaultAPIVersion, "OpenFaaS CRD API version")
+	generateCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", defaultFunctionNamespace, "Kubernetes namespace for functions")
+	generateCmd.Flags().StringVar(&tag, "tag", "file", "Tag Docker image for function, specify file or SHA")
+	faasCmd.AddCommand(generateCmd)
+}
+
+var generateCmd = &cobra.Command{
+	Use:   "generate --api=openfaas.com/v1alpha2 --yaml stack.yml --tag=sha --namespace=openfaas-fn",
+	Short: "Generate Kubernetes CRD YAML file",
+	Long:  `The generate command creates kubernetes CRD YAML file for functions`,
+	Example: `faas-cli generate --api=openfaas.com/v1alpha2 --yaml stack.yml | kubectl apply  -f -
+faas-cli generate --api=openfaas.com/v1alpha2 -f stack.yml
+faas-cli generate --api=openfaas.com/v1alpha2 --namespace openfaas-fn -f stack.yml
+faas-cli generate --api=openfaas.com/v1alpha2 -f stack.yml --tag=sha -n openfaas-fn`,
+	PreRunE: preRunGenerate,
+	RunE:    runGenerate,
+}
+
+func preRunGenerate(cmd *cobra.Command, args []string) error {
+	if len(api) == 0 {
+		return fmt.Errorf("You must supply api version with the --api flag")
+	}
+	return nil
+}
+
+func runGenerate(cmd *cobra.Command, args []string) error {
+
+	var services stack.Services
+
+	//Process function stack file
+	if len(yamlFile) > 0 {
+		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
+		if err != nil {
+			return err
+		}
+
+		if parsedServices != nil {
+			services = *parsedServices
+		}
+	}
+
+	format := schema.DefaultFormat
+	var version string
+	var branch string
+
+	if strings.ToLower(tag) == "sha" {
+		version = builder.GetGitSHA()
+		if len(version) == 0 {
+			return fmt.Errorf("cannot tag image with Git SHA as this is not a Git repository")
+
+		}
+		format = schema.SHAFormat
+	}
+
+	if strings.ToLower(tag) == "branch" {
+		branch = builder.GetGitBranch()
+		if len(branch) == 0 {
+			return fmt.Errorf("cannot tag image with Git branch and SHA as this is not a Git repository")
+
+		}
+		version = builder.GetGitSHA()
+		if len(version) == 0 {
+			return fmt.Errorf("cannot tag image with Git SHA as this is not a Git repository")
+
+		}
+		format = schema.BranchAndSHAFormat
+	}
+
+	var objectsString string
+
+	if len(services.Functions) > 0 {
+		for name, function := range services.Functions {
+			//read environment variables from the file
+			fileEnvironment, err := readFiles(function.EnvironmentFile)
+			if err != nil {
+				return err
+			}
+
+			//combine all environment variables
+			allEnvironment, envErr := compileEnvironment([]string{}, function.Environment, fileEnvironment)
+			if envErr != nil {
+				return envErr
+			}
+
+			metadata := schema.Metadata{Name: name, Namespace: functionNamespace}
+			imageName := schema.BuildImageName(format, function.Image, version, branch)
+
+			spec := schema.Spec{
+				Name:        name,
+				Image:       imageName,
+				Environment: allEnvironment,
+				Labels:      function.Labels,
+				Limits:      function.Limits,
+				Requests:    function.Requests,
+				Constraints: function.Constraints,
+				Secrets:     function.Secrets,
+			}
+
+			crd := schema.CRD{
+				APIVersion: api,
+				Kind:       resourceKind,
+				Metadata:   metadata,
+				Spec:       spec,
+			}
+
+			//Marshal the object definition to yaml
+			objectString, err := yaml.Marshal(crd)
+			if err != nil {
+				return err
+			}
+			objectsString += "---\n" + string(objectString)
+		}
+	}
+
+	if len(objectsString) > 0 {
+		fmt.Println(objectsString)
+	}
+	return nil
+}

--- a/schema/crd.go
+++ b/schema/crd.go
@@ -1,0 +1,45 @@
+// Copyright (c) OpenFaaS Author(s) 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package schema
+
+import "github.com/openfaas/faas-cli/stack"
+
+//Metadata metadata of the object
+type Metadata struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
+//Spec describe characteristics of the object
+type Spec struct {
+	//Name name of the function
+	Name string `yaml:"name"`
+	//Image docker image name of the function
+	Image string `yaml:"image"`
+
+	Environment map[string]string `yaml:"environment,omitempty"`
+
+	Labels *map[string]string `yaml:"labels,omitempty"`
+
+	//Limits for the function
+	Limits *stack.FunctionResources `yaml:"limits,omitempty"`
+
+	//Requests of resources requested by function
+	Requests *stack.FunctionResources `yaml:"requests,omitempty"`
+
+	Constraints *[]string `yaml:"constraints,omitempty"`
+
+	//Secrets list of secrets to be made available to function
+	Secrets []string `yaml:"secrets,omitempty"`
+}
+
+//CRD root level YAML definition for the object
+type CRD struct {
+	//APIVersion CRD API version
+	APIVersion string `yaml:"apiVersion"`
+	//Kind kind of the object
+	Kind     string   `yaml:"kind"`
+	Metadata Metadata `yaml:"metadata"`
+	Spec     Spec     `yaml:"spec"`
+}

--- a/schema/crd.go
+++ b/schema/crd.go
@@ -1,4 +1,4 @@
-// Copyright (c) OpenFaaS Author(s) 2017. All rights reserved.
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 package schema
@@ -8,7 +8,7 @@ import "github.com/openfaas/faas-cli/stack"
 //Metadata metadata of the object
 type Metadata struct {
 	Name      string `yaml:"name"`
-	Namespace string `yaml:"namespace"`
+	Namespace string `yaml:"namespace,omitempty"`
 }
 
 //Spec describe characteristics of the object


### PR DESCRIPTION
This commit adds new subcommand `generate` faas-cli which can be used to
generate YAML file definition for Kubernetes CRD.

Output of this command can be piped to `kubectl` to apply to
Kubernetes cluster.

Usage: `faas-cli generate --api=openfaas.com/v1alpha2 --yaml fn-1.yml |
kubectl apply  -f -`

Fixes: #426

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

issue created by @alexellis  #426 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested on local kubernetes cluster with OpenFaaS operator. 

```sh
functions cat issue-bot.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080

functions:
  issue-bot:
    lang: python3
    handler: ./issue-bot
    image: viveksyngh/issue-bot
    environment_file:
    - env.yml
➜  functions /Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli generate --api=openfaas.com/v1alpha2 --yaml=issue-bot.yml
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: issue-bot
  namespace: openfaas-fn
spec:
  name: issue-bot
  image: viveksyngh/issue-bot
  environment:
    auth_token: <something secret>
    write_debug: "true"

---

➜  functions /Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli generate --api=openfaas.com/v1alpha2 --yaml=issue-bot.yml | kubectl apply -f -
function.openfaas.com "issue-bot" configured
➜  functions kubectl get functions -n openfaas-fn
NAME        AGE
issue-bot   8m
```
```
cat stack.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080

functions:
  dnd-info:
    lang: go
    handler: ./dnd-info
    image: viveksyngh/dnd-info
    environment:
      combine_output: false
    environment_file:
    - env.yml
    secrets:
      - slack-secrets

  end-dnd:
    lang: go
    handler: ./end-dnd
    image: viveksyngh/end-dnd
    environment:
      combine_output: false
    environment_file:
    - env.yml
    secrets:
      - slack-secrets

  set-snooze:
    lang: go
    handler: ./set-snooze
    image: viveksyngh/set-snooze
    environment:
      combine_output: false
    environment_file:
    - env.yml
    secrets:
      - slack-secrets

  end-snooze:
    lang: go
    handler: ./end-snooze
    image: viveksyngh/end-snooze
    environment:
      combine_output: false
    environment_file:
    - env.yml
    secrets:
      - slack-secrets

  api-webhook:
    lang: go
    handler: ./api-webhook
    image: viveksyngh/api-webhook
    environment:
      combine_output: false
      gateway_url: "http://gateway.openfaas:8080"

/Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli generate --api=openfaas.com/v1alpha2

apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: dnd-info
  namespace: openfaas-fn
spec:
  name: dnd-info
  image: viveksyngh/dnd-info
  environment:
    combine_output: "false"
    slack_token: <secret_token>
  secrets:
  - slack-secrets

---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: end-dnd
  namespace: openfaas-fn
spec:
  name: end-dnd
  image: viveksyngh/end-dnd
  environment:
    combine_output: "false"
    slack_token: <secret_token>
  secrets:
  - slack-secrets

---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: set-snooze
  namespace: openfaas-fn
spec:
  name: set-snooze
  image: viveksyngh/set-snooze
  environment:
    combine_output: "false"
    slack_token: <secret_token>
  secrets:
  - slack-secrets

---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: end-snooze
  namespace: openfaas-fn
spec:
  name: end-snooze
  image: viveksyngh/end-snooze
  environment:
    combine_output: "false"
    slack_token: <secret_token>
  secrets:
  - slack-secrets

---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: api-webhook
  namespace: openfaas-fn
spec:
  name: api-webhook
  image: viveksyngh/api-webhook
  environment:
    combine_output: "false"
    gateway_url: http://gateway.openfaas:8080

---

slack-dnd-openfaas git:(master) /Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli generate --api=openfaas.com/v1alpha2  | kubectl apply -f -
function.openfaas.com "dnd-info" created
function.openfaas.com "end-dnd" created
function.openfaas.com "set-snooze" created
function.openfaas.com "end-snooze" created
function.openfaas.com "api-webhook" created
```

Steps for testing. 

Install Helm. 
```
brew install kubernetes-helm
kubectl -n kube-system create sa tiller

kubectl create clusterrolebinding tiller-cluster-rule \
    --clusterrole=cluster-admin \
    --serviceaccount=kube-system:tiller 

helm init --skip-refresh --upgrade --service-account tiller
```

Install OpenFaaS operator with helm.
```
kubectl apply -f https://raw.githubusercontent.com/openfaas/faas-netes/master/namespaces.yml

password=$(head -c 12 /dev/urandom | shasum | cut -d' ' -f1)

kubectl -n openfaas create secret generic basic-auth \
--from-literal=basic-auth-user=admin \
--from-literal=basic-auth-password=$password

helm repo add openfaas https://openfaas.github.io/faas-netes/


helm upgrade openfaas --install openfaas/openfaas \
    --namespace openfaas  \
    --set functionNamespace=openfaas-fn \
    --set serviceType=LoadBalancer \
    --set basic_auth=true \
    --set operator.create=true
```

Then use `faas-cli generate` command to deploy already existing functions with stack.yml to kubernetes cluster with OpenFaaS Operator.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
