### PR TITLE
Extend last PR to make store deploy return proper status code

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -110,6 +110,13 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	_, err = deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure)
+	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure)
+
+	if badStatusCode(statusCode) {
+		failedStatusCode := map[string]int{itemName: statusCode}
+		err := deployFailed(failedStatusCode)
+		return err
+	}
+
 	return err
 }


### PR DESCRIPTION
Bubble up store deploy to return 1 when deploy failed through
store deploy command

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Small change that handles the store deploy return code.

## Description
<!--- Describe your changes in detail -->

Bubble up the error to handle bad status codes in store deploy, like in deploy command.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

This is the issue https://github.com/openfaas/faas-cli/issues/473.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

When didn't gave credentials to the cli
```
$ faas-cli store deploy figlet

unauthorized access, run "faas-cli login" to setup authentication for this server

Function 'figlet' failed to deploy with status code: 401
$ echo $?
1
```
```docker service scale func_gateway=0```
```
$ faas-cli store deploy figlet

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: getsockopt: connection refused

Function 'figlet' failed to deploy with status code: 500
$ echo $?
1
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
