### PR TITLE
[WIP] Fixes issue with faas-cli build for same folder

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -5,6 +5,7 @@ package builder
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
@@ -156,7 +157,21 @@ func createBuildTemplate(functionName string, handler string, language string) s
 	CopyFiles("./template/"+language, tempPath)
 
 	// Overlay in user-function
-	CopyFiles(handler, functionPath)
+	// CopyFiles(handler, functionPath)
+	infos, readErr := ioutil.ReadDir(handler)
+	if readErr != nil {
+		fmt.Printf("Error reading the handler %s - %s.\n", handler, readErr.Error())
+	}
+
+	for _, info := range infos {
+		switch info.Name() {
+		case "build":
+			fmt.Println("Skipping \"build\" folder")
+			continue
+		default:
+			CopyFiles(info.Name(), functionPath)
+		}
+	}
 
 	return tempPath
 }
@@ -177,7 +192,21 @@ func dockerBuildFolder(functionName string, handler string, language string) str
 		language = "dockerfile"
 	}
 
-	CopyFiles(handler, tempPath)
+	// CopyFiles(handler, tempPath)
+	infos, readErr := ioutil.ReadDir(handler)
+	if readErr != nil {
+		fmt.Printf("Error reading the handler %s - %s.\n", handler, readErr.Error())
+	}
+
+	for _, info := range infos {
+		switch info.Name() {
+		case "build":
+			fmt.Println("Skipping \"build\" folder")
+			continue
+		default:
+			CopyFiles(info.Name(), tempPath)
+		}
+	}
 
 	return tempPath
 }


### PR DESCRIPTION
This change skips copy for `build` folder in copyDir
function to avoid the recursion while copying files.

Fixes: #478

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Issue #478 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested on my local system.

```
 kph-demo ls
handler.py       kph-demo.yml     requirements.txt
➜  kph-demo /Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli build -f kph-demo.yml
2018/07/27 23:07:17 No templates found in current directory.
2018/07/27 23:07:17 Attempting to expand templates from https://github.com/openfaas/templates.git
2018/07/27 23:07:21 Fetched 13 template(s) : [csharp dockerfile go go-armhf java8 node node-arm64 node-armhf python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates.git
[0] > Building kph-demo.
Clearing temporary build folder: ./build/kph-demo/
Preparing ./ ./build/kph-demo/function
Building: viveksyngh/kph-demo:latest with python template. Please wait..
Sending build context to Docker daemon  8.704kB
Step 1/24 : FROM python:2.7-alpine
 ---> 0781c116c406
Step 2/24 : ARG ADDITIONAL_PACKAGE
 ---> Running in 633e6678a9e5
Removing intermediate container 633e6678a9e5
 ---> d4bd332dbbfb
Step 3/24 : RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE}     && echo "Pulling watchdog binary from Github."     && curl -sSL https://github.com/openfaas/faas/releases/download/0.8.9/fwatchdog > /usr/bin/fwatchdog     && chmod +x /usr/bin/fwatchdog     && apk del curl --no-cache
 ---> Running in df79e6de5e25
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/3) Installing libssh2 (1.7.0-r0)
(2/3) Installing libcurl (7.59.0-r0)
(3/3) Installing curl (7.59.0-r0)
Executing busybox-1.24.2-r14.trigger
OK: 32 MiB in 35 packages
Pulling watchdog binary from Github.
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.4/community/x86_64/APKINDEX.tar.gz
(1/3) Purging curl (7.59.0-r0)
(2/3) Purging libcurl (7.59.0-r0)
(3/3) Purging libssh2 (1.7.0-r0)
Executing busybox-1.24.2-r14.trigger
OK: 31 MiB in 32 packages
Removing intermediate container df79e6de5e25
 ---> b13b744a1290
Step 4/24 : RUN addgroup -S app && adduser app -S -G app
 ---> Running in b4b41dbb0bb3
Removing intermediate container b4b41dbb0bb3
 ---> cee8f4699c4d
Step 5/24 : RUN chown app /home/app
 ---> Running in 588da43ebc92
Removing intermediate container 588da43ebc92
 ---> 725d13bc79d3
Step 6/24 : USER app
 ---> Running in 89ec51e01629
Removing intermediate container 89ec51e01629
 ---> a6d9ae264c91
Step 7/24 : ENV PATH=$PATH:/home/app/.local/bin
 ---> Running in 7a1a68f955a7
Removing intermediate container 7a1a68f955a7
 ---> 1f99144dca6e
Step 8/24 : WORKDIR /home/app/
Removing intermediate container de30e53a8b62
 ---> d534dfa14951
Step 9/24 : COPY index.py           .
 ---> 4c152150054b
Step 10/24 : COPY requirements.txt   .
 ---> d4f499deda80
Step 11/24 : RUN pip install -r requirements.txt
 ---> Running in 92779eb476f7
You must give at least one requirement to install (see "pip help install")
You are using pip version 9.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Removing intermediate container 92779eb476f7
 ---> 7e8a619019bb
Step 12/24 : RUN mkdir -p function
 ---> Running in 7819c9940d7a
Removing intermediate container 7819c9940d7a
 ---> 1f07d1b2b2b4
Step 13/24 : RUN touch ./function/__init__.py
 ---> Running in 1a8b9f6c2636
Removing intermediate container 1a8b9f6c2636
 ---> 43f554d28068
Step 14/24 : WORKDIR /home/app/function/
Removing intermediate container 27811bbbc32a
 ---> 43f24d1a51c1
Step 15/24 : COPY function/requirements.txt	.
 ---> 289f72a1fa55
Step 16/24 : RUN pip install --user -r requirements.txt
 ---> Running in 7f922632372b
You must give at least one requirement to install (see "pip help install")
You are using pip version 9.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Removing intermediate container 7f922632372b
 ---> 32ae90ad70ce
Step 17/24 : WORKDIR /home/app/
Removing intermediate container 8928e4a6aef0
 ---> 7d68f6d10f76
Step 18/24 : USER root
 ---> Running in 6b3c8680ee66
Removing intermediate container 6b3c8680ee66
 ---> 5a9e8d3cfe19
Step 19/24 : COPY function           function
 ---> e8677f3ea6e8
Step 20/24 : RUN chown -R app:app ./
 ---> Running in 5425757cf67e
Removing intermediate container 5425757cf67e
 ---> b11c6b609dcc
Step 21/24 : USER app
 ---> Running in b6a7e166d2b5
Removing intermediate container b6a7e166d2b5
 ---> 898c5429e3c6
Step 22/24 : ENV fprocess="python index.py"
 ---> Running in 3dbf95892026
Removing intermediate container 3dbf95892026
 ---> 9e7455c29672
Step 23/24 : HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 ---> Running in a9e84dea8323
Removing intermediate container a9e84dea8323
 ---> ade9cb1ab207
Step 24/24 : CMD ["fwatchdog"]
 ---> Running in 9b2032b69f1d
Removing intermediate container 9b2032b69f1d
 ---> d55dc99e7584
Successfully built d55dc99e7584
Successfully tagged viveksyngh/kph-demo:latest
Image: viveksyngh/kph-demo:latest built.
[0] < Building kph-demo done.
[0] worker done.
```

```
test-function ls
template          test-function     test-function.yml
➜  test-function faas-cli build -f test-function.yml
[0] > Building test-function.
Clearing temporary build folder: ./build/test-function/
Preparing ./test-function/ ./build/test-function/function
Building: test-function with python3 template. Please wait..
Sending build context to Docker daemon  8.704kB
Step 1/24 : FROM python:3-alpine
 ---> 5be6d36f77ee
Step 2/24 : ARG ADDITIONAL_PACKAGE
 ---> Running in 4ba5093ec539
Removing intermediate container 4ba5093ec539
 ---> c928ab9ced53
Step 3/24 : RUN apk --no-cache add curl ${ADDITIONAL_PACKAGE}     && echo "Pulling watchdog binary from Github."     && curl -sSL https://github.com/openfaas/faas/releases/download/0.8.9/fwatchdog > /usr/bin/fwatchdog     && chmod +x /usr/bin/fwatchdog     && apk del curl --no-cache
 ---> Running in fdb7fe7a2f8e
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
(1/3) Installing libssh2 (1.8.0-r2)
(2/3) Installing libcurl (7.61.0-r0)
(3/3) Installing curl (7.61.0-r0)
Executing busybox-1.27.2-r7.trigger
OK: 33 MiB in 46 packages
Pulling watchdog binary from Github.
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
(1/3) Purging curl (7.61.0-r0)
(2/3) Purging libcurl (7.61.0-r0)
(3/3) Purging libssh2 (1.8.0-r2)
Executing busybox-1.27.2-r7.trigger
OK: 32 MiB in 43 packages
Removing intermediate container fdb7fe7a2f8e
 ---> 2280424e40d9
Step 4/24 : RUN addgroup -S app && adduser app -S -G app
 ---> Running in 69f5aae705f8
Removing intermediate container 69f5aae705f8
 ---> 86b6e76e05bf
Step 5/24 : WORKDIR /home/app/
Removing intermediate container d15ca761e703
 ---> ea2b1ff7a265
Step 6/24 : COPY index.py           .
 ---> 7225fea22f7a
Step 7/24 : COPY requirements.txt   .
 ---> 873850675324
Step 8/24 : RUN chown -R app /home/app
 ---> Running in d56c6cdcd77f
Removing intermediate container d56c6cdcd77f
 ---> 32bfe66bac21
Step 9/24 : USER app
 ---> Running in a0cb25e4caf8
Removing intermediate container a0cb25e4caf8
 ---> b6cf8f9f87a7
Step 10/24 : ENV PATH=$PATH:/home/app/.local/bin
 ---> Running in effbb2c5aefb
Removing intermediate container effbb2c5aefb
 ---> 59f4dcecd8bd
Step 11/24 : RUN pip install --user -r requirements.txt
 ---> Running in 8ef03835d2eb
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Removing intermediate container 8ef03835d2eb
 ---> ae15c806a03e
Step 12/24 : RUN mkdir -p function
 ---> Running in c64a6b5b2dc8
Removing intermediate container c64a6b5b2dc8
 ---> 39faf07863cf
Step 13/24 : RUN touch ./function/__init__.py
 ---> Running in 787ccf4c2796
Removing intermediate container 787ccf4c2796
 ---> 39c77f528540
Step 14/24 : WORKDIR /home/app/function/
Removing intermediate container 0bb2724af746
 ---> 943e325d0a20
Step 15/24 : COPY function/requirements.txt	.
 ---> 8bcbc7c6b55c
Step 16/24 : RUN pip install --user -r requirements.txt
 ---> Running in 29d353745889
You are using pip version 10.0.1, however version 18.0 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Removing intermediate container 29d353745889
 ---> e901b25305b8
Step 17/24 : WORKDIR /home/app/
Removing intermediate container e2490144c1a1
 ---> 71ee679af597
Step 18/24 : USER root
 ---> Running in 046a508bf027
Removing intermediate container 046a508bf027
 ---> cf857cb0de0f
Step 19/24 : COPY function           function
 ---> 64f08b7c0dc1
Step 20/24 : RUN chown -R app:app ./
 ---> Running in 3650c0c82af7
Removing intermediate container 3650c0c82af7
 ---> e6391dd1dcb6
Step 21/24 : USER app
 ---> Running in 305fa68591a6
Removing intermediate container 305fa68591a6
 ---> 141c55bc3a2d
Step 22/24 : ENV fprocess="python3 index.py"
 ---> Running in 66668dea9626
Removing intermediate container 66668dea9626
 ---> 467c2ab9cc8e
Step 23/24 : HEALTHCHECK --interval=1s CMD [ -e /tmp/.lock ] || exit 1
 ---> Running in 2e967b1372f6
Removing intermediate container 2e967b1372f6
 ---> be7a6130f530
Step 24/24 : CMD ["fwatchdog"]
 ---> Running in a505889956ad
Removing intermediate container a505889956ad
 ---> c9e46bcf335d
Successfully built c9e46bcf335d
Successfully tagged test-function:latest
Image: test-function built.
[0] < Building test-function done.
[0] worker done.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
