### PR TITLE
Implement read-only root file system for store deploy command

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -110,7 +110,15 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure)
+	statusCode, err := deployImage(
+		item.Image,
+		item.Fprocess,
+		itemName,
+		registryAuth,
+		storeDeployFlags,
+		tlsInsecure,
+		item.ReadOnlyRootFilesystem,
+	)
 
 	if badStatusCode(statusCode) {
 		failedStatusCode := map[string]int{itemName: statusCode}

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 
 	"github.com/openfaas/faas-cli/test"
+	"github.com/openfaas/faas/gateway/requests"
 )
 
 const tlsNoVerify = true
@@ -31,24 +32,27 @@ func runDeployProxyTest(t *testing.T, deployTest deployProxyTest) {
 	)
 	defer s.Close()
 
+	req := requests.CreateFunctionRequest{
+		EnvProcess:             "fprocess",
+		Image:                  "image",
+		RegistryAuth:           "dXNlcjpwYXNzd29yZA==",
+		Network:                "network",
+		Service:                "function",
+		EnvVars:                nil,
+		Constraints:            []string{},
+		Secrets:                []string{},
+		Labels:                 &map[string]string{},
+		Annotations:            &map[string]string{},
+		ReadOnlyRootFilesystem: false,
+	}
 	stdout := test.CaptureStdout(func() {
 		DeployFunction(
-			"fproces",
+			req,
 			s.URL,
-			"function",
-			"image",
-			"dXNlcjpwYXNzd29yZA==",
 			"language",
 			deployTest.replace,
-			nil,
-			"network",
-			[]string{},
 			deployTest.update,
-			[]string{},
-			map[string]string{},
-			map[string]string{},
 			FunctionResourceRequest{},
-			false,
 			tlsNoVerify,
 		)
 	})
@@ -93,24 +97,27 @@ func Test_RunDeployProxyTests(t *testing.T) {
 func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 	url := "127.0.0.1:8080"
 
+	req := requests.CreateFunctionRequest{
+		EnvProcess:             "fprocess",
+		Image:                  "image",
+		RegistryAuth:           "dXNlcjpwYXNzd29yZA==",
+		Network:                "network",
+		Service:                "function",
+		EnvVars:                nil,
+		Constraints:            []string{},
+		Secrets:                []string{},
+		Labels:                 &map[string]string{},
+		Annotations:            &map[string]string{},
+		ReadOnlyRootFilesystem: false,
+	}
 	stdout := test.CaptureStdout(func() {
 		DeployFunction(
-			"fprocess",
+			req,
 			url,
-			"function",
-			"image",
-			"dXNlcjpwYXNzd29yZA==",
 			"language",
 			false,
-			nil,
-			"network",
-			[]string{},
 			false,
-			[]string{},
-			map[string]string{},
-			map[string]string{},
 			FunctionResourceRequest{},
-			false,
 			tlsNoVerify,
 		)
 	})

--- a/schema/store_item.go
+++ b/schema/store_item.go
@@ -2,14 +2,15 @@ package schema
 
 // StoreItem represents an item of store
 type StoreItem struct {
-	Icon        string            `json:"icon"`
-	Title       string            `json:"title"`
-	Description string            `json:"description"`
-	Image       string            `json:"image"`
-	Name        string            `json:"name"`
-	Fprocess    string            `json:"fprocess"`
-	Network     string            `json:"network"`
-	RepoURL     string            `json:"repo_url"`
-	Environment map[string]string `json:"environment"`
-	Labels      map[string]string `json:"labels"`
+	Icon                   string            `json:"icon"`
+	Title                  string            `json:"title"`
+	Description            string            `json:"description"`
+	Image                  string            `json:"image"`
+	Name                   string            `json:"name"`
+	Fprocess               string            `json:"fprocess"`
+	Network                string            `json:"network"`
+	RepoURL                string            `json:"repo_url"`
+	Environment            map[string]string `json:"environment"`
+	Labels                 map[string]string `json:"labels"`
+	ReadOnlyRootFilesystem bool              `json:"readOnlyRootFilesystem"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Add read only feature to `store deploy` command.

## Description
<!--- Describe your changes in detail -->

Currently, the `store deploy` command is not including `readOnlyRootFilesystem` from the store functions. The following change will implement this feature for the command, while also cleaning up the deploy methods to allow for easier maintenance and additions.

Fixes: #490

Signed-off-by: James Smith <jamessmithsmusic@gmail.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

References [[#490](https://github.com/openfaas/faas-cli/issues/490)].

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests ran successfully.

Verified read-only root file system of store functions by the following steps :

- Set up Docker Swarm
- Pull a RO function (ex. `Figlet`)
- Validate RO RFS with the following commands
```
$ docker inspect <CONTAINER_ID> --format {{.HostConfig.ReadonlyRootfs}}
true
$ docker exec -it <CONTAINER_ID> sh
~ $ touch hello.txt
touch: hello.txt: Read-only file system
~ $ touch /tmp/what-about-here
~ $
```

In addition, verified non-read-only root file system of store functions by the following steps :

- Set up Docker Swarm
- Pull a non-RO function (ex. `mememachine`)
- Validate non-RO RFS with the following commands
```
$ docker inspect <CONTAINER_ID> --format {{.HostConfig.ReadonlyRootfs}}
false
$ docker exec -it <CONTAINER_ID> sh
~ # touch hello.txt
~ #
```

Existing functionality with the standard deploy has also been verified by the following steps :

- Set up Docker Swarm
- Deploy function
- Validate RO RFS with the following commands
```
$ docker inspect <CONTAINER_ID> --format {{.HostConfig.ReadonlyRootfs}}
false
$ docker exec -it <CONTAINER_ID> sh
~ # touch hello.txt
~ #
```
- Deploy function with `--readonly` flag
- Validate RO RFS with the following commands
```
$ docker inspect <CONTAINER_ID> --format {{.HostConfig.ReadonlyRootfs}}
true
$ docker exec -it <CONTAINER_ID> sh
~ $ touch hello.txt
touch: hello.txt: Read-only file system
~ $ touch /tmp/what-about-here
~ $
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
  - Modified current tests to satisfy.
- [x] All new and existing tests passed.