### PR TITLE
Add unit tests for generate command

### DIFF
--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+package commands
+
+import (
+	"testing"
+
+	"github.com/openfaas/faas-cli/schema"
+
+	"github.com/openfaas/faas-cli/stack"
+)
+
+var generateTestcases = []struct {
+	Name       string
+	Input      string
+	Output     string
+	Format     schema.BuildFormat
+	APIVersion string
+	Namespace  string
+	Branch     string
+	Version    string
+}{
+	{
+		Name: "Default Namespace and API Version",
+		Input: `
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"      
+functions:
+ url-ping:
+   lang: python
+   handler: ./sample/url-ping
+   image: alexellis/faas-url-ping:0.2`,
+		Output: `---
+apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: url-ping
+  namespace: openfaas-fn
+spec:
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+`,
+		Format:     schema.DefaultFormat,
+		APIVersion: "openfaas.com/v1alpha2",
+		Namespace:  "openfaas-fn",
+		Branch:     "",
+		Version:    "",
+	},
+
+	{
+		Name: "Blank namespace",
+		Input: `
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"
+functions:
+ url-ping:
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2`,
+		Output: `---
+apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: url-ping
+spec:
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+`,
+		Format:     schema.DefaultFormat,
+		APIVersion: "openfaas.com/v1alpha2",
+		Namespace:  "",
+		Branch:     "",
+		Version:    "",
+	},
+	{
+		Name: "BranchAndSHA Image format",
+		Input: `
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"
+functions:
+ url-ping:
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2`,
+		Output: `---
+apiVersion: openfaas.com/v1alpha2
+kind: Function
+metadata:
+  name: url-ping
+  namespace: openfaas-function
+spec:
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2-master-6bgf36qd
+`,
+		Format:     schema.BranchAndSHAFormat,
+		APIVersion: "openfaas.com/v1alpha2",
+		Namespace:  "openfaas-function",
+		Branch:     "master",
+		Version:    "6bgf36qd",
+	},
+	{
+		Name: "Multiple functions",
+		Input: `
+provider:
+  name: faas
+  gateway: http://127.0.0.1:8080  
+  network: "func_functions"
+functions:
+ url-ping:
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2
+ astronaut-finder:
+  lang: python3
+  handler: ./astronaut-finder
+  image: astronaut-finder
+  environment:
+   write_debug: true`,
+		Output: `---
+apiVersion: openfaas.com/v2alpha2
+kind: Function
+metadata:
+  name: url-ping
+  namespace: openfaas-fn
+spec:
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+---
+apiVersion: openfaas.com/v2alpha2
+kind: Function
+metadata:
+  name: astronaut-finder
+  namespace: openfaas-fn
+spec:
+  name: astronaut-finder
+  image: astronaut-finder:latest
+  environment:
+    write_debug: "true"
+`,
+		Format:     schema.DefaultFormat,
+		APIVersion: "openfaas.com/v2alpha2",
+		Namespace:  "openfaas-fn",
+		Branch:     "",
+		Version:    "",
+	},
+}
+
+func Test_generateCRDYAML(t *testing.T) {
+
+	for _, testcase := range generateTestcases {
+		parsedServices, err := stack.ParseYAMLData([]byte(testcase.Input), "", "")
+
+		if err != nil {
+			t.Fatalf("%s failed: error while parsing the input data.", testcase.Name)
+		}
+
+		if parsedServices == nil {
+			t.Fatalf("%s failed: empty input file", testcase.Name)
+		}
+		services := *parsedServices
+
+		generatedYAML, err := generateCRDYAML(services, testcase.Format, testcase.APIVersion, testcase.Namespace, testcase.Branch, testcase.Version)
+		if err != nil {
+			t.Fatalf("%s failed: error while generating CRD YAML.", testcase.Name)
+		}
+
+		if generatedYAML != testcase.Output {
+			t.Fatalf("%s failed: ouput is not as expected: %s", testcase.Name, generatedYAML)
+		}
+	}
+
+}


### PR DESCRIPTION
This commit add unit tests for `generate` verb of faas-cli.

Fixes: #492

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#492 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
provider:
  name: faas
  gateway: http://localhost:8080  # can be a remote server

functions:
  # Pass a username as an argument to find how many images user has pushed to Docker Hub.
  hubstats:
    lang: dockerfile
    image: functions/hubstats:latest
    skip_build: true

  # Node.js gives OS info about the node (Host)
  nodeinfo:
    lang: dockerfile
    image: functions/nodeinfo:latest
    skip_build: true

  # Uses `cat` to echo back response, fastest function to execute.
  echoit:
    lang: dockerfile
    image: functions/alpine:latest
    fprocess: "cat"
    skip_build: true

  # Counts words in request with `wc` utility
  wordcount:
    lang: dockerfile
    image: functions/alpine:latest
    fprocess: "wc"
    skip_build: true

  # Calculates base64 representation of request body.
  base64:
    lang: dockerfile
    image: functions/alpine:latest
    fprocess: "base64"
    skip_build: true

  # Converts body in (markdown format) -> (html)
  markdown:
    lang: dockerfile
    image: functions/markdown-render:latest
    skip_build: true
```

```
/Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli generate
---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: echoit
  namespace: openfaas-fn
spec:
  name: echoit
  image: functions/alpine:latest
---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: wordcount
  namespace: openfaas-fn
spec:
  name: wordcount
  image: functions/alpine:latest
---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: base64
  namespace: openfaas-fn
spec:
  name: base64
  image: functions/alpine:latest
---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: markdown
  namespace: openfaas-fn
spec:
  name: markdown
  image: functions/markdown-render:latest
---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: hubstats
  namespace: openfaas-fn
spec:
  name: hubstats
  image: functions/hubstats:latest
---
apiVersion: openfaas.com/v1alpha2
kind: Function
metadata:
  name: nodeinfo
  namespace: openfaas-fn
spec:
  name: nodeinfo
  image: functions/nodeinfo:latest
```
```
/Users/viveks/Repos/go-projects/src/github.com/openfaas/faas-cli/faas-cli generate | kubectl apply -f -
function.openfaas.com "echoit" created
function.openfaas.com "wordcount" created
function.openfaas.com "base64" created
function.openfaas.com "markdown" created
function.openfaas.com "hubstats" created
function.openfaas.com "nodeinfo" created
```

```
kubectl get functions -n openfaas-fn
NAME        AGE
base64      6m
echoit      6m
hubstats    6m
markdown    6m
nodeinfo    6m
wordcount   6m
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
