### PR TITLE
Add annotation flag support to the deploy and store-deploy

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -24,7 +24,7 @@ func init() {
 	storeDeployCmd.Flags().StringArrayVar(&storeDeployFlags.constraints, "constraint", []string{}, "Apply a constraint to the function")
 	storeDeployCmd.Flags().StringArrayVar(&storeDeployFlags.secrets, "secret", []string{}, "Give the function access to a secure secret")
 	storeDeployCmd.Flags().BoolVarP(&storeDeployFlags.sendRegistryAuth, "send-registry-auth", "a", false, "send registryAuth from Docker credentials manager with the request")
-
+	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.annotationOpts, "annotation", "", []string{}, "Set one or more annotation (ANNOTATION=VALUE)")
 	// Set bash-completion.
 	_ = storeDeployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
 
@@ -37,7 +37,8 @@ var storeDeployCmd = &cobra.Command{
                         [--gateway GATEWAY_URL]
                         [--network NETWORK_NAME]
                         [--env ENVVAR=VALUE ...]
-                        [--label LABEL=VALUE ...]
+						[--label LABEL=VALUE ...]
+						[--annotation ANNOTATION=VALUE ...]
                         [--replace=false]
                         [--update=true]
                         [--constraint PLACEMENT_CONSTRAINT ...]
@@ -82,6 +83,13 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		for k, v := range item.Labels {
 			label := fmt.Sprintf("%s=%s", k, v)
 			storeDeployFlags.labelOpts = append(storeDeployFlags.labelOpts, label)
+		}
+	}
+
+	if item.Annotations != nil {
+		for k, v := range item.Annotations {
+			annotation := fmt.Sprintf("%s=%s", k, v)
+			storeDeployFlags.annotationOpts = append(storeDeployFlags.annotationOpts, annotation)
 		}
 	}
 

--- a/schema/store_item.go
+++ b/schema/store_item.go
@@ -12,5 +12,6 @@ type StoreItem struct {
 	RepoURL                string            `json:"repo_url"`
 	Environment            map[string]string `json:"environment"`
 	Labels                 map[string]string `json:"labels"`
+	Annotations            map[string]string `json:"annotations"`
 	ReadOnlyRootFilesystem bool              `json:"readOnlyRootFilesystem"`
 }


### PR DESCRIPTION
Adding support for annotations through annotation flag
to the faas-cli deploy and store-deploy.

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

The change adds support for annotations not only through yaml files but through the cli.

## Description
<!--- Describe your changes in detail -->

Extended faas-cli by adding `--annotations key=value` flag to the deploy and store deploy commands.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #498 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Created new function nfn.yml
```
$ cat nfn.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080

functions:
  nfn:
    lang: go
    handler: ./nfn
    image: martindekov/nfn:latest
$ faas-cli deploy -f nfn.yml
...
$ curl -X GET http://127.0.0.1:8080/system/function/nfn
{"name":"nfn","image":"martindekov/nfn:latest","invocationCount":0,"replicas":1,"envProcess":"./handler","availableReplicas":0,"labels":{"com.openfaas.function":"nfn","com.openfaas.uid":"112016928","function":"true"},"annotations":null}
```
Add annotations to the .yml file
```
$ cat nfn.yml
provider:  name: faas  gateway: http://127.0.0.1:8080

functions:
  nfn:
    lang: go
    handler: ./nfn
    image: martindekov/nfn:latest
    annotations:
      thmf: wat
```
deploy without flags
```
$ faas-cli deploy -f nfn.yml
...
$ curl -X GET http://127.0.0.1:8080/system/function/nfn
{"name":"nfn","image":"martindekov/nfn:latest","invocationCount":0,"replicas":1,"envProcess":"./handler","availableReplicas":1,"labels":{"com.openfaas.function":"nfn","com.openfaas.uid":"620972632","function":"true"},"annotations":{"com.openfaas.annotations.thmf":"wat"}}
```
deploy with annotation in .yaml and with flag

```
$ faas-cli deploy -f nfn.yml --annotation good=morning
...
$ curl -X GET http://127.0.0.1:8080/system/function/nfn
{"name":"nfn","image":"martindekov/nfn:latest","invocationCount":0,"replicas":1,"envProcess":"./handler","availableReplicas":1,"labels":{"com.openfaas.function":"nfn","com.openfaas.uid":"951183419","function":"true"},"annotations":{"com.openfaas.annotations.good":"morning","com.openfaas.annotations.thmf":"wat"}}
```
deploy with .yml annotation and two flags
```
$ faas-cli deploy -f nfn.yml --annotation good=morning --annotation better=afternoon
...
$ curl -X GET http://127.0.0.1:8080/system/function/nfn
{"name":"nfn","image":"martindekov/nfn:latest","invocationCount":0,"replicas":1,"envProcess":"./handler","availableReplicas":0,"labels":{"com.openfaas.function":"nfn","com.openfaas.uid":"910999546","function":"true"},"annotations":{"com.openfaas.annotations.better":"afternoon","com.openfaas.annotations.good":"morning","com.openfaas.annotations.thmf":"wat"}}
```
deploy with no annotation in ./yml but with two flags
```
$ faas-cli deploy -f nfn.yml --annotation good=morning --annotation better=afternoon
...
$ curl -X GET http://127.0.0.1:8080/system/function/nfn
{"name":"nfn","image":"martindekov/nfn:latest","invocationCount":0,"replicas":1,"envProcess":"./handler","availableReplicas":0,"labels":{"com.openfaas.function":"nfn","com.openfaas.uid":"347771862","function":"true"},"annotations":{"com.openfaas.annotations.better":"afternoon","com.openfaas.annotations.good":"morning"}}
```
Test with store deploy and no annotation set (figlet is outdated)
```
$ faas-cli store deploy cows
...
$ curl -X GET http://127.0.0.1:8080/system/function/cows
{"name":"cows","image":"alexellis2/ascii-cows-openfaas:0.1","invocationCount":0,"replicas":1,"envProcess":"node show_cow.js","availableReplicas":1,"labels":{"com.openfaas.function":"cows","com.openfaas.uid":"412903869","function":"true"},"annotations":null}
```
Test store deploy with one annotation set
```
$ faas-cli store deploy cows --annotation figlet=outdated
...
$ curl -X GET http://127.0.0.1:8080/system/function/cows
{"name":"cows","image":"alexellis2/ascii-cows-openfaas:0.1","invocationCount":0,"replicas":1,"envProcess":"node show_cow.js","availableReplicas":0,"labels":{"com.openfaas.function":"cows","com.openfaas.uid":"882310342","function":"true"},"annotations":{"com.openfaas.annotations.figlet":"outdated"}}
```
Test store deploy with three annotation set
```
$ faas-cli store deploy cows --annotation figlet=outdated --annotation cows=are --annotation the=thing
...
$ curl -X GET http://127.0.0.1:8080/system/function/cows
{"name":"cows","image":"alexellis2/ascii-cows-openfaas:0.1","invocationCount":0,"replicas":1,"envProcess":"node show_cow.js","availableReplicas":0,"labels":{"com.openfaas.function":"cows","com.openfaas.uid":"507126914","function":"true"},"annotations":{"com.openfaas.annotations.cows":"are","com.openfaas.annotations.figlet":"outdated","com.openfaas.annotations.the":"thing"}}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
