### PR TITLE
Configurable handler directory

### DIFF
--- a/commands/faas.go
+++ b/commands/faas.go
@@ -30,6 +30,7 @@ var (
 var (
 	fprocess     string
 	functionName string
+	handlerDir   string
 	network      string
 	gateway      string
 	handler      string


### PR DESCRIPTION
This PR implements #481 

## Description
The fass-cli can now write the handler code to a directory that is different from the function name, by passing the `--handler` flag

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

My original motivation was being able to define the handler code as a python-importable module, in order to write some tests for it. But I realized that other people might have other requirements, and this is flexible enough to accommodate them.


## How Has This Been Tested?

I added a new test case to `commands/new_function_test.go`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
