### PR TITLE
Fix issue with header parse with = in value

### DIFF
--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -126,7 +126,7 @@ func parseHeaders(headers []string) (map[string]string, error) {
 	headerMap := make(map[string]string)
 
 	for _, header := range headers {
-		headerValues := strings.Split(header, "=")
+		headerValues := strings.SplitN(header, "=", 2)
 		if len(headerValues) != 2 {
 			return headerMap, fmt.Errorf("the --header or -H flag must take the form of key=value")
 		}


### PR DESCRIPTION
This commit fixes issue with header parse for CLI which has `=` sign in
values. For instance `--header "X-Hub-Signature"="sha1=shashashaebaf43"`

This commit also adds unit tests for `parseHeaders` function.

Fixes: #509

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

issue raised by @alexellis  #509 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
