### PR TITLE
Add describe verb for a function

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -62,6 +62,19 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	//To get correct value for invocation count from /system/functions endpoint
+	functionList, err := proxy.ListFunctions(gatewayAddress, tlsInsecure)
+	if err != nil {
+		return err
+	}
+
+	var invocationCount float64
+	for _, fn := range functionList {
+		if fn.Name == function.Name {
+			invocationCount = fn.InvocationCount
+		}
+	}
+
 	var status string
 	if function.AvailableReplicas > 0 {
 		status = "Ready"
@@ -73,7 +86,7 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s:\t\t\t%s\n", "Status", status)
 	fmt.Printf("%s:\t\t%d\n", "Replicas", function.Replicas)
 	fmt.Printf("%s:\t%d\n", "Available replicas", function.AvailableReplicas)
-	fmt.Printf("%s:\t\t%v\n", "Invocations", function.InvocationCount)
+	fmt.Printf("%s:\t\t%v\n", "Invocations", invocationCount)
 	fmt.Printf("%s:\t\t\t%s\n", "Image", function.Image)
 	fmt.Printf("%s:\t%s\n", "Function process", function.EnvProcess)
 	fmt.Printf("%s:\t\t\t%s\n", "URL", getFunctionURL(gatewayAddress, functionName))

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -1,0 +1,93 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/openfaas/faas-cli/proxy"
+	"github.com/openfaas/faas-cli/stack"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	describeCmd.Flags().StringVar(&functionName, "name", "", "Name of the function")
+	describeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
+	describeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
+	faasCmd.AddCommand(describeCmd)
+}
+
+var describeCmd = &cobra.Command{
+	Use:   "describe FUNCTION_NAME [--gateway GATEWAY_URL]",
+	Short: "Describe an OpenFaaS function",
+	Long:  `Display details of an OpenFaaS function`,
+	Example: `faas-cli describe figlet 
+faas-cli describe env --gateway http://127.0.0.1:8080
+faas-cli describe echo -g http://127.0.0.1.8080`,
+	PreRunE: preRunDescribe,
+	RunE:    runDescribe,
+}
+
+func preRunDescribe(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func runDescribe(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return fmt.Errorf("please provide a name for the function")
+	}
+	var yamlGateway string
+	var services stack.Services
+	functionName = args[0]
+
+	if len(yamlFile) > 0 {
+		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter)
+		if err != nil {
+			return err
+		}
+
+		if parsedServices != nil {
+			services = *parsedServices
+			yamlGateway = services.Provider.GatewayURL
+		}
+	}
+	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
+
+	function, err := proxy.GetFunctionInfo(gatewayAddress, functionName, tlsInsecure)
+	if err != nil {
+		return err
+	}
+
+	var status string
+	if function.AvailableReplicas > 0 {
+		status = "Ready"
+	} else {
+		status = "Not Ready"
+	}
+
+	fmt.Printf("%s:\t\t\t%s\n", "Name", function.Name)
+	fmt.Printf("%s:\t\t\t%s\n", "Status", status)
+	fmt.Printf("%s:\t\t%d\n", "Replicas", function.Replicas)
+	fmt.Printf("%s:\t%d\n", "Available replicas", function.AvailableReplicas)
+	fmt.Printf("%s:\t\t%v\n", "Invocations", function.InvocationCount)
+	fmt.Printf("%s:\t\t\t%s\n", "Image", function.Image)
+	fmt.Printf("%s:\t%s\n", "Function process", function.EnvProcess)
+	fmt.Printf("%s:\t\t\t%s\n", "URL", getFunctionURL(gatewayAddress, functionName))
+	fmt.Printf("%s:\t\t%s\n", "Async URL", getFunctionAsyncURL(gatewayAddress, functionName))
+
+	return nil
+}
+
+func getFunctionURL(gateway string, functionName string) string {
+	gateway = strings.TrimRight(gateway, "/")
+	return gateway + "/function/" + functionName
+}
+
+func getFunctionAsyncURL(gateway string, functionName string) string {
+	gateway = strings.TrimRight(gateway, "/")
+	return gateway + "/async-function/" + functionName
+}

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -8,7 +8,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
+	"net/url"
+	"path"
 	"time"
 
 	"github.com/openfaas/faas/gateway/requests"
@@ -18,11 +19,16 @@ import (
 func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (requests.Function, error) {
 	var result requests.Function
 
-	gateway = strings.TrimRight(gateway, "/")
 	timeout := 60 * time.Second
 	client := MakeHTTPClient(&timeout, tlsInsecure)
 
-	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/function/"+functionName, nil)
+	gatewayURL, err := url.Parse(gateway)
+	if err != nil {
+		return result, fmt.Errorf("invalid gateway URL: %s", gateway)
+	}
+	gatewayURL.Path = path.Join(gatewayURL.Path, "/system/function/", functionName)
+
+	getRequest, err := http.NewRequest(http.MethodGet, gatewayURL.String(), nil)
 	if err != nil {
 		return result, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -1,0 +1,61 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/openfaas/faas/gateway/requests"
+)
+
+//GetFunctionInfo get an OpenFaaS function information
+func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (requests.Function, error) {
+	var result requests.Function
+
+	gateway = strings.TrimRight(gateway, "/")
+	timeout := 60 * time.Second
+	client := MakeHTTPClient(&timeout, tlsInsecure)
+
+	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/function/"+functionName, nil)
+	if err != nil {
+		return result, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+	}
+	SetAuth(getRequest, gateway)
+
+	res, err := client.Do(getRequest)
+	if err != nil {
+		return result, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		bytesOut, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return result, fmt.Errorf("cannot read result from OpenFaaS on URL: %s", gateway)
+		}
+
+		jsonErr := json.Unmarshal(bytesOut, &result)
+		if jsonErr != nil {
+			return result, fmt.Errorf("cannot parse result from OpenFaaS on URL: %s\n%s", gateway, jsonErr.Error())
+		}
+	case http.StatusUnauthorized:
+		return result, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+	default:
+		bytesOut, err := ioutil.ReadAll(res.Body)
+		if err == nil {
+			return result, fmt.Errorf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
+		}
+	}
+	return result, nil
+}

--- a/proxy/describe_test.go
+++ b/proxy/describe_test.go
@@ -53,7 +53,7 @@ func Test_GetFunctionInfo_MissingURLPrefix(t *testing.T) {
 		t.Fatalf("Error was not returned")
 	}
 
-	expectedErrMsg := "cannot connect to OpenFaaS on URL:"
+	expectedErrMsg := "invalid gateway URL:"
 	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
 	if !r.MatchString(err.Error()) {
 		t.Fatalf("Want: %s, Got: %s", expectedErrMsg, err.Error())

--- a/proxy/describe_test.go
+++ b/proxy/describe_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"testing"
+
+	"github.com/openfaas/faas-cli/test"
+	"github.com/openfaas/faas/gateway/requests"
+)
+
+func Test_GetFunctionInfo(t *testing.T) {
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			ResponseStatusCode: http.StatusOK,
+			ResponseBody:       expectedGetFunctionInfoResponse,
+		},
+	})
+
+	defer s.Close()
+	result, err := GetFunctionInfo(s.URL, "func-test1", !tlsNoVerify)
+	if err != nil {
+		t.Fatalf("Error returned: %s", err)
+	}
+	if expectedGetFunctionInfoResponse != result {
+		t.Fatalf("Want: %#v, Got: %#v", expectedGetFunctionInfoResponse, result)
+	}
+}
+
+func Test_GetFunctionInfo_Not200(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
+
+	_, err := GetFunctionInfo(s.URL, "func-test1", tlsNoVerify)
+
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+
+	r := regexp.MustCompile(`(?m:server returned unexpected status code)`)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Error not matched: %s", err)
+	}
+}
+
+func Test_GetFunctionInfo_MissingURLPrefix(t *testing.T) {
+	_, err := GetFunctionInfo("127.0.0.1:8080", "func-test", tlsNoVerify)
+
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+
+	expectedErrMsg := "cannot connect to OpenFaaS on URL:"
+	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Want: %s, Got: %s", expectedErrMsg, err.Error())
+	}
+}
+
+var expectedGetFunctionInfoResponse = requests.Function{
+	Name:            "func-test1",
+	Image:           "image-test1",
+	Replicas:        1,
+	InvocationCount: 1,
+	EnvProcess:      "env-process test1",
+}

--- a/schema/describe.go
+++ b/schema/describe.go
@@ -1,0 +1,17 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package schema
+
+//FunctionDescription information related to a function
+type FunctionDescription struct {
+	Name              string
+	Status            string
+	Replicas          int
+	AvailableReplicas int
+	InvocationCount   int
+	Image             string
+	EnvProcess        string
+	URL               string
+	AsyncURL          string
+}


### PR DESCRIPTION
This commit adds a new verb `describe` to display information of an
OpenFaaS function.

Fixes: #446

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required]
(https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

issue #446 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested on my local system. 

```
./faas-cli describe haveibeenpwned
Name:			haveibeenpwned
Status:			Not Ready
Replicas:		1
Available replicas:	0
Invocations:		0
Image:			functions/haveibeenpwned:0.1
Function process:
URL:			http://127.0.0.1:8080/function/haveibeenpwned
Async URL:		http://127.0.0.1:8080/async-function/haveibeenpwned
➜  faas-cli git:(describe_verb) ✗ ./faas-cli describe env
Name:			env
Status:			Ready
Replicas:		1
Available replicas:	1
Invocations:		0
Image:			functions/alpine:latest
Function process:	env
URL:			http://127.0.0.1:8080/function/env
Async URL:		http://127.0.0.1:8080/async-function/env

./faas-cli describe figlet
Server returned unexpected status code: 404 -

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
