### PR TITLE
Override for template pull URL via ENV variable OPENFAAS_TEMPLATE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Advanced commands:
 
 * `faas-cli template pull` - pull in templates from a remote GitHub repository [Detailed Documentation](guide/TEMPLATE.md)
 
+The default template URL of `https://github.com/openfaas/templates.git` can be overriden in two places including an environmental variable
+
+* 1st priority CLI input
+* 2nd priority `OPENFAAS_TEMPLATE_URL` environmental variable
+
 Help for all of the commands supported by the CLI can be found by running:
 
 * `faas-cli help` or `faas-cli [command] --help`

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 )
 
-const openFaaSURLEnvironment = "OPENFAAS_URL"
+const (
+	openFaaSURLEnvironment = "OPENFAAS_URL"
+	templateURLEnvironment = "OPENFAAS_TEMPLATE_URL"
+)
 
 func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) string {
 	var gatewayURL string
@@ -29,4 +32,18 @@ func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) stri
 	}
 
 	return gatewayURL
+}
+
+func getTemplateURL(argumentURL, environmentURL, defaultURL string) string {
+	var templateURL string
+
+	if len(argumentURL) > 0 && argumentURL != defaultURL {
+		templateURL = argumentURL
+	} else if len(environmentURL) > 0 {
+		templateURL = environmentURL
+	} else {
+		templateURL = defaultURL
+	}
+
+	return templateURL
 }

--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -66,9 +66,20 @@ Currently supported verbs: %v`, supportedVerbs)
 }
 
 func runTemplatePull(cmd *cobra.Command, args []string) {
-	repository := DefaultTemplateRepository
+	repository := ""
 	if len(args) > 1 {
 		repository = args[1]
+	}
+
+	repository = getTemplateURL(repository, os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
+
+	if _, err := os.Stat(repository); err != nil {
+		var validURL = regexp.MustCompile(gitRemoteRepoRegex)
+		if !validURL.MatchString(repository) {
+			fmt.Println("The repository URL must be a valid git repo uri")
+
+			os.Exit(1)
+		}
 	}
 
 	fmt.Println("Fetch templates from repository: " + repository)

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -68,7 +68,6 @@ func Test_templatePull(t *testing.T) {
 		faasCmd.SetArgs([]string{"template", "pull", "user@host.xz:openfaas/faas-cli.git"})
 		faasCmd.SetOutput(&buf)
 		err := faasCmd.Execute()
-
 		if !strings.Contains(err.Error(), "The repository URL must be a valid git repo uri") {
 			t.Fatal("Output does not contain the required string", err.Error())
 		}
@@ -124,6 +123,46 @@ func Test_repositoryUrlRemoteRegExp(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func Test_templatePullPriority(t *testing.T) {
+	templateURLs := []struct {
+		name      string
+		envURL    string
+		cliURL    string
+		resultURL string
+	}{
+		{
+			name:      "Use Default URL when none provided",
+			resultURL: DefaultTemplateRepository,
+		},
+		{
+			name:      "Use Env URL when only env provided",
+			envURL:    "https://github.com/user/project.git",
+			resultURL: "https://github.com/user/project.git",
+		},
+		{
+			name:      "Use Cli URL when only cli provided",
+			cliURL:    "git@github.com:user/project.git",
+			resultURL: "git@github.com:user/project.git",
+		},
+		{
+			name:      "Use Cli URL when both cli and env provided",
+			cliURL:    "git@github.com:user/project.git",
+			envURL:    "https://github.com/user/project.git",
+			resultURL: "git@github.com:user/project.git",
+		},
+	}
+	for _, scenario := range templateURLs {
+		t.Run(fmt.Sprintf("%s", scenario.name), func(t *testing.T) {
+			repository = getTemplateURL(scenario.cliURL, scenario.envURL, DefaultTemplateRepository)
+			if repository != scenario.resultURL {
+				t.Errorf("result URL,  want %s got %s", scenario.resultURL, repository)
+			}
+
+		})
+
 	}
 }
 

--- a/guide/TEMPLATE.md
+++ b/guide/TEMPLATE.md
@@ -43,17 +43,25 @@ template
 In order to build functions using 3rd party templates, you need to add 3rd templates before the build step, with the following command:
 
 ```bash
-./faas-cli template pull https://github.com/itscaro/openfaas-template-php.git
+faas-cli template pull https://github.com/openfaas-incubator/golang-http-template
 ```
 
 If you need to update the downloaded repository, just add the flag `--overwrite` to the download command:
 
 ```bash
-./faas-cli template pull https://github.com/itscaro/openfaas-template-php.git --override
+faas-cli template pull https://github.com/openfaas-incubator/golang-http-template --override
 ```
+
+You can specify the template URL with `OPENFAAS_TEMPLATE_URL` environmental variable. CLI overrides the environmental variable.
+
+```bash
+export OPENFAAS_TEMPLATE_URL="https://github.com/openfaas-incubator/golang-http-template"
+faas-cli template pull
+```
+
 
 ## List locally available languages
 
 ```bash
-./faas-cli new --list
+faas-cli new --list
 ```


### PR DESCRIPTION
Provides an override for template pull URL for env variable `OPENFAAS_TEMPLATES_URL`. 

## Description
The default template URL of `https://github.com/openfaas/templates.git` can be overriden in two places including an environmental variable

* 1st priority CLI input
* 2nd priority `OPENFAAS_TEMPLATES_URL` environmental variable

It takes a similar approach used for `OPENFAAS_URL`. 

## Motivation and Context
Currently you can pass this as a parameter, but allowing an override would mean a user could customize this as a one-time thing in their bash profile.
[Issue-502](#502) 

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
The test is done based on the below criteria.  

criteria | CLI URL | ENV URL | Used URL
-----| ------ | ------- |------ 
None Provided | none | none | https://github.com/openfaas/templates.git. 
ENV Provided | none | https://github.com/s8sg/faaschain | https://github.com/s8sg/faaschain. 
ENV and CLI Provided | https://github.com/nicholasjackson/open-faas-templates | https://github.com/s8sg/faaschain | https://github.com/nicholasjackson/open-faas-templates. 
CLI Provided | https://github.com/s8sg/faaschain | none | https://github.com/s8sg/faaschain

used `export OPENFAAS_TEMPLATES_URL="<ENV URL>"` to set and `unset OPENFAAS_TEMPLATES_URL` to set and clear environment variable.  
The template pull command is `faas-cli template pull <CLI URL>`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.