### PR TITLE
Skip template folder during the build

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -6,6 +6,7 @@ package builder
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -170,10 +171,14 @@ func createBuildTemplate(functionName string, handler string, language string) s
 			fmt.Printf("Skipping \"%s\" folder\n", info.Name())
 			continue
 		default:
-			CopyFiles(
+			copyErr := CopyFiles(
 				filepath.Clean(handler+"/"+info.Name()),
 				filepath.Clean(functionPath+"/"+info.Name()),
 			)
+
+			if copyErr != nil {
+				log.Fatal(copyErr)
+			}
 		}
 	}
 
@@ -208,10 +213,14 @@ func dockerBuildFolder(functionName string, handler string, language string) str
 			fmt.Printf("Skipping \"%s\" folder\n", info.Name())
 			continue
 		default:
-			CopyFiles(
+			copyErr := CopyFiles(
 				filepath.Clean(handler+"/"+info.Name()),
 				filepath.Clean(tempPath+"/"+info.Name()),
 			)
+
+			if copyErr != nil {
+				log.Fatal(copyErr)
+			}
 		}
 	}
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -166,8 +166,8 @@ func createBuildTemplate(functionName string, handler string, language string) s
 
 	for _, info := range infos {
 		switch info.Name() {
-		case "build":
-			fmt.Println("Skipping \"build\" folder")
+		case "build", "template":
+			fmt.Printf("Skipping \"%s\" folder\n", info.Name())
 			continue
 		default:
 			CopyFiles(
@@ -204,8 +204,8 @@ func dockerBuildFolder(functionName string, handler string, language string) str
 
 	for _, info := range infos {
 		switch info.Name() {
-		case "build":
-			fmt.Println("Skipping \"build\" folder")
+		case "build", "template":
+			fmt.Printf("Skipping \"%s\" folder\n", info.Name())
 			continue
 		default:
 			CopyFiles(


### PR DESCRIPTION

## Description
- Skip both `build` and `template` from the stack root directory because these are temporary folders that should not be considered part of the
handler code

I would like to improve the tests here, but I need to think about the best way to implement them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [X] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #478  

## How Has This Been Tested?
Manual testing with a go template, a Dockerfile function, a python template, and @kenfdev custom go-http template

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ X I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
