### PR TITLE
Add `--skip-deploy` flag to `up` command

### DIFF
--- a/commands/up.go
+++ b/commands/up.go
@@ -11,13 +11,15 @@ import (
 )
 
 var (
-	skipPush bool
+	skipPush   bool
+	skipDeploy bool
 )
 
 func init() {
 
 	upFlagset := pflag.NewFlagSet("up", pflag.ExitOnError)
 	upFlagset.BoolVar(&skipPush, "skip-push", false, "Skip pushing function to remote registry")
+	upFlagset.BoolVar(&skipDeploy, "skip-deploy", false, "Skip function deployment")
 	upCmd.Flags().AddFlagSet(upFlagset)
 
 	build, _, _ := faasCmd.Find([]string{"build"})
@@ -34,13 +36,14 @@ func init() {
 
 // upCmd is a wrapper to the build, push and deploy commands
 var upCmd = &cobra.Command{
-	Use:   `up -f [YAML_FILE] [--skip-push] [flags from build, push, deploy]`,
+	Use:   `up -f [YAML_FILE] [--skip-push] [--skip-deploy] [flags from build, push, deploy]`,
 	Short: "Builds, pushes and deploys OpenFaaS function containers",
 	Long: `Build, Push, and Deploy OpenFaaS function containers either via the
 supplied YAML config using the "--yaml" flag (which may contain multiple function
 definitions), or directly via flags. 
 
-The push step may be skipped by setting the --skip-push flag.
+The push step may be skipped by setting the --skip-push flag
+and the deploy step with --skip-deploy.
 
 Note: All flags from the build, push and deploy flags are valid and can be combined,
 see the --help text for those commands for details.`,
@@ -71,8 +74,10 @@ func upHandler(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Println()
 	}
-	if err := runDeploy(cmd, args); err != nil {
-		return err
+	if !skipDeploy {
+		if err := runDeploy(cmd, args); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
This change adds `--skip-deploy` flag analogous to `--skip-push`
to the `faas-cli up` command. The requrement for this came from
user experience, as using `build` and `push` together without
`deploy` happens frequently

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Raised by @alexellis on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`faas-cli-darwin up`
`faas-cli-darwin up  --skip-push`
`faas-cli-darwin up  --skip-push --skip-deploy`
`faas-cli-darwin up  --skip-deploy`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.