### PR TITLE
Add message signatures to invoke command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -21,6 +21,14 @@
   version = "v1.0.4"
 
 [[projects]]
+  digest = "1:871b7cfa5fe18bfdbd4bf117c166c3cff8d3b61c8afe4e998b5b8ac0c160ca24"
+  name = "github.com/alexellis/hmac"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d5d71edd7bc74eb6ae4b99eccc6bda738435f43f"
+  version = "1.2"
+
+[[projects]]
   digest = "1:53e99d883df3e940f5f0223795f300eb32b8c044f226132bfc0e74930f24ea4b"
   name = "github.com/docker/docker"
   packages = [
@@ -125,6 +133,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/alexellis/hmac",
     "github.com/docker/docker-credential-helpers/client",
     "github.com/docker/docker/pkg/term",
     "github.com/mitchellh/go-homedir",

--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ Curated language templates:
 
 Read more on [community templates here](guide/TEMPLATE.md).
 
+#### HMAC
+
+It is possible to sign a `faas-cli invoke` request using a sha1 HMAC.  To do this, the name of a header to hold the code during transmission should be specified using the `--sign` flag, and the shared secret used to hash the message should be provided through `--key`. E.g.
+
+```
+$ echo -n OpenFaaS | faas-cli invoke env --sign X-Hub-Signature --key yoursecret
+```
+Results in the following header being added:
+```
+Http_X_Hub_Signature=sha1=2fc4758f8755f57f6e1a59799b56f8a6cf33b13f
+```
+
 #### Docker image as a function
 
 Specify `lang: Dockerfile` if you want the faas-cli to execute a build or `skip_build: true` for pre-built images.

--- a/commands/invoke_test.go
+++ b/commands/invoke_test.go
@@ -7,15 +7,17 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"io/ioutil"
 
+	"github.com/alexellis/hmac"
 	"github.com/openfaas/faas-cli/test"
 )
 
 func Test_invoke(t *testing.T) {
-	expected_invoke_response := "response-test-data"
+	expectedInvokeResponse := "response-test-data"
 	funcName := "test-1"
 
 	s := test.MockHttpServer(t, []test.Request{
@@ -23,7 +25,7 @@ func Test_invoke(t *testing.T) {
 			Method:             http.MethodPost,
 			Uri:                "/function/" + funcName,
 			ResponseStatusCode: http.StatusOK,
-			ResponseBody:       expected_invoke_response,
+			ResponseBody:       expectedInvokeResponse,
 		},
 	})
 	defer s.Close()
@@ -44,8 +46,8 @@ func Test_invoke(t *testing.T) {
 		faasCmd.Execute()
 	})
 
-	if found, err := regexp.MatchString(`(?m:`+expected_invoke_response+`)`, stdOut); err != nil || !found {
-		t.Fatalf("Output is not as expected:\nExpected:\n%s\n Got:\n%s", `(?m:`+expected_invoke_response+`)`, stdOut)
+	if found, err := regexp.MatchString(`(?m:`+expectedInvokeResponse+`)`, stdOut); err != nil || !found {
+		t.Fatalf("Output is not as expected:\nExpected:\n%s\n Got:\n%s", `(?m:`+expectedInvokeResponse+`)`, stdOut)
 	}
 
 }
@@ -83,4 +85,117 @@ func Test_async_invoke(t *testing.T) {
 		t.Fatalf("Async output is not as expected:\nExpected:\n%s\n Got:\n%s", `(?m:)`, stdOut)
 	}
 
+}
+
+func Test_generateSignedHeader(t *testing.T) {
+
+	var generateTestcases = []struct {
+		title       string
+		message     []byte
+		key         string
+		headerName  string
+		expectedSig string
+		expectedErr bool
+	}{
+		{
+			title:       "Header with empty key",
+			message:     []byte("This is a message"),
+			key:         "",
+			headerName:  "HeaderSet",
+			expectedSig: "HeaderSet=sha1=cdefd604e685e5c8b31fbcf6621a6e8282770dfe",
+			expectedErr: false,
+		},
+		{
+			title:       "Key with empty Header",
+			message:     []byte("This is a message"),
+			key:         "KeySet",
+			headerName:  "",
+			expectedSig: "",
+			expectedErr: true,
+		},
+		{
+			title:       "Header & key with empty message",
+			message:     []byte(""),
+			key:         "KeySet",
+			headerName:  "HeaderSet",
+			expectedSig: "HeaderSet=sha1=33dcd94ffaf13fce58615585c030c1a39d100b3c",
+			expectedErr: false,
+		},
+		{
+			title:       "Header with empty message & key",
+			message:     []byte(""),
+			key:         "",
+			headerName:  "HeaderSet",
+			expectedSig: "HeaderSet=sha1=fbdb1d1b18aa6c08324b7d64b71fb76370690e1d",
+			expectedErr: false,
+		},
+	}
+	for _, test := range generateTestcases {
+		t.Run(test.title, func(t *testing.T) {
+			sig, err := generateSignedHeader(test.message, test.key, test.headerName)
+
+			if sig != test.expectedSig {
+				t.Fatalf("error generating signature, wanted: %s, got %s", test.expectedSig, sig)
+			}
+			if (err != nil) != test.expectedErr {
+				t.Fatalf("error generating expected error: %v, got: %v", err != nil, test.expectedErr)
+			}
+
+			if test.expectedErr == false {
+
+				encodedHash := strings.SplitN(test.expectedSig, "=", 2)
+
+				invalid := hmac.Validate(test.message, encodedHash[1], test.key)
+
+				if invalid != nil {
+					t.Fatalf("expected no error, but got: %s", invalid.Error())
+				}
+			}
+		})
+	}
+}
+
+func Test_missingSignFlag(t *testing.T) {
+
+	var signtestcases = []struct {
+		title       string
+		hdr         string
+		key         string
+		expectedRes bool
+	}{
+		{
+			title:       "Header and key",
+			hdr:         "Header",
+			key:         "Key",
+			expectedRes: false,
+		},
+		{
+			title:       "Header without key",
+			hdr:         "Header",
+			key:         "",
+			expectedRes: true,
+		},
+		{
+			title:       "Key without Header",
+			hdr:         "",
+			key:         "Key",
+			expectedRes: true,
+		},
+		{
+			title:       "No Key No Header",
+			hdr:         "",
+			key:         "",
+			expectedRes: false,
+		},
+	}
+	for _, test := range signtestcases {
+		t.Run(test.title, func(t *testing.T) {
+
+			res := missingSignFlag(test.hdr, test.key)
+
+			if res != test.expectedRes {
+				t.Fatalf("error testing ability to sign, wanted: %v, got %v", test.expectedRes, res)
+			}
+		})
+	}
 }

--- a/commands/list_test.go
+++ b/commands/list_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func Test_list(t *testing.T) {
-	expected_list_response := []requests.Function{
+	expectedListResponse := []requests.Function{
 		{
 			Name:            "function-test-1",
 			Image:           "image-test-1",
@@ -33,7 +33,7 @@ func Test_list(t *testing.T) {
 			Method:             http.MethodGet,
 			Uri:                "/system/functions",
 			ResponseStatusCode: http.StatusOK,
-			ResponseBody:       expected_list_response,
+			ResponseBody:       expectedListResponse,
 		},
 	})
 	defer s.Close()

--- a/vendor/github.com/alexellis/hmac/README.md
+++ b/vendor/github.com/alexellis/hmac/README.md
@@ -1,0 +1,18 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/vendor/github.com/alexellis/hmac/pkg.go
+++ b/vendor/github.com/alexellis/hmac/pkg.go
@@ -1,0 +1,58 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte) bool {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte) []byte {
+	mac := hmac.New(sha1.New, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	if len(encodedHash) > 5 {
+
+		hashingMethod := encodedHash[:5]
+		if hashingMethod != "sha1=" {
+			return fmt.Errorf("unexpected hashing method: %s", hashingMethod)
+		}
+
+		messageMAC := encodedHash[5:] // first few chars are: sha1=
+		messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+		res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey))
+		if res == false {
+			validated = fmt.Errorf("invalid message digest or secret")
+		}
+	} else {
+		return fmt.Errorf("invalid encodedHash, should have at least 5 characters")
+	}
+
+	return validated
+}
+
+func init() {
+
+}


### PR DESCRIPTION
## Description
Change adds the ability to sha1 sign invoke calls with a pre-shared key.
Signing requires  both the header value to store the hash (`--sign`) and the key (`--key`) used
to generate the hash so checking for both values is implemented.

Once the hash has been generated and the header value constructed the
header is appended to, and treated the same as, the existing set of headers.

Unit tests added to cover the new methods with the `generateSignedHeader()` tests
both generating and validating the generated values.

## Motivation and Context
- [x] I have raised an issue to propose this change (Fixes #512)

## How Has This Been Tested?
* Unit tests added an passing
* Build succeeds
* Post build testing:

➖Flags but no values:
```
$ echo OpenFaaS | ./faas-cli-darwin invoke figlet --sign  --key
Signing requires both --sign <header-value> and --key <key-value>
```

➖Flags with empty --key arg:
```
$ echo OpenFaaS | ./faas-cli-darwin invoke figlet --sign X-GitHub-Event --key
Flag needs an argument: --key
```

➖Missing --key flag:
```
$ echo OpenFaaS | ./faas-cli-darwin invoke figlet --sign X-GitHub-Event
Signing requires both --sign <header-value> and --key <key-value>
```

➖Missing --sign flag:
```
$ echo OpenFaaS | ./faas-cli-darwin invoke figlet --key OpenFaaSCLI!
Signing requires both --sign <header-value> and --key <key-value>
```

➕ Local valid requests - demonstrating the client assembles the header:
```
$ echo OpenFaaS | ./faas-cli-darwin invoke figlet --sign X-GitHub-Event --key OpenFaaSCLI!
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
```

➕Trapping the packets using tcpdump yields:
Outgoing:
```
HTTP: POST /function/figlet HTTP/1

Host: 127.0.0.1:8080

User-Agent: Go-http-client/1.1
Content-Length: 9
Content-Type: text/plain
X-Github-Event: sha1=e40b047676161961396023cbc6b6c72a1e8e7697
Accept-Encoding: gzip


OpenFaaS
```

➕Return:
```
HTTP/1.1 200 OK

Content-Length: 282

Content-Type: text/plain

Date: Mon, 24 Sep 2018 19:00:35 GMT

X-Call-Id: a672c5fb-ce86-4918-b8cb-5f223474bc62

X-Duration-Seconds: 0.001992

X-Start-Time: 1537815635063950400

  ___                   _____           ____  
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___| 
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \ 
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/ 
      |_|  
```

➕ Local call against `env` function:
```
$ echo -n OpenFaaS | ./faas-cli-darwin invoke env --sign X-Hub-Signature --key richard_gee
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=1578b13f53d6
fprocess=env
write_debug=false
HOME=/home/app
Http_User_Agent=Go-http-client/1.1
Http_Accept_Encoding=gzip
Http_Content_Type=text/plain
Http_X_Call_Id=ff57a4a2-e592-4116-86e7-fe1541970dc2
Http_X_Forwarded_For=10.255.0.2:37968
Http_X_Hub_Signature=sha1=5ae711185dd7dfe35d1c62fd50fbfa9c6457e268
Http_X_Start_Time=1537899562621415900
Http_Method=POST
Http_ContentLength=-1
Http_Path=/function/env
Http_Host=env:8080
```

➕Remote valid requests - demonstrating a server with the shared key will validate the message:
```
$ echo -n OpenFaaS | ./faas-cli-darwin invoke alexellis-signed-and-sealed --sign X-Hub-Signature --key richard_gee
You got in - thanks for using the secret to sign your payload
```
➖ Remote invalid requests - demonstrating a server with an incorrect shared key will not validate the message:
```
$ echo -n OpenFaaS | ./faas-cli-darwin invoke alexellis-signed-and-sealed --sign X-Hub-Signature --key richard_gere
invalid message digest or secret
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
