### PR TITLE
Update describe verb to align text left

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -109,7 +109,7 @@ func getFunctionURLs(gateway string, functionName string) (string, string) {
 }
 
 func printFunctionDescription(funcDesc schema.FunctionDescription) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.AlignRight)
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
 	fmt.Fprintln(w, "Name:\t "+funcDesc.Name)
 	fmt.Fprintln(w, "Status:\t "+funcDesc.Status)
 	fmt.Fprintln(w, "Replicas:\t "+strconv.Itoa(funcDesc.Replicas))

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -57,6 +57,8 @@ func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (req
 		}
 	case http.StatusUnauthorized:
 		return result, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+	case http.StatusNotFound:
+		return result, fmt.Errorf("No such function: %s", functionName)
 	default:
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err == nil {

--- a/proxy/describe_test.go
+++ b/proxy/describe_test.go
@@ -60,6 +60,22 @@ func Test_GetFunctionInfo_MissingURLPrefix(t *testing.T) {
 	}
 }
 
+func Test_GetFunctionInfo_NotFound(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusNotFound)
+	functionName := "funct-test"
+
+	_, err := GetFunctionInfo(s.URL, functionName, tlsNoVerify)
+	if err == nil {
+		t.Fatalf("Error was not returned")
+	}
+
+	expectedErrMsg := fmt.Sprintf("No such function: %s", functionName)
+	if err.Error() != expectedErrMsg {
+		t.Fatalf("Want: %s, Got: %s", expectedErrMsg, err.Error())
+	}
+
+}
+
 var expectedGetFunctionInfoResponse = requests.Function{
 	Name:            "func-test1",
 	Image:           "image-test1",


### PR DESCRIPTION
This commit align `faas-cli describe` output text to the left.

Fixes: #531

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required]
(https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #531 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
./faas-cli describe figleta  -g http://142.93.39.213:8080/
No such function: figleta

./faas-cli describe figlet  -g http://142.93.39.213:8080/
Name:                figlet
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         4
Image:               functions/figlet:0.1
Function process:
URL:                 http://142.93.39.213:8080/function/figlet
Async URL:           http://142.93.39.213:8080/async-function/figlet
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
