### PR TITLE
Returns error code 1 when stack fails to build and displays errors if a build fails at the end

### DIFF
--- a/builder/exec.go
+++ b/builder/exec.go
@@ -23,7 +23,7 @@ func ExecCommand(tempPath string, builder []string) {
 	err := targetCmd.Wait()
 	if err != nil {
 		errString := fmt.Sprintf("ERROR - Could not execute command: %s", builder)
-		log.Fatalf(aec.RedF.Apply(errString))
+		log.Panicf(aec.RedF.Apply(errString))
 	}
 }
 
@@ -32,7 +32,7 @@ func ExecCommandWithOutput(builder []string, skipFailure bool) string {
 	output, err := exec.Command(builder[0], builder[1:]...).CombinedOutput()
 	if err != nil && !skipFailure {
 		errString := fmt.Sprintf("ERROR - Could not execute command: %s", builder)
-		log.Fatalf(aec.RedF.Apply(errString))
+		log.Panicf(aec.RedF.Apply(errString))
 	}
 	return string(output)
 }

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -4,7 +4,11 @@
 package commands
 
 import (
+	"errors"
+	"fmt"
 	"testing"
+
+	"github.com/openfaas/faas-cli/stack"
 )
 
 func Test_build(t *testing.T) {
@@ -73,4 +77,166 @@ func Test_parseBuildArgs_MultipleSeparators(t *testing.T) {
 		t.Errorf("value for 'k', want: %s got: %s", "v=z", mapped["k"])
 		t.Fail()
 	}
+}
+
+func Test_build_NoLanguage(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first": {
+			Handler:  "first_handler",
+			Image:    "first_image",
+			Language: "",
+		},
+		"second": {
+			Handler:  "second_handler",
+			Image:    "second_image",
+			Language: "",
+		},
+	}
+	services := &stack.Services{
+		Functions: functions,
+	}
+
+	mockbuildImageFunc := func(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string, buildOptions []string, tag string) error {
+		return nil
+	}
+
+	err := build(services, 2, true, mockbuildImageFunc)
+	if err == nil {
+		fmt.Errorf("Expected error")
+	}
+}
+
+func Test_build_SkipBuilds(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first": {
+			Handler:   "first_handler",
+			Image:     "first_image",
+			Language:  "first_language",
+			SkipBuild: true,
+		},
+		"second": {
+			Handler:   "second_handler",
+			Image:     "second_image",
+			Language:  "second_language",
+			SkipBuild: true,
+		},
+	}
+	services := &stack.Services{
+		Functions: functions,
+	}
+
+	mockbuildImageFunc := func(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string, buildOptions []string, tag string) error {
+		return nil
+	}
+	err := build(services, 2, true, mockbuildImageFunc)
+	if err != nil {
+		fmt.Errorf("Did not expected error")
+	}
+}
+
+func Test_build_BuildImageNoErrors(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first": {
+			Handler:  "first_handler",
+			Image:    "first_image",
+			Language: "first_language",
+		},
+		"second": {
+			Handler:  "second_handler",
+			Image:    "second_image",
+			Language: "second_language",
+		},
+	}
+	services := &stack.Services{
+		Functions: functions,
+	}
+
+	mockbuildImageFunc := func(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string, buildOptions []string, tag string) error {
+		return nil
+	}
+	err := build(services, 2, true, mockbuildImageFunc)
+	if err != nil {
+		fmt.Errorf("Did not expected error")
+	}
+}
+
+func Test_build_BuildImageOneError(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first": {
+			Handler:  "first_handler",
+			Image:    "first_image",
+			Language: "first_language",
+		},
+		"second": {
+			Handler:  "second_handler",
+			Image:    "second_image",
+			Language: "second_language",
+		},
+	}
+	services := &stack.Services{
+		Functions: functions,
+	}
+
+	mockbuildImageFunc := func(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string, buildOptions []string, tag string) error {
+		if functionName == "first" {
+			return nil
+		}
+		return errors.New("Build error")
+	}
+	err := build(services, 2, true, mockbuildImageFunc)
+	if err == nil {
+		fmt.Errorf("Expected error")
+	}
+}
+
+func Test_build_BuildImageAllErrors(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first": {
+			Handler:  "first_handler",
+			Image:    "first_image",
+			Language: "first_language",
+		},
+		"second": {
+			Handler:  "second_handler",
+			Image:    "second_image",
+			Language: "second_language",
+		},
+	}
+	services := &stack.Services{
+		Functions: functions,
+	}
+
+	mockbuildImageFunc := func(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string, buildOptions []string, tag string) error {
+		return errors.New("Build error")
+	}
+	err := build(services, 2, true, mockbuildImageFunc)
+	if err == nil {
+		fmt.Errorf("Expected error")
+	}
+}
+
+func Test_build_BuildImagePanics(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first": {
+			Handler:  "first_handler",
+			Image:    "first_image",
+			Language: "first_language",
+		},
+		"second": {
+			Handler:  "second_handler",
+			Image:    "second_image",
+			Language: "second_language",
+		},
+	}
+	services := &stack.Services{
+		Functions: functions,
+	}
+	mockbuildImageFunc := func(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string, buildOptions []string, tag string) error {
+		panic("build error")
+	}
+	err := build(services, 2, false, mockbuildImageFunc)
+	if err == nil {
+		fmt.Errorf("Expected error")
+	}
+
 }


### PR DESCRIPTION
Signed-off-by: Thomas Fan <thomasjpfan@gmail.com>

Returns error code 1 when stack fails to build. All errors are gathered together at the end to be displayed. 

## Description
Refactors the parallel build code address issues with building. 

## Motivation and Context
Closes #499
Closes #214 

## How Has This Been Tested?
1. **Case One**: Two functions, one of the functions has an invalid stack.

```bash
./faas-cli new hello --lang "go"
./faas-cli new hello-2 --lang "go" --append "hello.yml"

# invalid path
mv hello "$hello-invalid"
./faas-cli build -f hello.yml --parallel 2
```

This outputs at the end:

```
hello failed to build with error: building hello:latest, ./hello is an invalid path
hello-2 was built successfully
Build exited with 1 error(s)
```

2. **Case Two**: Two functions, one of the functions fails `docker build`.

```bash
./faas-cli new hello --lang "go"
./faas-cli new hello-2 --lang "go" --append "hello.yml"

# bad syntax for go
echo "openfaas" >> hello-2/handler.go
./faas-cli build -f hello.yml --parallel 2
```

This will fail since the `docker build` command fails, at the end this outputs:

```
hello was built successfully
hello-2 failed to build with error: ERROR - Could not execute command: [docker build -t hello-2:latest .]
Build exited with 1 error(s)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.