### PR TITLE
[DO NOT MERGE] Add test to demonstrate incomplete template definition

### DIFF
--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -24,6 +24,22 @@ var (
 	quiet      bool
 )
 
+// Define template of stack file.
+const stackTmpl = `{{ if .Provider.Name -}}
+provider:
+  name: {{ .Provider.Name }}
+  gateway: {{ .Provider.GatewayURL }}
+
+functions:
+{{- end }}
+{{- range $name, $function := .Functions }}
+  {{ $name }}:
+    lang: {{ $function.Language }}
+    handler: {{ $function.Handler }}
+    image: {{ $function.Image }}
+{{- end }}
+`
+
 func init() {
 	newFunctionCmd.Flags().StringVar(&language, "lang", "", "Language or template to use")
 	newFunctionCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL to store in YAML stack file")
@@ -162,22 +178,6 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 	builder.CopyFiles(filepath.Join("template", language, "function"), handlerDir)
 	printFiglet()
 	fmt.Printf("\nFunction created in folder: %s\n", handlerDir)
-
-	// Define template of stack file.
-	const stackTmpl = `{{ if .Provider.Name -}}
-provider:
-  name: {{ .Provider.Name }}
-  gateway: {{ .Provider.GatewayURL }}
-
-functions:
-{{- end }}
-{{- range $name, $function := .Functions }}
-  {{ $name }}:
-    lang: {{ $function.Language }}
-    handler: {{ $function.Handler }}
-    image: {{ $function.Image }}
-{{- end }}
-`
 
 	var imageName string
 	if imagePrefix = strings.TrimSpace(imagePrefix); len(imagePrefix) > 0 {


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
1) Pulled the stack template constant in `commands/new_function.go` up out of the function to enable it to be included in the new test.
2) Created a test that includes environment variables in the function definition
3) Ran the test to demonstrate that the test fails

## Motivation and Context
Issue #543 details what we are looking to demonstrate with this
- [x] I have raised an issue to propose this change

## How Has This Been Tested?
Its a test of an existing issue and currently it fails.
Travis highlights the failure: https://travis-ci.org/rgee0/faas-cli/builds/438326419#L786

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug illustration

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
