### PR TITLE
Restore file append functionality to `faas-cli new`

### DIFF
--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -148,6 +148,11 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("folder: %s already exists", handlerDir)
 	}
 
+	_, err := os.Stat(fileName)
+	if err == nil && appendMode == false {
+		return fmt.Errorf("file: %s already exists", fileName)
+	}
+
 	if err := os.Mkdir(handlerDir, 0700); err != nil {
 		return fmt.Errorf("folder: could not create %s : %s", handlerDir, err)
 	}


### PR DESCRIPTION
## Description

This change alters the mode of operation so that the `new` command only concerns itself with the function that the user is trying to create.  The deduplication to avoid multiple functions with the same name remains in place and the generated yaml is either written to a new file or appended to the existing file depending upon whether the user supplied `--append`. 

## Motivation and Context
Restores the yaml file append functionality that 973a75291e84901ca73837822337749da875876c introduced and e509cc7476a0c5f2c2e5d9e74b724e2e3ea833dd built upon that was inadvertently removed in 2186a07ebb639d099b10f06e1910d35980a15c4b through the introduction of parsing of the services struct via a golang template.

The template would rewrite the entire file based on the content of the services struct which would cause attributes such as env-vars, secrets, labels and annotations to be lost.  As well as any comments the user may have inserted into their stack file.

- [x] I have raised an issue to propose this change (Fixes #543 )

## How Has This Been Tested?

* Create a new function and output the yaml file contents\
```
$ ./faas-cli new --lang node fn1
Folder: fn1 created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: fn1
Stack file written: fn1.yml

Notes:
You have created a new function which uses Node.js 8.9.1.
npm i --save can be used to add third-party packages like request or cheerio
npm documentation: https://docs.npmjs.com/

$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
```
* Append a second function to the first yaml file and output the contents
```
$ ./faas-cli new --lang node fn2 --append fn1.yml
Folder: fn2 created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: fn2
Stack file updated: fn1.yml

Notes:
You have created a new function which uses Node.js 8.9.1.
npm i --save can be used to add third-party packages like request or cheerio
npm documentation: https://docs.npmjs.com/

$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
```
* Add some environment variables to the second function
```
$ printf '    environment:\n      alex: ellis\n' >> fn1.yml
$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
    environment:
      alex: ellis
```
* Append a third function to the first yaml file and output the contents
```
$ ./faas-cli new --lang node fn3 --append fn1.yml
Folder: fn3 created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: fn3
Stack file updated: fn1.yml

Notes:
You have created a new function which uses Node.js 8.9.1.
npm i --save can be used to add third-party packages like request or cheerio
npm documentation: https://docs.npmjs.com/

$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
    environment:
      alex: ellis
  fn3:
    lang: node
    handler: ./fn3
    image: fn3:latest
```
The environment variables added to the second function are preserved.

* Add a comment and print output
```
$ printf '    # This is a comment\n' >> fn1.yml
$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
    environment:
      alex: ellis
  fn3:
    lang: node
    handler: ./fn3
    image: fn3:latest
    # This is a comment
```
* Append a fourth function to the first yaml file and output the contents
```
$ ./faas-cli new --lang node fn4 --append fn1.yml
Folder: fn4 created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: fn4
Stack file updated: fn1.yml

Notes:
You have created a new function which uses Node.js 8.9.1.
npm i --save can be used to add third-party packages like request or cheerio
npm documentation: https://docs.npmjs.com/

$ cat fn1.yml 
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
    environment:
      alex: ellis
  fn3:
    lang: node
    handler: ./fn3
    image: fn3:latest
    # This is a comment
  fn4:
    lang: node
    handler: ./fn4
    image: fn4:latest
```
The comment after the third function is preserved.

* Test that the yaml will satisfy `deploy`
```
$ faas deploy -f fn1.yml
Deploying: fn1.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/fn1

Deploying: fn2.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/fn2

Deploying: fn3.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/fn3

Deploying: fn4.

Deployed. 200 OK.
URL: http://127.0.0.1:8080/function/fn4

```
* Additional test case to cover characteristic reported by @kenfdev
```
$ rm -rf fn1

$ ./faas-cli new --lang node fn1
File: fn1.yml already exists

$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
    environment:
      alex: ellis
  fn3:
    lang: node
    handler: ./fn3
    image: fn3:latest
    # This is a comment
  fn4:
    lang: node
    handler: ./fn4
    image: fn4:latest
```

* Try to append fn2, which already exists, to fn1.yml

```
$ ./faas-cli new --lang node fn2 --append fn1.yml

Function fn2 already exists in fn1.yml file. 
Cannot have duplicate function names in same yaml file

$ cat fn1.yml
provider:
  name: faas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: node
    handler: ./fn1
    image: fn1:latest
  fn2:
    lang: node
    handler: ./fn2
    image: fn2:latest
    environment:
      alex: ellis
  fn3:
    lang: node
    handler: ./fn3
    image: fn3:latest
    # This is a comment
  fn4:
    lang: node
    handler: ./fn4
    image: fn4:latest
```

Results in refusal with the pre-existing message:

```
Function fn2 already exists in fn1.yml file. 
Cannot have duplicate function names in same yaml file
```

The contents on fn1.yml remains in place with the additional env-var for fn2

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: Richard Gee <richard@technologee.co.uk>