### PR TITLE
Set the gateway url regardless of the `send-registry-auth` flag

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -289,8 +289,9 @@ Error: %s`, fprocessErr.Error())
 		}
 	} else {
 		if len(image) == 0 || len(functionName) == 0 {
-			return fmt.Errorf("To deploy a function give --yaml/-f or a --image flag")
+			return fmt.Errorf("To deploy a function give --yaml/-f or a --image and --name flag")
 		}
+		gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
 		var registryAuth string
 		if deployFlags.sendRegistryAuth {
@@ -300,7 +301,6 @@ Error: %s`, fprocessErr.Error())
 				log.Printf("Unable to read the docker config - %v\n", err.Error())
 			}
 
-			gateway = getGatewayURL(gateway, defaultGateway, gateway, os.Getenv(openFaaSURLEnvironment))
 			registryAuth = getRegistryAuth(&dockerConfig, image)
 		}
 		// default to a readable filesystem until we get more input about the expected behavior


### PR DESCRIPTION
Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

## Description
<!--- Describe your changes in detail -->
The gateway url needs to be set regardless of the `send-registry-auth` flag. Hence this change puts the code which sets the gateway url outside of the `if` condition.

Fixes #547 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have a local kubernetes and OpenFaaS cluster. The gateway is sitting at `http://127.0.0.1:31112`.

**Ensure the default request fails because `OPENFAAS_URL` is not set**
```
$ echo $OPENFAAS_URL

$ faas-cli deploy --name env --image="functions/alpine:latest"

Is FaaS deployed? Do you need to specify the --gateway flag?
Put http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: connect: connection refused

Function 'env' failed to deploy with status code: 500
```

**Set the `OPENFAAS_URL` and check that the request succeeds.**
```
$ export OPENFAAS_URL=http://127.0.0.1:31112
$ echo $OPENFAAS_URL
http://127.0.0.1:31112

$ faas-cli deploy --name env --image="functions/alpine:latest"

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/env
```

**Check that `send-registry-auth` is working as well**
```
faas-cli deploy --name env --image="functions/alpine:latest" --send-registry-auth
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/env
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
