### PR TITLE
Remove instructions for scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,7 @@ $version = (Invoke-WebRequest "https://api.github.com/repos/openfaas/faas-cli/re
 
 #### Windows
 
-The easiest way to install the faas-cli is through `scoop`:
-
-```
-scoop install faas-cli
-```
-
-Note: The `scoop` release may not run the latest minor release but is updated regularly.
+To install the faas-cli on Windows go to [Releases](https://github.com/openfaas/faas-cli/releases) and download the latest faas-cli.exe.
 
 #### Build from source
 


### PR DESCRIPTION
Those instructions are outdated and are confusing users and
causing errors. Pointing to the latest exe file instead

Signed-off-by: Ivana Yovcheva (VMware) <iyovcheva@vmware.com>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Raised on slack

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
