### PR TITLE
Add template store command

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ The template store has templates from openfaas and openfaas-incubator organizati
 
 In order to see what templates are available in the store type `faas-cli template store list`.
 
-> Note: You can set your own custom store location with `--url` flag
+> Note: You can set your own custom store location with `--url` flag or set `OPENFAAS_TEMPLATE_STORE_URL` environmental variable
 
 To pull templates from the store just write the name of the template you want, you can pull couple of templates at once `faas-cli template store pull go golang-http python3-debian ...`
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ In order to see what templates are available in the store type `faas-cli templat
 
 > Note: You can set your own custom store location with `--url` flag or set `OPENFAAS_TEMPLATE_STORE_URL` environmental variable
 
-To pull templates from the store just write the name of the template you want, you can pull couple of templates at once `faas-cli template store pull go golang-http python3-debian ...`
+To pull templates from the store just write the name of the template you want `faas-cli template store pull go` or the repository and name `faas-cli template store pull openfaas/go`
 
 > Note: This feature is still in experimental stage and in the future the CLI verbs might be changed
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ Curated language templates:
 
 Read more on [community templates here](guide/TEMPLATE.md).
 
+**Templates store**
+
+The template store has templates from openfaas and openfaas-incubator organizations with openfaas templates being the official ones.
+
+In order to see what templates are available in the store type `faas-cli template store list`.
+
+> Note: You can set your own custom store location with `--url` flag
+
+To pull templates from the store just write the name of the template you want, you can pull couple of templates at once `faas-cli template store pull go golang-http python3-debian ...`
+
+> Note: This feature is still in experimental stage and in the future the CLI verbs might be changed
+
 #### HMAC
 
 It is possible to sign a `faas-cli invoke` request using a sha1 HMAC.  To do this, the name of a header to hold the code during transmission should be specified using the `--sign` flag, and the shared secret used to hash the message should be provided through `--key`. E.g.

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	openFaaSURLEnvironment = "OPENFAAS_URL"
-	templateURLEnvironment = "OPENFAAS_TEMPLATE_URL"
+	openFaaSURLEnvironment      = "OPENFAAS_URL"
+	templateURLEnvironment      = "OPENFAAS_TEMPLATE_URL"
+	templateStoreURLEnvironment = "OPENFAAS_TEMPLATE_STORE_URL"
 )
 
 func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) string {
@@ -46,4 +47,14 @@ func getTemplateURL(argumentURL, environmentURL, defaultURL string) string {
 	}
 
 	return templateURL
+}
+
+func getTemplateStoreURL(argumentURL, environmentURL, defaultURL string) string {
+	if argumentURL != defaultURL {
+		return argumentURL
+	} else if len(environmentURL) > 0 {
+		return environmentURL
+	} else {
+		return defaultURL
+	}
 }

--- a/commands/priority_test.go
+++ b/commands/priority_test.go
@@ -1,0 +1,51 @@
+package commands
+
+import "testing"
+
+func Test_getTemplateStoreURL(t *testing.T) {
+	tests := []struct {
+		title       string
+		envURL      string
+		defaultURL  string
+		argURL      string
+		expectedURL string
+	}{
+		{
+			title:       "Environmental variable is set and argument equals defaultURL which should be priority",
+			envURL:      "https://github.com/custom/url",
+			defaultURL:  DefaultTemplatesStore,
+			argURL:      DefaultTemplatesStore,
+			expectedURL: "https://github.com/custom/url",
+		},
+		{
+			title:       "Environmental variable is unset and argument is unset which falls back to default store",
+			envURL:      "",
+			defaultURL:  DefaultTemplatesStore,
+			argURL:      DefaultTemplatesStore,
+			expectedURL: DefaultTemplatesStore,
+		},
+		{
+			title:       "Environmental variable is unset but argument is set which should set URL as argument",
+			envURL:      "",
+			defaultURL:  DefaultTemplatesStore,
+			argURL:      "https://github.com/openfaas/store/official",
+			expectedURL: "https://github.com/openfaas/store/official",
+		},
+		{
+			title:       "Environmental variable is set and argument is set which should set URL as argument",
+			envURL:      "https://github.com/custom/url",
+			defaultURL:  DefaultTemplatesStore,
+			argURL:      "https://github.com/openfaas/store/official",
+			expectedURL: "https://github.com/openfaas/store/official",
+		},
+	}
+	// defaultURL is always present that is why we don't test that case
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			storeURL := getTemplateStoreURL(test.argURL, test.envURL, test.defaultURL)
+			if storeURL != test.expectedURL {
+				t.Errorf("expected store URL: `%s` got: `%s`", test.expectedURL, storeURL)
+			}
+		})
+	}
+}

--- a/commands/template.go
+++ b/commands/template.go
@@ -1,0 +1,24 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	faasCmd.AddCommand(templateCmd)
+}
+
+// templateCmd allows access to store and pull commands
+var templateCmd = &cobra.Command{
+	Use:   `template [COMMAND]`,
+	Short: "OpenFaaS template store and pull commands",
+	Long:  "Allows browsing templates from store or pulling custom templates",
+	Example: `  faas-cli template pull https://github.com/custom/template
+  faas-cli template store list
+  faas-cli template store ls
+  faas-cli template store pull ruby-http
+  faas-cli template store pull openfaas-incubator/ruby-http`,
+}

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -20,7 +20,10 @@ func Test_templatePull(t *testing.T) {
 		defer tearDownFetchTemplates(t)
 
 		faasCmd.SetArgs([]string{"template", "pull", localTemplateRepository})
-		faasCmd.Execute()
+		err := faasCmd.Execute()
+		if err != nil {
+			t.Errorf("unexpected error while puling valid repo: %s", err.Error())
+		}
 
 		// Verify created directories
 		if _, err := os.Stat("template"); err != nil {
@@ -32,7 +35,10 @@ func Test_templatePull(t *testing.T) {
 		defer tearDownFetchTemplates(t)
 
 		faasCmd.SetArgs([]string{"template", "pull", localTemplateRepository})
-		faasCmd.Execute()
+		err := faasCmd.Execute()
+		if err != nil {
+			t.Errorf("unexpected error while executing template pull: %s", err.Error())
+		}
 
 		var buf bytes.Buffer
 		log.SetOutput(&buf)
@@ -40,7 +46,10 @@ func Test_templatePull(t *testing.T) {
 		r := regexp.MustCompile(`(?m:Cannot overwrite the following \d+ template\(s\):)`)
 
 		faasCmd.SetArgs([]string{"template", "pull", localTemplateRepository})
-		faasCmd.Execute()
+		err = faasCmd.Execute()
+		if err != nil {
+			t.Errorf("unexpected error while executing template pull: %s", err.Error())
+		}
 
 		if !r.MatchString(buf.String()) {
 			t.Fatal(buf.String())
@@ -49,7 +58,10 @@ func Test_templatePull(t *testing.T) {
 		buf.Reset()
 
 		faasCmd.SetArgs([]string{"template", "pull", localTemplateRepository, "--overwrite"})
-		faasCmd.Execute()
+		err = faasCmd.Execute()
+		if err != nil {
+			fmt.Errorf("unexpected error while executing template pull with --overwrite: %s", err.Error())
+		}
 
 		str := buf.String()
 		if r.MatchString(str) {
@@ -63,13 +75,10 @@ func Test_templatePull(t *testing.T) {
 	})
 
 	t.Run("InvalidUrlError", func(t *testing.T) {
-		var buf bytes.Buffer
-
 		faasCmd.SetArgs([]string{"template", "pull", "user@host.xz:openfaas/faas-cli.git"})
-		faasCmd.SetOutput(&buf)
 		err := faasCmd.Execute()
 		if !strings.Contains(err.Error(), "The repository URL must be a valid git repo uri") {
-			t.Fatal("Output does not contain the required string", err.Error())
+			t.Errorf("Output does not contain the required error: %s", err.Error())
 		}
 	})
 }
@@ -172,5 +181,8 @@ func templatePullLocalTemplateRepo(t *testing.T) {
 	defer os.RemoveAll(localTemplateRepository)
 
 	faasCmd.SetArgs([]string{"template", "pull", localTemplateRepository})
-	faasCmd.Execute()
+	err := faasCmd.Execute()
+	if err != nil {
+		fmt.Printf("error while executing template pull: %s", err.Error())
+	}
 }

--- a/commands/template_store.go
+++ b/commands/template_store.go
@@ -1,0 +1,23 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	templateCmd.AddCommand(templateStoreCmd)
+}
+
+// templateStoreCmd allows access to pull and list commands from store
+var templateStoreCmd = &cobra.Command{
+	Use:   `store [COMMAND]`,
+	Short: `Command for pulling and listing templates from store`,
+	Long:  `This command provides the list of the templates from the official store by default`,
+	Example: `  faas-cli template store list --verbose
+  faas-cli template store ls -v
+  faas-cli template store pull ruby-http
+  faas-cli template store pull --url=https://raw.githubusercontent.com/openfaas/store/master/templates.json`,
+}

--- a/commands/template_store_list.go
+++ b/commands/template_store_list.go
@@ -38,7 +38,7 @@ var templateStoreListCmd = &cobra.Command{
 	Use:     `list`,
 	Short:   `List templates from OpenFaaS organizations`,
 	Aliases: []string{"ls"},
-	Long:    `List templates from official store or from custom URL`,
+	Long:    `List templates from official store or from custom URL or set the environmental variable OPENFAAS_TEMPLATE_STORE_URL to be the default store location`,
 	Example: `  faas-cli template store list
   faas-cli template store ls
   faas-cli template store ls --url=https://raw.githubusercontent.com/openfaas/store/master/templates.json

--- a/commands/template_store_list.go
+++ b/commands/template_store_list.go
@@ -1,0 +1,153 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// DefaultTemplatesStore is the URL where the official store can be found
+	DefaultTemplatesStore = "https://raw.githubusercontent.com/openfaas/store/master/templates.json"
+)
+
+var (
+	templateStoreURL string
+)
+
+func init() {
+	templateStoreListCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Shows additional language and platform")
+	templateStoreListCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, "Use as alternative store for templates")
+
+	templateStoreCmd.AddCommand(templateStoreListCmd)
+}
+
+// templateStoreListCmd lists templates from default store or custom store if set
+var templateStoreListCmd = &cobra.Command{
+	Use:     `list`,
+	Short:   `List templates from OpenFaaS organizations`,
+	Aliases: []string{"ls"},
+	Long:    `List templates from official store or from custom URL`,
+	Example: `  faas-cli template store list
+  faas-cli template store ls
+  faas-cli template store ls --url=https://raw.githubusercontent.com/openfaas/store/master/templates.json
+  faas-cli template store ls --verbose=true`,
+	RunE: runTemplateStoreList,
+}
+
+func runTemplateStoreList(cmd *cobra.Command, args []string) error {
+	envTemplateRepoStore := os.Getenv(templateStoreURLEnvironment)
+	storeURL := getTemplateStoreURL(templateStoreURL, envTemplateRepoStore, DefaultTemplatesStore)
+
+	templatesInfo, templatesErr := getTemplateInfo(storeURL)
+	if templatesErr != nil {
+		return fmt.Errorf("error while getting templates info: %s", templatesErr)
+	}
+
+	formattedOutput := formatCommandOutput(templatesInfo)
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s", formattedOutput)
+
+	return nil
+}
+
+func getTemplateInfo(repository string) ([]TemplateInfo, error) {
+	req, reqErr := http.NewRequest(http.MethodGet, repository, nil)
+	if reqErr != nil {
+		return nil, fmt.Errorf("error while trying to create request to take template info: %s", reqErr.Error())
+	}
+
+	client := http.DefaultClient
+	res, clientErr := client.Do(req)
+	if clientErr != nil {
+		return nil, fmt.Errorf("error while requesting template list: %s", clientErr.Error())
+	}
+
+	if res != nil {
+		if res.Body != nil {
+			defer res.Body.Close()
+			if res.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("unexpected status code wanted: %d got: %d", http.StatusOK, res.StatusCode)
+			}
+
+			body, bodyErr := ioutil.ReadAll(res.Body)
+			if bodyErr != nil {
+				return nil, fmt.Errorf("error while reading data from templates body: %s", bodyErr.Error())
+			}
+
+			templatesInfo := []TemplateInfo{}
+			unmarshallErr := json.Unmarshal(body, &templatesInfo)
+			if unmarshallErr != nil {
+				return nil, fmt.Errorf("error while unmarshalling into templates struct: %s", unmarshallErr.Error())
+			}
+			return templatesInfo, nil
+		}
+		return nil, fmt.Errorf("error empty response body from: %s", templateStoreURL)
+	}
+	return nil, fmt.Errorf("error empty response from: %s", templateStoreURL)
+}
+
+func formatCommandOutput(templates []TemplateInfo) string {
+	templatesOutput := formatTemplatesOutput(templates, verbose)
+
+	return templatesOutput
+}
+
+func formatTemplatesOutput(templates []TemplateInfo, verbose bool) string {
+	var buff bytes.Buffer
+	lineWriter := tabwriter.NewWriter(&buff, 0, 0, 1, ' ', 0)
+
+	fmt.Fprintln(lineWriter)
+	if verbose {
+		formatVerboseOutput(lineWriter, templates)
+	} else {
+		formatBasicOutput(lineWriter, templates)
+	}
+	fmt.Fprintln(lineWriter)
+
+	lineWriter.Flush()
+
+	return buff.String()
+}
+
+func formatBasicOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo) {
+	fmt.Fprintf(lineWriter, "NAME\tSOURCE\tDESCRIPTION\n")
+	for _, template := range templates {
+		fmt.Fprintf(lineWriter, "%s\t%s\t%s\n",
+			template.TemplateName,
+			template.Source,
+			template.Description)
+	}
+}
+
+func formatVerboseOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo) {
+	fmt.Fprintf(lineWriter, "NAME\tLANGUAGE\tPLATFORM\tSOURCE\tDESCRIPTION\n")
+	for _, template := range templates {
+		fmt.Fprintf(lineWriter, "%s\t%s\t%s\t%s\t%s\n",
+			template.TemplateName,
+			template.Language,
+			template.Platform,
+			template.Source,
+			template.Description)
+	}
+}
+
+// TemplateInfo is the definition of a template which is part of the store
+type TemplateInfo struct {
+	TemplateName string `json:"template"`
+	Platform     string `json:"platform"`
+	Language     string `json:"language"`
+	Source       string `json:"source"`
+	Description  string `json:"description"`
+	Repository   string `json:"repo"`
+	Official     string `json:"official"`
+}

--- a/commands/template_store_pull.go
+++ b/commands/template_store_pull.go
@@ -6,7 +6,6 @@ package commands
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -24,18 +23,19 @@ var templateStorePullCmd = &cobra.Command{
 	Use:   `pull [TEMPLATE_NAME]`,
 	Short: `Pull templates from store`,
 	Long:  `Pull templates from store supported by openfaas or openfaas-incubator organizations or your custom store`,
-	Example: `  faas-cli template store pull ruby-http ...
-  faas-cli template store pull openfaas/go openfaas-incubator/node10-express ...
-  faas-cli template store pull go ... --debug
-  faas-cli template store pull openfaas/go openfaas-incubator/node10-express --overwrite
+	Example: `  faas-cli template store pull ruby-http
+  faas-cli template store pull go --debug
+  faas-cli template store pull openfaas/go --overwrite
   faas-cli template store pull golang-middleware --url https://raw.githubusercontent.com/openfaas/store/master/templates.json`,
 	RunE: runTemplateStorePull,
 }
 
 func runTemplateStorePull(cmd *cobra.Command, args []string) error {
-	var nonExistingTemplates []string
 	if len(args) == 0 {
-		return fmt.Errorf("\nNeed to specify one of the store templates check available ones by running the command:\n\nfaas-cli template store list\n")
+		return fmt.Errorf("\nNeed to specify one of the store templates, check available ones by running the command:\n\nfaas-cli template store list\n")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("\nNeed to specify single template from the store, check available ones by running the command:\n\nfaas-cli template store list\n")
 	}
 
 	envTemplateRepoStore := os.Getenv(templateStoreURLEnvironment)
@@ -46,27 +46,21 @@ func runTemplateStorePull(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error while fetching templates from store: %s", templatesErr)
 	}
 
-	for _, template := range args {
-		found := false
-		for _, storeTemplate := range storeTemplates {
-			sourceName := fmt.Sprintf("%s/%s", storeTemplate.Source, storeTemplate.TemplateName)
-			if template == storeTemplate.TemplateName || template == sourceName {
-				err := runTemplatePull(cmd, []string{storeTemplate.Repository})
-				if err != nil {
-					return fmt.Errorf("error while pulling template: %s : %s", storeTemplate.TemplateName, err.Error())
-				}
-				found = true
-				break
+	templateName := args[0]
+	found := false
+	for _, storeTemplate := range storeTemplates {
+		sourceName := fmt.Sprintf("%s/%s", storeTemplate.Source, storeTemplate.TemplateName)
+		if templateName == storeTemplate.TemplateName || templateName == sourceName {
+			err := runTemplatePull(cmd, []string{storeTemplate.Repository})
+			if err != nil {
+				return fmt.Errorf("error while pulling template: %s : %s", storeTemplate.TemplateName, err.Error())
 			}
-		}
-		if !found {
-			nonExistingTemplates = append(nonExistingTemplates, fmt.Sprintf("\nThere is no template with name: `%s` in the store.\n", template))
+			found = true
+			break
 		}
 	}
-	if len(nonExistingTemplates) > 0 {
-		nonExistingTemplates = append(nonExistingTemplates, "\ncheck available options by running:\n\nfaas-cli template store pull <NAME>|<SOURCE/NAME>\n")
-		return fmt.Errorf("%s", strings.Join(nonExistingTemplates, ""))
+	if !found {
+		return fmt.Errorf("template with name: `%s` does not exist in the repo", templateName)
 	}
-
 	return nil
 }

--- a/commands/template_store_pull.go
+++ b/commands/template_store_pull.go
@@ -1,0 +1,69 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	templateStorePullCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, "Use as alternative store for templates")
+	templatePull, _, _ := faasCmd.Find([]string{"template", "pull"})
+	templateStoreCmd.PersistentFlags().AddFlagSet(templatePull.Flags())
+
+	templateStoreCmd.AddCommand(templateStorePullCmd)
+}
+
+// templateStorePullCmd pulls templates from default store or custom store if set
+var templateStorePullCmd = &cobra.Command{
+	Use:   `pull [TEMPLATE_NAME]`,
+	Short: `Pull templates from store`,
+	Long:  `Pull templates from store supported by openfaas or openfaas-incubator organizations or your custom store`,
+	Example: `  faas-cli template store pull ruby-http ...
+  faas-cli template store pull openfaas/go openfaas-incubator/node10-express ...
+  faas-cli template store pull go ... --debug
+  faas-cli template store pull openfaas/go openfaas-incubator/node10-express --overwrite
+  faas-cli template store pull golang-middleware --url https://raw.githubusercontent.com/openfaas/store/master/templates.json`,
+	RunE: runTemplateStorePull,
+}
+
+func runTemplateStorePull(cmd *cobra.Command, args []string) error {
+	var nonExistingTemplates []string
+	if len(args) == 0 {
+		return fmt.Errorf("\nNeed to specify one of the store templates check available ones by running the command:\n\nfaas-cli template store list\n")
+	} else {
+		envTemplateRepoStore := os.Getenv(templateStoreURLEnvironment)
+		storeURL := getTemplateStoreURL(templateStoreURL, envTemplateRepoStore, DefaultTemplatesStore)
+
+		storeTemplates, templatesErr := getTemplateInfo(storeURL)
+		if templatesErr != nil {
+			return fmt.Errorf("error while fetching templates from store: %s", templatesErr)
+		}
+
+		for _, template := range args {
+			found := false
+			for _, storeTemplate := range storeTemplates {
+				sourceName := fmt.Sprintf("%s/%s", storeTemplate.Source, storeTemplate.TemplateName)
+				if template == storeTemplate.TemplateName || template == sourceName {
+					runTemplatePull(cmd, []string{storeTemplate.Repository})
+					found = true
+					break
+				}
+			}
+			if !found {
+				nonExistingTemplates = append(nonExistingTemplates, fmt.Sprintf("\nThere is no template with name: `%s` in the store.\n", template))
+			}
+		}
+	}
+	if len(nonExistingTemplates) > 0 {
+		nonExistingTemplates = append(nonExistingTemplates, "\ncheck available options by running:\n\nfaas-cli template store pull <NAME>|<SOURCE/NAME>\n")
+		return fmt.Errorf("%s", strings.Join(nonExistingTemplates, ""))
+	}
+
+	return nil
+}

--- a/guide/TEMPLATE.md
+++ b/guide/TEMPLATE.md
@@ -65,3 +65,31 @@ faas-cli template pull
 ```bash
 faas-cli new --list
 ```
+
+## Check template store
+
+In order to check what templates are available in the template store type
+
+```bash
+faas-cli template store list
+```
+
+Pull the desired template by specifying `NAME` attribute only:
+
+```bash
+faas-cli template store pull go
+```
+
+or pull the template by mixing the repository and name the following way:
+
+```bash
+faas-cli template store pull openfaas/go
+```
+
+If you have your own store with templates, you can set that as your default official store by setting the environmental variable `OPENFAAS_TEMPLATE_STORE_URL` the following way:
+
+```bash
+export OPENFAAS_TEMPLATE_STORE_URL=https://raw.githubusercontent.com/user/openfaas-templates/templates.json
+```
+
+Now the source of the store is changed to the URL you have specified above.


### PR DESCRIPTION
Moving template command as own command which has store and
pull commands as subcommands. Also adding store list and
store pull commands to list and pull from store

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Also opened Issue in store which slaps the keys: [43](https://github.com/openfaas/store/pull/44)

This PR separates `template pull` command into separate commands and adding additional `template store list` and `template store pull` for interactions with the official templates store.

The commands are structured the following way:

* `template`

    * `pull`

    * `store`

        * `list`
        
        * `pull`

And are used as before, there are the ways you can use every command now:

`faas-cli template pull <URL OF REPOSITORY>`' <- (default)
`faas-cli template pull <URL OF REPOSITORY> --overwrite`
`faas-cli template pull <URL OF REPOSITORY> --debug`
`faas-cli template store list`
`faas-cli template store ls`
`faas-cli template store list --verbose`
`faas-cli template store list --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json`
The fields inside `<>` aka `<NAME>` is the content below the fields seen through the command above aka.
```
faas-cli template store list

NAME      SOURCE      DESCRIPTION
...       ...         ...
```

`faas-cli template store pull <NAME>||<SOURCE/NAME> ...` <- (default)
`faas-cli template store pull <NAME>||<SOURCE/NAME> ... --overwrite`
`faas-cli template store pull <NAME>||<SOURCE/NAME> ... --debug`
`faas-cli template store pull <NAME>||<SOURCE/NAME> ... --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json`

Also you can set the environmental variable `OPENFAAS_TEMPLATE_STORE_URL` which will prioritize over the default one the following way `argument` > `environmental_variable` > `default`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes https://github.com/openfaas/faas-cli/issues/559

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual tests:

`faas-cli template store ls`
```
> ./faas-cli template store ls

NAME                    SOURCE             DESCRIPTION
csharp                  openfaas           Official C# template
...
node10-express-armhf    openfaas-incubator NodeJS 10 Express armhf template
...
```

`faas-cli template store ls -v`
```
> ./faas-cli template store ls -v

NAME                    LANGUAGE   PLATFORM SOURCE             DESCRIPTION
csharp                  C#         x86_64   openfaas           Official C# template
...
node10-express-armhf    NodeJS     armhf    openfaas-incubator NodeJS 10 Express armhf template
...
```

`faas-cli template store pull csharp golang-http python3-debian`
```
> ./faas-cli template store pull csharp golang-http python3-debian
Fetch templates from repository: https://github.com/openfaas/templates
2018/11/26 01:47:35 Attempting to expand templates from https://github.com/openfaas/templates
2018/11/26 01:47:37 Fetched 14 template(s) : [csharp dockerfile go go-armhf java8 node node-arm64 node-armhf php7 python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates
Fetch templates from repository: https://github.com/openfaas-incubator/golang-http-template
2018/11/26 01:47:37 Attempting to expand templates from https://github.com/openfaas-incubator/golang-http-template
2018/11/26 01:47:38 Fetched 4 template(s) : [golang-http golang-http-armhf golang-middleware golang-middleware-armhf] from https://github.com/openfaas-incubator/golang-http-template
Fetch templates from repository: https://github.com/openfaas-incubator/python3-debian
2018/11/26 01:47:38 Attempting to expand templates from https://github.com/openfaas-incubator/python3-debian
2018/11/26 01:47:40 Fetched 1 template(s) : [python3-debian] from https://github.com/openfaas-incubator/python3-debian
```
`faas-cli template store pull csharp what golang-http template python3-debian --overwrite`
```
> ./faas-cli template store pull csharp what golang-http template python3-debian --overwrite
Fetch templates from repository: https://github.com/openfaas/templates
2018/11/26 01:48:19 Attempting to expand templates from https://github.com/openfaas/templates
2018/11/26 01:48:20 Fetched 14 template(s) : [csharp dockerfile go go-armhf java8 node node-arm64 node-armhf php7 python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates
Fetch templates from repository: https://github.com/openfaas-incubator/golang-http-template
2018/11/26 01:48:20 Attempting to expand templates from https://github.com/openfaas-incubator/golang-http-template
2018/11/26 01:48:22 Fetched 4 template(s) : [golang-http golang-http-armhf golang-middleware golang-middleware-armhf] from https://github.com/openfaas-incubator/golang-http-template
Fetch templates from repository: https://github.com/openfaas-incubator/python3-debian
2018/11/26 01:48:22 Attempting to expand templates from https://github.com/openfaas-incubator/python3-debian
2018/11/26 01:48:23 Fetched 1 template(s) : [python3-debian] from https://github.com/openfaas-incubator/python3-debian

There is no template with name: `what` in the store.

There is no template with name: `template` in the store.

check available options by running:

faas-cli template store pull <NAME>|<SOURCE/NAME>

```
`faas-cli template store pull `
```
> ./faas-cli template store pull 

Need to specify one of the store templates check available ones by running the command:

faas-cli template store list

```
`faas-cli template store pull go --url=asd`
```
> ./faas-cli template store pull go --url=asd
Error while fetching templates from store: error while requesting template list: Get asd: unsupported protocol scheme ""
```
`faas-cli template store list go --url=asd`
```
> ./faas-cli template store list go --url=asd
Error while getting templates info: error while requesting template list: Get asd: unsupported protocol scheme ""
```
`faas-cli template store pull golang-http python3-debian --debug`
```
> ./faas-cli template store pull golang-http python3-debian --debug
Fetch templates from repository: https://github.com/openfaas-incubator/golang-http-template
2018/11/26 01:58:01 Attempting to expand templates from https://github.com/openfaas-incubator/golang-http-template
Temp files in /tmp/openFaasTemplates879867391
2018/11/26 01:58:04 Cannot overwrite the following 4 template(s): [golang-http golang-http-armhf golang-middleware golang-middleware-armhf]
2018/11/26 01:58:04 Fetched 0 template(s) : [] from https://github.com/openfaas-incubator/golang-http-template
Fetch templates from repository: https://github.com/openfaas-incubator/python3-debian
2018/11/26 01:58:04 Attempting to expand templates from https://github.com/openfaas-incubator/python3-debian
Temp files in /tmp/openFaasTemplates578810194
2018/11/26 01:58:06 Cannot overwrite the following 1 template(s): [python3-debian]
2018/11/26 01:58:06 Fetched 0 template(s) : [] from https://github.com/openfaas-incubator/python3-debian
```
`faas-cli template store list --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json`
```
> ./faas-cli template store list --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json

NAME                    SOURCE             DESCRIPTION
csharp                  openfaas           Official C# template
...
node10-express-armhf    openfaas-incubator NodeJS 10 Express armhf template
...
```

`faas-cli template store list --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json -v`

```
> ./faas-cli template store list --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json -v

NAME                    LANGUAGE   PLATFORM SOURCE             DESCRIPTION
csharp                  C#         x86_64   openfaas           Official C# template
...
node10-express-armhf    NodeJS     armhf    openfaas-incubator NodeJS 10 Express armhf template
...
```

`faas-cli template store pull csharp ruby-http python27-flask --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json --overwrite`

```
> ./faas-cli template store pull csharp ruby-http python27-flask --url https://raw.githubusercontent.com/martindekov/store/martindekov/unofficial_templates_json/templates.json --overwrite
Fetch templates from repository: https://github.com/openfaas/templates
2018/11/26 02:04:28 Attempting to expand templates from https://github.com/openfaas/templates
2018/11/26 02:04:30 Fetched 14 template(s) : [csharp dockerfile go go-armhf java8 node node-arm64 node-armhf php7 python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates
Fetch templates from repository: https://github.com/openfaas-incubator/ruby-http
2018/11/26 02:04:30 Attempting to expand templates from https://github.com/openfaas-incubator/ruby-http
2018/11/26 02:04:31 Fetched 1 template(s) : [ruby-http] from https://github.com/openfaas-incubator/ruby-http
Fetch templates from repository: https://github.com/openfaas-incubator/python-flask-template
2018/11/26 02:04:31 Attempting to expand templates from https://github.com/openfaas-incubator/python-flask-template
2018/11/26 02:04:33 Fetched 3 template(s) : [python27-flask python3-flask python3-flask-armhf] from https://github.com/openfaas-incubator/python-flask-template
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
