### PR TITLE
Add template store describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ In order to see what templates are available in the store type `faas-cli templat
 
 To pull templates from the store just write the name of the template you want `faas-cli template store pull go` or the repository and name `faas-cli template store pull openfaas/go`
 
+To get more detail on a template just use the `template store describe` command and pick a template of your choice, example with `go` would look like this `faas-cli template store describe go`
+
 > Note: This feature is still in experimental stage and in the future the CLI verbs might be changed
 
 #### HMAC

--- a/commands/template_store_describe.go
+++ b/commands/template_store_describe.go
@@ -1,0 +1,84 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	templateStoreDescribeCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, "Use as alternative store for templates")
+
+	templateStoreCmd.AddCommand(templateStoreDescribeCmd)
+}
+
+var templateStoreDescribeCmd = &cobra.Command{
+	Use:   `describe`,
+	Short: `Describe the template`,
+	Long:  `Describe the template by outputting all the fields that the template struct has`,
+	Example: `  faas-cli template store describe golang-http
+  faas-cli template store describe haskell --url https://raw.githubusercontent.com/custom/store/master/templates.json`,
+	RunE: runTemplateStoreDescribe,
+}
+
+func runTemplateStoreDescribe(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("\nNeed to specify one of the store templates, check available ones by running the command:\n\nfaas-cli template store list\n")
+	}
+	if len(args) > 1 {
+		return fmt.Errorf("\nNeed to specify single template from the store, check available ones by running the command:\n\nfaas-cli template store list\n")
+	}
+	envTemplateRepoStore := os.Getenv(templateStoreURLEnvironment)
+	storeURL := getTemplateStoreURL(templateStoreURL, envTemplateRepoStore, DefaultTemplatesStore)
+
+	templatesInfo, templatesErr := getTemplateInfo(storeURL)
+	if templatesErr != nil {
+		return fmt.Errorf("error while getting templates info: %s", templatesErr)
+	}
+	template := args[0]
+	storeTemplate, templateErr := checkExistingTemplate(templatesInfo, template)
+	if templateErr != nil {
+		return fmt.Errorf("error while searching for template in store: %s", templateErr.Error())
+	}
+
+	templateInfo := formatTemplateOutput(storeTemplate)
+	fmt.Fprintf(cmd.OutOrStdout(), "%s", templateInfo)
+
+	return nil
+}
+
+func checkExistingTemplate(storeTemplates []TemplateInfo, template string) (TemplateInfo, error) {
+	var existingTemplate TemplateInfo
+	for _, storeTemplate := range storeTemplates {
+		sourceName := fmt.Sprintf("%s/%s", storeTemplate.Source, storeTemplate.TemplateName)
+		if template == storeTemplate.TemplateName || template == sourceName {
+			existingTemplate = storeTemplate
+			return existingTemplate, nil
+		}
+	}
+	return existingTemplate, fmt.Errorf("template with name: `%s` does not exist in the store", template)
+}
+
+func formatTemplateOutput(storeTemplate TemplateInfo) string {
+	var buff bytes.Buffer
+	lineWriter := tabwriter.NewWriter(&buff, 0, 0, 1, ' ', 0)
+	fmt.Fprintln(lineWriter)
+	fmt.Fprintf(lineWriter, "Name:\t%s\n", storeTemplate.TemplateName)
+	fmt.Fprintf(lineWriter, "Platform:\t%s\n", storeTemplate.Platform)
+	fmt.Fprintf(lineWriter, "Language:\t%s\n", storeTemplate.Language)
+	fmt.Fprintf(lineWriter, "Source:\t%s\n", storeTemplate.Source)
+	fmt.Fprintf(lineWriter, "Description:\t%s\n", storeTemplate.Description)
+	fmt.Fprintf(lineWriter, "Repository:\t%s\n", storeTemplate.Repository)
+	fmt.Fprintf(lineWriter, "Official Template:\t%s\n", storeTemplate.Official)
+	fmt.Fprintln(lineWriter)
+
+	lineWriter.Flush()
+
+	return buff.String()
+}

--- a/guide/TEMPLATE.md
+++ b/guide/TEMPLATE.md
@@ -93,3 +93,15 @@ export OPENFAAS_TEMPLATE_STORE_URL=https://raw.githubusercontent.com/user/openfa
 ```
 
 Now the source of the store is changed to the URL you have specified above.
+
+To get specific information for a template use the following command:
+
+```bash
+faas-cli template store describe golang-middleware
+```
+
+or use the source and the name in case of name collision:
+
+```bash
+faas-cli template store describe openfaas-incubator/golang-middleware
+```


### PR DESCRIPTION
Adding template store describe command to output
the whole json template object aka. describing the
template

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Adding `template store describe` to output the fields in the `.json` template object

## Description
<!--- Describe your changes in detail -->

Adds a way to describe a single template by outputting every field from the json struct the following way:

```
> ./faas-cli template store describe go

Name:              go
Platform:          x86_64
Language:          Go
Source:            openfaas
Description:       Official Golang template
Repository:        https://github.com/openfaas/templates
Official Template: true

```

The store location URL is copied from list so it is `argument` > `env_var` > `default`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Closes #563 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual:

```
> ./faas-cli template store describe

Need to specify one of the store templates, check available ones by running the command:

faas-cli template store list

```

```
> ./faas-cli template store describe asd
Error while searching for template in store: template with name: `asd` does not exist in the store
```

```
> ./faas-cli template store describe go

Name:              go
Platform:          x86_64
Language:          Go
Source:            openfaas
Description:       Official Golang template
Repository:        https://github.com/openfaas/templates
Official Template: true

```

```
> ./faas-cli template store describe go --url asd
Error while getting templates info: error while requesting template list: Get asd: unsupported protocol scheme ""
```

```
> ./faas-cli template store describe openfaas-incubator/golang-http

Name:              golang-http
Platform:          x86_64
Language:          Go
Source:            openfaas-incubator
Description:       Golang HTTP template
Repository:        https://github.com/openfaas-incubator/golang-http-template
Official Template: false

```

The `attribute` > `env_var` > `default store` can be seen here
```
> export OPENFAAS_TEMPLATE_STORE_URL=swag
> ./faas-cli template store describe go
Error while getting templates info: error while requesting template list: Get swag: unsupported protocol scheme ""
> ./faas-cli template store describe go --url=asd
Error while getting templates info: error while requesting template list: Get asd: unsupported protocol scheme ""
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
