### PR TITLE
Add platform flag to template store

### DIFF
--- a/commands/template_store_list.go
+++ b/commands/template_store_list.go
@@ -20,15 +20,19 @@ import (
 const (
 	// DefaultTemplatesStore is the URL where the official store can be found
 	DefaultTemplatesStore = "https://raw.githubusercontent.com/openfaas/store/master/templates.json"
+	allPlatforms          = "allPlatforms"
 )
 
 var (
-	templateStoreURL string
+	templateStoreURL   string
+	platform           string
+	availablePlatforms = [...]string{"armhf", "x86_64", "arm64"}
 )
 
 func init() {
 	templateStoreListCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Shows additional language and platform")
 	templateStoreListCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, "Use as alternative store for templates")
+	templateStoreListCmd.Flags().StringVarP(&platform, "platform", "p", allPlatforms, "Shows the platform if the output is verbose")
 
 	templateStoreCmd.AddCommand(templateStoreListCmd)
 }
@@ -42,7 +46,8 @@ var templateStoreListCmd = &cobra.Command{
 	Example: `  faas-cli template store list
   faas-cli template store ls
   faas-cli template store ls --url=https://raw.githubusercontent.com/openfaas/store/master/templates.json
-  faas-cli template store ls --verbose=true`,
+  faas-cli template store ls --verbose=true
+  faas-cli template store list --platform arm64`,
 	RunE: runTemplateStoreList,
 }
 
@@ -55,7 +60,7 @@ func runTemplateStoreList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error while getting templates info: %s", templatesErr)
 	}
 
-	formattedOutput := formatTemplatesOutput(templatesInfo, verbose)
+	formattedOutput := formatTemplatesOutput(templatesInfo, verbose, platform)
 
 	fmt.Fprintf(cmd.OutOrStdout(), "%s", formattedOutput)
 
@@ -100,15 +105,22 @@ func getTemplateInfo(repository string) ([]TemplateInfo, error) {
 	return templatesInfo, nil
 }
 
-func formatTemplatesOutput(templates []TemplateInfo, verbose bool) string {
+func formatTemplatesOutput(templates []TemplateInfo, verbose bool, platform string) string {
+	if platform != allPlatforms {
+		err := checkExistingPlatforms(platform)
+		if err != nil {
+			return err.Error()
+		}
+	}
+
 	var buff bytes.Buffer
 	lineWriter := tabwriter.NewWriter(&buff, 0, 0, 1, ' ', 0)
 
 	fmt.Fprintln(lineWriter)
 	if verbose {
-		formatVerboseOutput(lineWriter, templates)
+		formatVerboseOutput(lineWriter, templates, platform)
 	} else {
-		formatBasicOutput(lineWriter, templates)
+		formatBasicOutput(lineWriter, templates, platform)
 	}
 	fmt.Fprintln(lineWriter)
 
@@ -117,25 +129,51 @@ func formatTemplatesOutput(templates []TemplateInfo, verbose bool) string {
 	return buff.String()
 }
 
-func formatBasicOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo) {
-	fmt.Fprintf(lineWriter, "NAME\tSOURCE\tDESCRIPTION\n")
-	for _, template := range templates {
-		fmt.Fprintf(lineWriter, "%s\t%s\t%s\n",
-			template.TemplateName,
-			template.Source,
-			template.Description)
+func formatBasicOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo, platform string) {
+	if platform != allPlatforms {
+		fmt.Fprintf(lineWriter, "NAME\tSOURCE\tDESCRIPTION\n")
+		for _, template := range templates {
+			if template.Platform == platform {
+				fmt.Fprintf(lineWriter, "%s\t%s\t%s\n",
+					template.TemplateName,
+					template.Source,
+					template.Description)
+			}
+		}
+	} else {
+		fmt.Fprintf(lineWriter, "NAME\tSOURCE\tDESCRIPTION\n")
+		for _, template := range templates {
+			fmt.Fprintf(lineWriter, "%s\t%s\t%s\n",
+				template.TemplateName,
+				template.Source,
+				template.Description)
+		}
 	}
 }
 
-func formatVerboseOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo) {
-	fmt.Fprintf(lineWriter, "NAME\tLANGUAGE\tPLATFORM\tSOURCE\tDESCRIPTION\n")
-	for _, template := range templates {
-		fmt.Fprintf(lineWriter, "%s\t%s\t%s\t%s\t%s\n",
-			template.TemplateName,
-			template.Language,
-			template.Platform,
-			template.Source,
-			template.Description)
+func formatVerboseOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo, platform string) {
+	if platform != allPlatforms {
+		fmt.Fprintf(lineWriter, "NAME\tLANGUAGE\tPLATFORM\tSOURCE\tDESCRIPTION\n")
+		for _, template := range templates {
+			if template.Platform == platform {
+				fmt.Fprintf(lineWriter, "%s\t%s\t%s\t%s\t%s\n",
+					template.TemplateName,
+					template.Language,
+					template.Platform,
+					template.Source,
+					template.Description)
+			}
+		}
+	} else {
+		fmt.Fprintf(lineWriter, "NAME\tLANGUAGE\tPLATFORM\tSOURCE\tDESCRIPTION\n")
+		for _, template := range templates {
+			fmt.Fprintf(lineWriter, "%s\t%s\t%s\t%s\t%s\n",
+				template.TemplateName,
+				template.Language,
+				template.Platform,
+				template.Source,
+				template.Description)
+		}
 	}
 }
 
@@ -148,4 +186,16 @@ type TemplateInfo struct {
 	Description  string `json:"description"`
 	Repository   string `json:"repo"`
 	Official     string `json:"official"`
+}
+
+func checkExistingPlatforms(platform string) error {
+	var err error
+	for lastPlatform, availablePlatform := range availablePlatforms {
+		if availablePlatform == platform {
+			break
+		} else if len(availablePlatforms)-1 == lastPlatform {
+			err = fmt.Errorf("\nCurrently supported platforms are: armhf, arm64 and x86_64. Unable to find: %s\n\n", platform)
+		}
+	}
+	return err
 }

--- a/commands/template_store_list_test.go
+++ b/commands/template_store_list_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"testing"
+)
+
+func Test_FilterTemplate(t *testing.T) {
+	// Template objects containing
+	// architectures as the template
+	// store would provide
+	templates := []TemplateInfo{
+		{
+			Platform: "arm64",
+		},
+		{
+			Platform: "armhf",
+		},
+		{
+			Platform: "x86_64",
+		},
+	}
+	// Valid values a user can give to the --platform flag
+	validPlatforms := []string{"ARMHF", "armhf", "ARM64", "arm64", "X86_64", "x86_64"}
+	for _, validPlatform := range validPlatforms {
+		filteredTemplate := filterTemplate(templates, validPlatform)
+		if len(filteredTemplate) != 1 {
+			t.Errorf("Expected one object to be filtered got: %d", len(filteredTemplate))
+		}
+	}
+}


### PR DESCRIPTION
Adding platform flag to template store to filter
the templates by platform

Signed-off-by: Martin Dekov (VMware) <mdekov@vmware.com>

<!--- Provide a general summary of your changes in the Title above -->

Adding `--platform` flag to filter by platform

## Description
<!--- Describe your changes in detail -->

Adding `--platform`/`-p` flag to filter templates by existing platforms from `PLATFORM` field 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #570 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually:

Normal invocation of command:
```
> ./faas-cli template store list

NAME                    SOURCE             DESCRIPTION
csharp                  openfaas           Official C# template
dockerfile              openfaas           Official Dockerfile template
go-armhf                openfaas           Official Golang armhf template
go                      openfaas           Official Golang template
java8                   openfaas           Official Java 8 template
node-arm64              openfaas           Official NodeJS 8 arm64 template
node                    openfaas           Official NodeJS 8 template
php7                    openfaas           Official PHP 7 template
python-armhf            openfaas           Official Python 2.7 armhf template
python                  openfaas           Official Python 2.7 template
python3-armhf           openfaas           Official Python 3.6 armhf template
python3                 openfaas           Official Python 3.6 template
ruby                    openfaas           Official Ruby 2.5 template
node10-express-armhf    openfaas-incubator NodeJS 10 Express armhf template
node10-express          openfaas-incubator NodeJS 10 Express template
ruby-http               openfaas-incubator Ruby 2.4 HTTP template
python27-flask          openfaas-incubator Python 2.7 Flask template
python3-flask-armhf     openfaas-incubator Python 3.6 Flask armhf template
python3-flask           openfaas-incubator Python 3.6 Flask template
node8-express-armhf     openfaas-incubator NodeJS 8 Express armhf template
node8-express           openfaas-incubator NodeJS 8 Express template
golang-http-armhf       openfaas-incubator Golang HTTP armhf template
golang-http             openfaas-incubator Golang HTTP template
golang-middleware-armhf openfaas-incubator Golang Middleware armhf template
golang-middleware       openfaas-incubator Golang Middleware template
python3-debian          openfaas-incubator Python 3.6 Debian template
powershell-template     openfaas-incubator Powershell Ubuntu:16.04 template
rust                    booyaa             Rust template
crystal                 tpei               Crystal template
```
Invocation with all available platforms:
```
> ./faas-cli template store list --platform armhf

NAME                    SOURCE             DESCRIPTION
go-armhf                openfaas           Official Golang armhf template
python-armhf            openfaas           Official Python 2.7 armhf template
python3-armhf           openfaas           Official Python 3.6 armhf template
node10-express-armhf    openfaas-incubator NodeJS 10 Express armhf template
python3-flask-armhf     openfaas-incubator Python 3.6 Flask armhf template
node8-express-armhf     openfaas-incubator NodeJS 8 Express armhf template
golang-http-armhf       openfaas-incubator Golang HTTP armhf template
golang-middleware-armhf openfaas-incubator Golang Middleware armhf template

 > ./faas-cli template store list --platform arm64

NAME       SOURCE   DESCRIPTION
node-arm64 openfaas Official NodeJS 8 arm64 template

> ./faas-cli template store list --platform x86_64

NAME                SOURCE             DESCRIPTION
csharp              openfaas           Official C# template
dockerfile          openfaas           Official Dockerfile template
go                  openfaas           Official Golang template
java8               openfaas           Official Java 8 template
node                openfaas           Official NodeJS 8 template
php7                openfaas           Official PHP 7 template
python              openfaas           Official Python 2.7 template
python3             openfaas           Official Python 3.6 template
ruby                openfaas           Official Ruby 2.5 template
node10-express      openfaas-incubator NodeJS 10 Express template
ruby-http           openfaas-incubator Ruby 2.4 HTTP template
python27-flask      openfaas-incubator Python 2.7 Flask template
python3-flask       openfaas-incubator Python 3.6 Flask template
node8-express       openfaas-incubator NodeJS 8 Express template
golang-http         openfaas-incubator Golang HTTP template
golang-middleware   openfaas-incubator Golang Middleware template
python3-debian      openfaas-incubator Python 3.6 Debian template
powershell-template openfaas-incubator Powershell Ubuntu:16.04 template
rust                booyaa             Rust template
crystal             tpei               Crystal template

```

Command with wrong string aka not supported:
```
> ./faas-cli template store list --platform randomstring

Currently supported platforms are: armhf, arm64 and x86_64. Unable to find: randomstring

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
