### PR TITLE
Add build-label flag for build command

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -107,6 +108,7 @@ func Test_buildFlagSlice(t *testing.T) {
 		buildArgMap   map[string]string
 		buildPackages []string
 		expectedSlice []string
+		buildLabelMap map[string]string
 	}{
 		{
 			title:         "no cache only",
@@ -218,14 +220,47 @@ func Test_buildFlagSlice(t *testing.T) {
 			buildPackages: []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
+		{
+			title:      "single build-label value",
+			nocache:    false,
+			squash:     false,
+			httpProxy:  "",
+			httpsProxy: "",
+			buildArgMap: map[string]string{
+				"muppets":    "burt and ernie",
+				"playschool": "Jemima",
+			},
+			buildPackages: []string{},
+			buildLabelMap: map[string]string{
+				"org.label-schema.name": "test function",
+			},
+			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima", "--label", "org.label-schema.name=test function"},
+		},
+		{
+			title:      "multiple build-label values",
+			nocache:    false,
+			squash:     false,
+			httpProxy:  "",
+			httpsProxy: "",
+			buildArgMap: map[string]string{
+				"muppets":    "burt and ernie",
+				"playschool": "Jemima",
+			},
+			buildPackages: []string{},
+			buildLabelMap: map[string]string{
+				"org.label-schema.name":        "test function",
+				"org.label-schema.description": "This is a test function",
+			},
+			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima", "--label", "org.label-schema.name=test function", "--label", "org.label-schema.description=This is a test function"},
+		},
 	}
 
 	for _, test := range buildFlagOpts {
 
 		t.Run(test.title, func(t *testing.T) {
 
-			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap, test.buildPackages)
-
+			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap, test.buildPackages, test.buildLabelMap)
+			fmt.Println(flagSlice)
 			if len(flagSlice) != len(test.expectedSlice) {
 				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedSlice), len(flagSlice))
 			}

--- a/commands/build.go
+++ b/commands/build.go
@@ -19,14 +19,16 @@ import (
 
 // Flags that are to be added to commands.
 var (
-	nocache      bool
-	squash       bool
-	parallel     int
-	shrinkwrap   bool
-	buildArgs    []string
-	buildArgMap  map[string]string
-	buildOptions []string
-	tag          string
+	nocache       bool
+	squash        bool
+	parallel      int
+	shrinkwrap    bool
+	buildArgs     []string
+	buildArgMap   map[string]string
+	buildOptions  []string
+	tag           string
+	buildLabels   []string
+	buildLabelMap map[string]string
 )
 
 func init() {
@@ -44,6 +46,7 @@ func init() {
 	buildCmd.Flags().StringArrayVarP(&buildArgs, "build-arg", "b", []string{}, "Add a build-arg for Docker (KEY=VALUE)")
 	buildCmd.Flags().StringArrayVarP(&buildOptions, "build-option", "o", []string{}, "Set a build option, e.g. dev")
 	buildCmd.Flags().StringVar(&tag, "tag", "", "Override latest tag on function Docker image, takes 'sha' or 'branch'")
+	buildCmd.Flags().StringArrayVar(&buildLabels, "build-label", []string{}, "Add a label for Docker image (LABEL=VALUE)")
 
 	// Set bash-completion.
 	_ = buildCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
@@ -92,7 +95,37 @@ func preRunBuild(cmd *cobra.Command, args []string) error {
 		buildArgMap = mapped
 	}
 
+	buildLabelMap, err = parseBuildLabel(buildLabels)
+
 	return err
+}
+
+func parseBuildLabel(args []string) (map[string]string, error) {
+	mapped := make(map[string]string)
+
+	for _, kvp := range args {
+		index := strings.Index(kvp, "=")
+		if index == -1 {
+			return nil, fmt.Errorf("each build-label must take the form key=value")
+		}
+
+		values := []string{kvp[0:index], kvp[index+1:]}
+
+		k := strings.TrimSpace(values[0])
+		v := strings.TrimSpace(values[1])
+
+		if len(k) == 0 {
+			return nil, fmt.Errorf("build-label must have a non-empty key")
+		}
+
+		if len(v) == 0 {
+			return nil, fmt.Errorf("build-label must have a non-empty value")
+		}
+
+		mapped[k] = v
+	}
+
+	return mapped, nil
 }
 
 func parseBuildArgs(args []string) (map[string]string, error) {
@@ -158,7 +191,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		if len(functionName) == 0 {
 			return fmt.Errorf("please provide the deployed --name of your function")
 		}
-		err := builder.BuildImage(image, handler, functionName, language, nocache, squash, shrinkwrap, buildArgMap, buildOptions, tag)
+		err := builder.BuildImage(image, handler, functionName, language, nocache, squash, shrinkwrap, buildArgMap, buildOptions, tag, buildLabelMap)
 		if err != nil {
 			return err
 		}
@@ -182,7 +215,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap bool) {
 				} else {
 
 					combinedBuildOptions := combineBuildOpts(function.BuildOptions, buildOptions)
-					err := builder.BuildImage(function.Image, function.Handler, function.Name, function.Language, nocache, squash, shrinkwrap, buildArgMap, combinedBuildOptions, tag)
+					err := builder.BuildImage(function.Image, function.Handler, function.Name, function.Language, nocache, squash, shrinkwrap, buildArgMap, combinedBuildOptions, tag, buildLabelMap)
 					if err != nil {
 						log.Println(err)
 					}


### PR DESCRIPTION
This changes add --build-label flag to function build command which can
be used to add additional metadata information for function images using
docker labels.

Fixes #567

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#567

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on my local on Docker for mac. 

1. Create a new function using 
    `faas-cli new label-func --lang=python --prefix=viveksyngh`

2. Build the function and pass build label values 

`./faas-cli build --build-label org.label-schema.vcs-url="https://github.com/nginx/nginx"  --build-label org.label-schema.description="Test function with docker labels"`

3. Then inspect the docker image with below command

`docker inspect viveksyngh/label-func` 

```json
...
"Labels": {
                "org.label-schema.description": "Test function with docker labels",
                "org.label-schema.vcs-url": "https://github.com/nginx/nginx"
            }
...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
