### PR TITLE
Implement pinned template repo clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ export OPENFAAS_URL=127.0.0.1:31112
 
 Advanced commands:
 
-* `faas-cli template pull` - pull in templates from a remote GitHub repository [Detailed Documentation](guide/TEMPLATE.md)
+* `faas-cli template pull` - pull in templates from a remote git repository [Detailed Documentation](guide/TEMPLATE.md)
 
-The default template URL of `https://github.com/openfaas/templates.git` can be overriden in two places including an environmental variable
+The default template URL of `https://github.com/openfaas/templates.git` can be overridden in two places including an environmental variable
 
 * 1st priority CLI input
 * 2nd priority `OPENFAAS_TEMPLATE_URL` environmental variable

--- a/commands/build.go
+++ b/commands/build.go
@@ -13,6 +13,7 @@ import (
 	"github.com/morikuni/aec"
 	"github.com/openfaas/faas-cli/builder"
 	"github.com/openfaas/faas-cli/stack"
+	"github.com/openfaas/faas-cli/versioncontrol"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +76,7 @@ via flags.`,
   faas-cli build -f ./stack.yml --tag branch
   faas-cli build -f ./stack.yml --filter "*gif*"
   faas-cli build -f ./stack.yml --regex "fn[0-9]_.*"
-  faas-cli build --image=my_image --lang=python --handler=/path/to/fn/ 
+  faas-cli build --image=my_image --lang=python --handler=/path/to/fn/
                  --name=my_fn --squash`,
 	PreRunE: preRunBuild,
 	RunE:    runBuild,
@@ -209,14 +210,15 @@ func build(services *stack.Services, queueDepth int, shrinkwrap bool) {
 
 }
 
-// PullTemplates pulls templates from Github from the master zip download file.
+// PullTemplates pulls templates from specified git remote. templateURL may be a pinned repository.
 func PullTemplates(templateURL string) error {
 	var err error
 	exists, err := os.Stat("./template")
 	if err != nil || exists == nil {
 		log.Println("No templates found in current directory.")
 
-		err = fetchTemplates(templateURL, false)
+		templateURL, refName := versioncontrol.ParsePinnedRemote(templateURL)
+		err = fetchTemplates(templateURL, refName, false)
 		if err != nil {
 			log.Println("Unable to download templates from Github.")
 			return err

--- a/commands/fetch_templates.go
+++ b/commands/fetch_templates.go
@@ -19,8 +19,8 @@ const DefaultTemplateRepository = "https://github.com/openfaas/templates.git"
 
 const templateDirectory = "./template/"
 
-// fetchTemplates fetch code templates from GitHub master zip file.
-func fetchTemplates(templateURL string, overwrite bool) error {
+// fetchTemplates fetch code templates using git clone.
+func fetchTemplates(templateURL string, refName string, overwrite bool) error {
 	if len(templateURL) == 0 {
 		return fmt.Errorf("pass valid templateURL")
 	}
@@ -35,7 +35,7 @@ func fetchTemplates(templateURL string, overwrite bool) error {
 
 	log.Printf("Attempting to expand templates from %s\n", templateURL)
 	pullDebugPrint(fmt.Sprintf("Temp files in %s", dir))
-	args := map[string]string{"dir": dir, "repo": templateURL}
+	args := map[string]string{"dir": dir, "repo": templateURL, "refname": refName}
 	if err := versioncontrol.GitClone.Invoke(".", args); err != nil {
 		return err
 	}

--- a/commands/fetch_templates_test.go
+++ b/commands/fetch_templates_test.go
@@ -27,7 +27,7 @@ func Test_PullTemplates(t *testing.T) {
 	t.Run("fetchTemplates", func(t *testing.T) {
 		defer tearDownFetchTemplates(t)
 
-		err := fetchTemplates(localTemplateRepository, false)
+		err := fetchTemplates(localTemplateRepository, "master", false)
 		if err != nil {
 			t.Error(err)
 		}

--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -26,11 +26,17 @@ func init() {
 // templatePullCmd allows the user to fetch a template from a repository
 var templatePullCmd = &cobra.Command{
 	Use:   `pull [REPOSITORY_URL]`,
-	Short: `Downloads templates from the specified github repo`,
-	Long: `Downloads the compressed github repo specified by [URL], and extracts the 'template'
-	directory from the root of the repo, if it exists.`,
-	Example: "faas-cli template pull https://github.com/openfaas/faas-cli",
-	RunE:    runTemplatePull,
+	Short: `Downloads templates from the specified git repo`,
+	Long: `Downloads templates from the specified git repo specified by [REPOSITORY_URL], and copies the 'template'
+directory from the root of the repo, if it exists.
+
+[REPOSITORY_URL] may specify a specific branch or tag to copy by adding a URL fragment with the branch or tag name.
+	`,
+	Example: `
+  faas-cli template pull https://github.com/openfaas/templates
+  faas-cli template pull https://github.com/openfaas/templates#1.0
+`,
+	RunE: runTemplatePull,
 }
 
 func runTemplatePull(cmd *cobra.Command, args []string) error {

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -82,59 +82,6 @@ func Test_templatePull(t *testing.T) {
 		}
 	})
 }
-
-func Test_repositoryUrlRemoteRegExp(t *testing.T) {
-
-	r := regexp.MustCompile(gitRemoteRepoRegex)
-	validURLs := []struct {
-		name string
-		url  string
-	}{
-		{name: "git protocol with sha", url: "git://github.com/openfaas/faas.git#ff78lf9h"},
-		{name: "git protocol without .git suffix", url: "git://host.xz/path/to/repo"},
-		{name: "git protocol with branch", url: "git://github.com/openfaas/faas.git#master"},
-		{name: "git protocol", url: "git://host.xz/path/to/repo.git/"},
-		{name: "scp style with ip address", url: "git@192.168.101.127:user/project.git"},
-		{name: "scp style with hostname", url: "git@github.com:user/project.git"},
-		{name: "http protocol with ip address", url: "http://192.168.101.127/user/project.git"},
-		{name: "http protocol", url: "http://github.com/user/project.git"},
-		{name: "http protocol without .git suffix", url: "http://github.com/user/project"},
-		{name: "https protocol with ip address", url: "https://192.168.101.127/user/project.git"},
-		{name: "https protocol with hostname", url: "https://github.com/user/project.git"},
-		{name: "https protocol with basic auth", url: "https://username:password@github.com/username/repository.git"},
-		{name: "ssh protocol with hostname no port", url: "ssh://user@host.xz/path/to/repo.git/"},
-		{name: "ssh protocol with hostname and port", url: "ssh://user@host.xz:port/path/to/repo.git/"},
-	}
-
-	for _, scenario := range validURLs {
-		t.Run(fmt.Sprintf("%s is a valid remote git url", scenario.name), func(t *testing.T) {
-			if !r.MatchString(scenario.url) {
-				t.Errorf("Url %s should pass the regex %s", scenario.url, gitRemoteRepoRegex)
-			}
-
-		})
-	}
-
-	invalidURLs := []struct {
-		name string
-		url  string
-	}{
-		{name: "local repo file protocol", url: "file:///path/to/repo.git/"},
-		{name: "ssh missing username and port", url: "host.xz:/path/to/repo.git"},
-		{name: "ssh username and missing port", url: "user@host.xz:path/to/repo.git"},
-		{name: "relative local path", url: "path/to/repo.git/"},
-		{name: "magic relative local", url: "~/path/to/repo.git"},
-	}
-	for _, scenario := range invalidURLs {
-		t.Run(fmt.Sprintf("%s is not a valid remote git url", scenario.name), func(t *testing.T) {
-			if r.MatchString(scenario.url) {
-				t.Errorf("Url %s should fail the regex %s", scenario.url, gitRemoteRepoRegex)
-			}
-
-		})
-	}
-}
-
 func Test_templatePullPriority(t *testing.T) {
 	templateURLs := []struct {
 		name      string

--- a/guide/TEMPLATE.md
+++ b/guide/TEMPLATE.md
@@ -59,6 +59,16 @@ export OPENFAAS_TEMPLATE_URL="https://github.com/openfaas-incubator/golang-http-
 faas-cli template pull
 ```
 
+## Pin the template repository version
+
+You may specify the branch or tag pulled by adding a URL fragment with the branch or tag name. For example, to pull the `1.0` tag of the default template repository, use
+
+```bash
+faas-cli template pull https://github.com/openfaas/templates#1.0
+```
+
+If a branch or tag is not specified, the repositories default branch is pulled (usually `master`).
+
 
 ## List locally available languages
 

--- a/versioncontrol/git.go
+++ b/versioncontrol/git.go
@@ -4,7 +4,23 @@ package versioncontrol
 var GitClone = &vcsCmd{
 	name:   "Git",
 	cmd:    "git",
-	cmds:   []string{"clone {repo} {dir} --depth=1 --config core.autocrlf=false"},
+	cmds:   []string{"clone {repo} {dir} --depth=1 --config core.autocrlf=false -b {refname}"},
+	scheme: []string{"git", "https", "http", "git+ssh", "ssh"},
+}
+
+// GitCheckout defines the command to clone a repo into a directory
+var GitCheckout = &vcsCmd{
+	name:   "Git",
+	cmd:    "git",
+	cmds:   []string{"-C {dir} checkout {refname}"},
+	scheme: []string{"git", "https", "http", "git+ssh", "ssh"},
+}
+
+// GitCheckRefName defines the command that validates if a string is a valid reference name or sha
+var GitCheckRefName = &vcsCmd{
+	name:   "Git",
+	cmd:    "git",
+	cmds:   []string{"check-ref-format --allow-onelevel {refname}"},
 	scheme: []string{"git", "https", "http", "git+ssh", "ssh"},
 }
 

--- a/versioncontrol/parse.go
+++ b/versioncontrol/parse.go
@@ -1,0 +1,61 @@
+package versioncontrol
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	pinCharater              = `#`
+	gitRemoteRegexpStr       = `(git|ssh|https?|git@[-\w.]+):(\/\/)?([^#]*?(?:\.git)?\/?)`
+	gitPinnedRemoteRegexpStr = gitRemoteRegexpStr + pinCharater + `[-\/\d\w._]+$`
+	gitRemoteRepoRegexpStr   = gitRemoteRegexpStr + `$`
+)
+
+var (
+	gitPinnedRegexp = regexp.MustCompile(gitPinnedRemoteRegexpStr)
+	gitRemoteRegexp = regexp.MustCompile(gitRemoteRepoRegexpStr)
+)
+
+// IsGitRemote validates if the supplied string is a valid git remote url value
+func IsGitRemote(repoURL string) bool {
+	// If using a Regexp in multiple goroutines,
+	// giving each goroutine its own copy helps to avoid lock contention.
+	// https://golang.org/pkg/regexp/#Regexp.Copy
+	return gitRemoteRegexp.Copy().MatchString(repoURL)
+}
+
+// IsPinnedGitRemote validates if the supplied string is a valid git remote url value
+func IsPinnedGitRemote(repoURL string) bool {
+	// If using a Regexp in multiple goroutines,
+	// giving each goroutine its own copy helps to avoid lock contention.
+	// https://golang.org/pkg/regexp/#Regexp.Copy
+	return gitPinnedRegexp.Copy().MatchString(repoURL)
+}
+
+// ParsePinnedRemote returns the remote url and contraint value from repository url
+func ParsePinnedRemote(repoURL string) (remoteURL, refName string) {
+	refName = "master"
+	remoteURL = repoURL
+
+	// If using a Regexp in multiple goroutines,
+	// giving each goroutine its own copy helps to avoid lock contention.
+	// https://golang.org/pkg/regexp/#Regexp.Copy
+	if !IsPinnedGitRemote(repoURL) {
+		return remoteURL, refName
+	}
+
+	// handle ssh special case
+
+	atIndex := strings.LastIndex(repoURL, pinCharater)
+	if atIndex > 0 {
+		refName = repoURL[atIndex+len(pinCharater):]
+		remoteURL = repoURL[:atIndex]
+	}
+
+	if !IsGitRemote(remoteURL) {
+		return repoURL, "master"
+	}
+
+	return remoteURL, refName
+}

--- a/versioncontrol/parse_test.go
+++ b/versioncontrol/parse_test.go
@@ -1,0 +1,159 @@
+package versioncontrol
+
+import (
+	"fmt"
+	"testing"
+)
+
+func Test_IsGitRemote(t *testing.T) {
+
+	validURLs := []struct {
+		name string
+		url  string
+	}{
+		{name: "git protocol without .git suffix", url: "git://host.xz/path/to/repo"},
+		{name: "git protocol", url: "git://host.xz/path/to/repo.git/"},
+		{name: "scp style with ip address", url: "git@192.168.101.127:user/project.git"},
+		{name: "scp style with hostname", url: "git@github.com:user/project.git"},
+		{name: "http protocol with ip address", url: "http://192.168.101.127/user/project.git"},
+		{name: "http protocol", url: "http://github.com/user/project.git"},
+		{name: "http protocol without .git suffix", url: "http://github.com/user/project"},
+		{name: "https protocol with ip address", url: "https://192.168.101.127/user/project.git"},
+		{name: "https protocol with hostname", url: "https://github.com/user/project.git"},
+		{name: "https protocol with basic auth", url: "https://username:password@github.com/username/repository.git"},
+		{name: "ssh protocol with hostname no port", url: "ssh://user@host.xz/path/to/repo.git/"},
+		{name: "ssh protocol with hostname and port", url: "ssh://user@host.xz:port/path/to/repo.git/"},
+	}
+
+	for _, scenario := range validURLs {
+		t.Run(fmt.Sprintf("%s is a valid remote git url", scenario.name), func(t *testing.T) {
+			if !IsGitRemote(scenario.url) {
+				t.Errorf("Url %s should pass the regex %s", scenario.url, gitRemoteRepoRegexpStr)
+			}
+
+		})
+	}
+
+	invalidURLs := []struct {
+		name string
+		url  string
+	}{
+		{name: "git protocol with hash", url: "git://github.com/openfaas/faas.git#ff78lf9h"},
+		{name: "local repo file protocol", url: "file:///path/to/repo.git/"},
+		{name: "ssh missing username and port", url: "host.xz:/path/to/repo.git"},
+		{name: "ssh username and missing port", url: "user@host.xz:path/to/repo.git"},
+		{name: "relative local path", url: "path/to/repo.git/"},
+		{name: "magic relative local", url: "~/path/to/repo.git"},
+	}
+	for _, scenario := range invalidURLs {
+		t.Run(fmt.Sprintf("%s is not a valid remote git url", scenario.name), func(t *testing.T) {
+			if IsGitRemote(scenario.url) {
+				t.Errorf("Url %s should fail the regex %s", scenario.url, gitRemoteRepoRegexpStr)
+			}
+
+		})
+	}
+}
+
+func Test_IsPinnedGitRemote(t *testing.T) {
+
+	validURLs := []struct {
+		name string
+		url  string
+	}{
+		{name: "git protocol without .git suffix", url: "git://host.xz/path/to/repo" + pinCharater + "feature-branch"},
+		{name: "git protocol", url: "git://host.xz/path/to/repo.git/" + pinCharater + "tagname"},
+		{name: "scp style with ip address", url: "git@192.168.101.127:user/project.git" + pinCharater + "v1.2.3"},
+		{name: "scp style with hostname", url: "git@github.com:user/project.git" + pinCharater + "feature-branch"},
+		{name: "http protocol with ip address", url: "http://192.168.101.127/user/project.git" + pinCharater + "tagname"},
+		{name: "http protocol", url: "http://github.com/user/project.git" + pinCharater + "v1.2.3"},
+		{name: "http protocol without .git suffix", url: "http://github.com/user/project" + pinCharater + "feature-branch"},
+		{name: "https protocol with ip address", url: "https://192.168.101.127/user/project.git" + pinCharater + "tagname"},
+		{name: "https protocol with hostname", url: "https://github.com/user/project.git" + pinCharater + "v1.2.3"},
+		{name: "https protocol with basic auth", url: "https://username:password@github.com/username/repository.git" + pinCharater + "feature/branch"},
+		{name: "ssh protocol with hostname no port", url: "ssh://user@host.xz/path/to/repo.git/" + pinCharater + "v1.2.3"},
+		{name: "ssh protocol with hostname and port", url: "ssh://user@host.xz:port/path/to/repo.git/" + pinCharater + "tagname"},
+	}
+
+	for _, scenario := range validURLs {
+		t.Run(fmt.Sprintf("%s is a valid pinned remote git url", scenario.name), func(t *testing.T) {
+			if !IsPinnedGitRemote(scenario.url) {
+				t.Errorf("Url %s should pass the regex %s", scenario.url, gitPinnedRemoteRegexpStr)
+			}
+
+		})
+	}
+
+	invalidURLs := []struct {
+		name string
+		url  string
+	}{
+		{name: "ssh protocol with hostname no port without pin", url: "ssh://user@host.xz/path/to/repo.git/"},
+		{name: "ssh protocol with hostname and port without pin", url: "ssh://user@host.xz:port/path/to/repo.git/"},
+		{name: "scp style with ip address without pin", url: "git@192.168.101.127:user/project.git"},
+		{name: "scp style with hostname without pin", url: "git@github.com:user/project.git"},
+		{name: "git protocol without .git suffix and no tag", url: "git://host.xz/path/to/repo"},
+		{name: "git protocol with hash", url: "git://github.com/openfaas/faas.git#ff78lf9h@feature/branch"},
+		{name: "local repo file protocol", url: "file:///path/to/repo.git/@feature/branch"},
+		{name: "ssh missing username and port", url: "host.xz:/path/to/repo.git" + pinCharater + "feature-branch"},
+		{name: "ssh username and missing port", url: "user@host.xz:path/to/repo.git" + pinCharater + "v1.2.3"},
+		{name: "relative local path", url: "path/to/repo.git/@feature/branch"},
+		{name: "magic relative local", url: "~/path/to/repo.git@feature/branch"},
+	}
+	for _, scenario := range invalidURLs {
+		t.Run(fmt.Sprintf("%s is not a valid pinned remote git url", scenario.name), func(t *testing.T) {
+			if IsPinnedGitRemote(scenario.url) {
+				t.Errorf("Url %s should fail the regex %s", scenario.url, gitPinnedRemoteRegexpStr)
+			}
+
+		})
+	}
+}
+
+func Test_ParsePinnedRemote(t *testing.T) {
+
+	cases := []struct {
+		name    string
+		url     string
+		refName string
+	}{
+		{name: "git protocol without .git suffix", url: "git://host.xz/path/to/repo", refName: "feature-branch"},
+		{name: "git protocol", url: "git://host.xz/path/to/repo.git/", refName: "tagname"},
+		{name: "scp style with ip address", url: "git@192.168.101.127:user/project.git", refName: "v1.2.3"},
+		{name: "scp style with hostname", url: "git@github.com:user/project.git", refName: "feature/branch"},
+		{name: "http protocol with ip address", url: "http://192.168.101.127/user/project.git", refName: "tagname"},
+		{name: "http protocol", url: "http://github.com/user/project.git", refName: "v1.2.3"},
+		{name: "http protocol without .git suffix", url: "http://github.com/user/project", refName: "feature/branch"},
+		{name: "https protocol with ip address", url: "https://192.168.101.127/user/project.git", refName: "tagname"},
+		{name: "https protocol with hostname", url: "https://github.com/user/project.git", refName: "v1.2.3"},
+		{name: "https protocol with basic auth", url: "https://username:password@github.com/username/repository.git", refName: "feature/branch"},
+		{name: "ssh protocol with hostname no port", url: "ssh://user@host.xz/path/to/repo.git/", refName: "v1.2.3"},
+		{name: "ssh protocol with hostname and port", url: "ssh://user@host.xz:port/path/to/repo.git/", refName: "tagname"},
+	}
+
+	for _, scenario := range cases {
+		t.Run(fmt.Sprintf("can parse refname from url with %s", scenario.name), func(t *testing.T) {
+			remote, refName := ParsePinnedRemote(scenario.url + pinCharater + scenario.refName)
+			if remote != scenario.url {
+				t.Errorf("expected remote url: %s, got: %s", scenario.url, remote)
+			}
+
+			if refName != scenario.refName {
+				t.Errorf("expected refName: %s, got: %s", scenario.refName, refName)
+			}
+
+		})
+
+		t.Run(fmt.Sprintf("can parse default refname from url with %s", scenario.name), func(t *testing.T) {
+			remote, refName := ParsePinnedRemote(scenario.url)
+			if remote != scenario.url {
+				t.Errorf("expected remote url: %s, got: %s", scenario.url, remote)
+			}
+
+			if refName != "master" {
+				t.Errorf("expected refName: master, got: %s", refName)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Update `template pull` command to parse a git reference name from the
trailing hash/url fragment in the git url. This allows the user to pin the template to a specific revision or tag or even update from a specific branch.

## Description
<!--- Describe your changes in detail -->
- Add parsing utilities to check for a pinning value in the git url
- Updates git clone command to specify the branch flag
- Adds git command to validate the reference name
- Updates and adds unit tests for the new parsing

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #573 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have manually tested it locally with a private template repository.   I have used `faas-cli template pull` with my private repository, with a tag and without a tag, as well as empty with the default OF template repo.

Additionally, unit tests have been added to validate the url parsing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

Because the pin separator is `#`, this was originally validated as an valid URL but not parsed in any specific way. This fragment is not handled by the `git` CLI directly, but could possibly be handled by a remote git server.  It is important to note that GitHub does not handle a fragment in the url, it will cause a 404. By using the `#` character, it is possible that this could break for a user with a very special private git server configuration. The vast majority of users will not see any issues since most git servers can't parse or wont accept the url with a fragment. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
