### PR TITLE
Add secret list command to faas-cli

### DIFF
--- a/commands/secret.go
+++ b/commands/secret.go
@@ -1,0 +1,18 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	faasCmd.AddCommand(secretCmd)
+}
+
+var secretCmd = &cobra.Command{
+	Use:   `secret`,
+	Short: "OpenFaaS secret commands",
+	Long:  "Manage function secrets",
+}

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -4,10 +4,13 @@
 package commands
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"text/tabwriter"
 
 	"github.com/openfaas/faas-cli/proxy"
+	"github.com/openfaas/faas-cli/schema"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +18,7 @@ import (
 var secretListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all secrets",
-	Long:  `List all secrets names and metadata`,
+	Long:  `List all secrets`,
 	Example: `faas-cli secret list
 faas-cli secret list --gateway=http://127.0.0.1:8080`,
 	RunE:    runSecretList,
@@ -53,9 +56,26 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	for _, secret := range secrets {
-		fmt.Println(secret.Name)
+	if len(secrets) == 0 {
+		fmt.Println("No secret found.")
+		return nil
 	}
+	fmt.Print(renderSecretList(secrets))
 
 	return nil
+}
+
+func renderSecretList(secrets []schema.Secret) string {
+	var b bytes.Buffer
+	w := tabwriter.NewWriter(&b, 0, 0, 1, ' ', 0)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "NAME")
+
+	for _, secret := range secrets {
+		fmt.Fprintf(w, "%s\n", secret)
+	}
+
+	fmt.Fprintln(w)
+	w.Flush()
+	return b.String()
 }

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -72,7 +72,7 @@ func renderSecretList(secrets []schema.Secret) string {
 	fmt.Fprintln(w, "NAME")
 
 	for _, secret := range secrets {
-		fmt.Fprintf(w, "%s\n", secret)
+		fmt.Fprintf(w, "%s\n", secret.Name)
 	}
 
 	fmt.Fprintln(w)

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -1,0 +1,61 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/openfaas/faas-cli/proxy"
+	"github.com/spf13/cobra"
+)
+
+// secretListCmd represents the secretCreate command
+var secretListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all secrets",
+	Long:  `List all secrets names and metadata`,
+	Example: `faas-cli secret list
+faas-cli secret list --gateway=http://127.0.0.1:8080`,
+	RunE:    runSecretList,
+	PreRunE: preRunSecretListCmd,
+}
+
+func init() {
+	secretListCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
+	// secretListCmd.Flags().BoolVarP(&verboseList, "verbose", "v", false, "Verbose output for the function list")
+	secretListCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
+
+	secretCmd.AddCommand(secretListCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// secretCreateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// secretCreateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func preRunSecretListCmd(cmd *cobra.Command, args []string) error {
+	return nil
+}
+
+func runSecretList(cmd *cobra.Command, args []string) error {
+	var gatewayAddress string
+	gatewayAddress = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
+
+	secrets, err := proxy.GetSecretList(gatewayAddress, tlsInsecure)
+	if err != nil {
+		return err
+	}
+
+	for _, secret := range secrets {
+		fmt.Println(secret.Name)
+	}
+
+	return nil
+}

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -16,9 +16,10 @@ import (
 
 // secretListCmd represents the secretCreate command
 var secretListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List all secrets",
-	Long:  `List all secrets`,
+	Use:     "list",
+	Aliases: []string{"ls"},
+	Short:   "List all secrets",
+	Long:    `List all secrets`,
 	Example: `faas-cli secret list
 faas-cli secret list --gateway=http://127.0.0.1:8080`,
 	RunE:    runSecretList,

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -14,6 +14,12 @@ import (
 func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
 	var results []schema.Secret
 
+	if tlsInsecure {
+		if !strings.HasPrefix(gateway, "https") {
+			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+		}
+	}
+
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -14,7 +14,7 @@ import (
 func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
 	var results []schema.Secret
 
-	if tlsInsecure {
+	if !tlsInsecure {
 		if !strings.HasPrefix(gateway, "https") {
 			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
 		}
@@ -40,7 +40,7 @@ func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
 	}
 
 	switch res.StatusCode {
-	case http.StatusOK:
+	case http.StatusOK, http.StatusAccepted:
 
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err != nil {

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -1,0 +1,60 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/openfaas/faas-cli/schema"
+)
+
+//GetSecretList get secrets list
+func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
+	var results []schema.Secret
+
+	gateway = strings.TrimRight(gateway, "/")
+	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
+
+	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/secrets", nil)
+	SetAuth(getRequest, gateway)
+
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+	}
+
+	res, err := client.Do(getRequest)
+	if err != nil {
+		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+
+		bytesOut, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, fmt.Errorf("cannot read result from OpenFaaS on URL: %s", gateway)
+		}
+
+		jsonErr := json.Unmarshal(bytesOut, &results)
+		if jsonErr != nil {
+			return nil, fmt.Errorf("cannot parse result from OpenFaaS on URL: %s\n%s", gateway, jsonErr.Error())
+		}
+
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+
+	default:
+		bytesOut, err := ioutil.ReadAll(res.Body)
+		if err == nil {
+			return nil, fmt.Errorf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
+		}
+	}
+
+	return results, nil
+}

--- a/schema/secret.go
+++ b/schema/secret.go
@@ -11,3 +11,7 @@ type KubernetesSecretMetadata struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
+
+type Secret struct {
+	Name string `json:"name"`
+}


### PR DESCRIPTION
This commit adds `faas-cli secret list` command to the faas-cli which
will be used to get secret list from the cluster.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#577 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on local Docker for Mac with faas-swarm.

```
./faas-cli secret ls -g http://127.0.0.1:8081
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
