### PR TITLE
Moved TLS warnings to its own package

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/openfaas/faas-cli/proxy"
-
 	"github.com/openfaas/faas-cli/config"
+	"github.com/openfaas/faas-cli/faaserrors"
+	"github.com/openfaas/faas-cli/proxy"
 	"github.com/spf13/cobra"
 )
 
@@ -118,7 +118,7 @@ func validateLogin(gatewayURL string, user string, pass string) error {
 	}
 
 	if res.TLS == nil {
-		fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+		fmt.Println(faaserrors.NoTLSWarn)
 	}
 
 	switch res.StatusCode {

--- a/faaserrors/errors.go
+++ b/faaserrors/errors.go
@@ -1,0 +1,6 @@
+package faaserrors
+
+const (
+	// NoTLSWarn Warning thrown when no SSL/TLS is used
+	NoTLSWarn = "WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates."
+)

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openfaas/faas-cli/faaserrors"
 	"github.com/openfaas/faas-cli/stack"
 	"github.com/openfaas/faas/gateway/requests"
 )
@@ -80,7 +81,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 
 	if warnInsecureGateway {
 		if (spec.RegistryAuth != "") && !strings.HasPrefix(spec.Gateway, "https") {
-			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+			fmt.Println(faaserrors.NoTLSWarn)
 		}
 	}
 

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/openfaas/faas-cli/faaserrors"
 	"github.com/openfaas/faas-cli/schema"
 )
 
@@ -17,7 +18,7 @@ func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
 
 	if !tlsInsecure {
 		if !strings.HasPrefix(gateway, "https") {
-			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+			fmt.Println(faaserrors.NoTLSWarn)
 		}
 	}
 
@@ -72,7 +73,7 @@ func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 
 	if !tlsInsecure {
 		if !strings.HasPrefix(gateway, "https") {
-			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+			fmt.Println(faaserrors.NoTLSWarn)
 		}
 	}
 
@@ -124,7 +125,7 @@ func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error {
 	if !tlsInsecure {
 		if !strings.HasPrefix(gateway, "https") {
-			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+			fmt.Println(faaserrors.NoTLSWarn)
 		}
 	}
 
@@ -173,7 +174,7 @@ func CreateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 
 	if !tlsInsecure {
 		if !strings.HasPrefix(gateway, "https") {
-			fmt.Println("WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.")
+			fmt.Println(faaserrors.NoTLSWarn)
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Mario Mazo <buster.mazo@gmail.com>

Moved TLS warnings to its own package to solve #581 

## Description
I have moved the TLS warnings to its own package. I have chosen the root level because
the message is spread across several packages. Also I have used the `faaserrors` instead of
the more widely used _errors_ to avoid confusion.

## Motivation and Context
avoiding updating error/warning messages in several places
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
Tested against OpenFaaS deployed in EKS. CLI seems to work as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.