### PR TITLE
Adds tls-no-verify to secrets commands help

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openfaas/faas-cli/schema"
 	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // DeployFlags holds flags that are to be added to commands.
@@ -93,7 +93,8 @@ var deployCmd = &cobra.Command{
                   [--filter "WILDCARD"]
 				  [--secret "SECRET_NAME"]
 				  [--tag <sha|branch>]
-				  [--readonly=false]`,
+				  [--readonly=false]
+				  [--tls-no-verify]`,
 
 	Short: "Deploy OpenFaaS functions",
 	Long: `Deploys OpenFaaS function containers either via the supplied YAML config using
@@ -281,7 +282,10 @@ Error: %s`, fprocessErr.Error())
 				TLSInsecure:             tlsInsecure,
 			}
 
-			fmt.Println(checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure))
+			if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {
+				fmt.Println(msg)
+			}
+
 			statusCode := proxy.DeployFunction(deploySpec)
 
 			if badStatusCode(statusCode) {
@@ -375,7 +379,10 @@ func deployImage(
 		TLSInsecure:             tlsInsecure,
 	}
 
-	fmt.Println(checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure))
+	if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {
+		fmt.Println(msg)
+	}
+
 	statusCode = proxy.DeployFunction(deploySpec)
 
 	return statusCode, nil

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -21,7 +21,11 @@ var (
 
 // secretCreateCmd represents the secretCreate command
 var secretCreateCmd = &cobra.Command{
-	Use:   "create SECRET_NAME [--from-literal=SECRET_VALUE] [--from-file=/path/to/secret/file] [STDIN]",
+	Use: `create SECRET_NAME 
+			[--from-literal=SECRET_VALUE]
+			[--from-file=/path/to/secret/file]
+			[STDIN]
+			[--tls-no-verify]`,
 	Short: "Create a new secret",
 	Long:  `The create command creates a new secret from file, literal or STDIN`,
 	Example: `faas-cli secret create secret-name --from-literal=secret-value
@@ -92,7 +96,10 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
-	fmt.Println(checkTLSInsecure(gatewayAddress, tlsInsecure))
+
+	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
+		fmt.Println(msg)
+	}
 
 	fmt.Println("Creating secret: " + secret.Name)
 	_, output := proxy.CreateSecret(gatewayAddress, secret, tlsInsecure)

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -16,7 +16,7 @@ import (
 
 // secretListCmd represents the secretCreate command
 var secretListCmd = &cobra.Command{
-	Use:     "list",
+	Use:     `list [--tls-no-verify]`,
 	Aliases: []string{"ls"},
 	Short:   "List all secrets",
 	Long:    `List all secrets`,
@@ -40,7 +40,10 @@ func preRunSecretListCmd(cmd *cobra.Command, args []string) error {
 func runSecretList(cmd *cobra.Command, args []string) error {
 	var gatewayAddress string
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
-	fmt.Println(checkTLSInsecure(gatewayAddress, tlsInsecure))
+
+	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
+		fmt.Println(msg)
+	}
 
 	secrets, err := proxy.GetSecretList(gatewayAddress, tlsInsecure)
 	if err != nil {

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -13,7 +13,7 @@ import (
 )
 
 var secretRemoveCmd = &cobra.Command{
-	Use:     "remove",
+	Use:     "remove [--tls-no-verify]",
 	Aliases: []string{"rm"},
 	Short:   "remove a secret",
 	Long:    `Remove a secret by name`,
@@ -44,7 +44,10 @@ func preRunSecretRemoveCmd(cmd *cobra.Command, args []string) error {
 func runSecretRemove(cmd *cobra.Command, args []string) error {
 	var gatewayAddress string
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
-	fmt.Println(checkTLSInsecure(gatewayAddress, tlsInsecure))
+
+	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
+		fmt.Println(msg)
+	}
 
 	secret := schema.Secret{
 		Name: args[0],

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -15,7 +15,7 @@ import (
 )
 
 var secretUpdateCmd = &cobra.Command{
-	Use:     "update",
+	Use:     "update [--tls-no-verify]",
 	Aliases: []string{"u"},
 	Short:   "Update a secret",
 	Long:    `Update a secret by name`,
@@ -55,7 +55,10 @@ func preRunSecretUpdate(cmd *cobra.Command, args []string) error {
 
 func runSecretUpdate(cmd *cobra.Command, args []string) error {
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
-	fmt.Println(checkTLSInsecure(gatewayAddress, tlsInsecure))
+
+	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
+		fmt.Println(msg)
+	}
 
 	secret := schema.Secret{
 		Name: args[0],


### PR DESCRIPTION
Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- this flag was added by the original author, but was not present
in the help messages.

## Motivation and Context

I saw this was lacking in the code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Via `go build` and running `faas-cli secret COMMAND --help`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
