### PR TITLE
Add validation for secret name

### DIFF
--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/openfaas/faas-cli/proxy"
@@ -53,7 +54,9 @@ func preRunSecretCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please provide secret using only one option from --from-literal, --from-file and STDIN")
 	}
 
-	return nil
+	err := validateSecretName(args[0])
+
+	return err
 }
 
 func runSecretCreate(cmd *cobra.Command, args []string) error {
@@ -103,4 +106,24 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 func readSecretFromFile(secretFile string) (string, error) {
 	fileData, err := ioutil.ReadFile(secretFile)
 	return string(fileData), err
+}
+
+//kubectl create secret generic my_secret --from-literal=my_secret=my_secret
+//The Secret "my_secret" is invalid: metadata.name: Invalid value: "my_secret": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+
+// Kubernetes DNS-1123 Subdomain Regex
+// https://github.com/kubernetes/kubernetes/blob/6902f3112d98eb6bd0894886ff9cd3fbd03a7f79/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L131
+const (
+	dns1123LabelFmt     string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+	dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
+)
+
+func validateSecretName(secretName string) error {
+	var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
+
+	if !dns1123SubdomainRegexp.MatchString(secretName) {
+		return fmt.Errorf(`ERROR: invalid secret name: %s, secret name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (regex used for validation is %s)`, secretName, dns1123SubdomainRegexp)
+	}
+
+	return nil
 }

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -116,14 +116,14 @@ func readSecretFromFile(secretFile string) (string, error) {
 const (
 	dns1123LabelFmt          string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
 	dns1123SubdomainFmt      string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
-	invalidSecretNameMessage string = `ERROR: invalid secret name: %s, secret name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (regex used for validation is %s)`
+	invalidSecretNameMessage string = "ERROR: invalid secret name %s\nSecret name must start and end with an alphanumeric character \nand can only contain lower-case alphanumeric characters, '-' or '.'"
 )
 
 func validateSecretName(secretName string) (bool, error) {
 	var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
 
 	if !dns1123SubdomainRegexp.MatchString(secretName) {
-		return false, fmt.Errorf(invalidSecretNameMessage, secretName, dns1123SubdomainRegexp)
+		return false, fmt.Errorf(invalidSecretNameMessage, secretName)
 	}
 
 	return true, nil

--- a/commands/secret_create_test.go
+++ b/commands/secret_create_test.go
@@ -109,7 +109,6 @@ func Test_SecretCreateFromLiteral(t *testing.T) {
 }
 
 func Test_validateSecretName(t *testing.T) {
-	var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
 
 	testcases := []struct {
 		Name       string
@@ -134,12 +133,12 @@ func Test_validateSecretName(t *testing.T) {
 		{
 			Name:       "Invalid secret name",
 			SecretName: "api_key_@secret",
-			Err:        fmt.Errorf(invalidSecretNameMessage, "api_key_@secret", dns1123SubdomainRegexp),
+			Err:        fmt.Errorf(invalidSecretNameMessage, "api_key_@secret"),
 		},
 		{
 			Name:       "Invalid secret name with number",
 			SecretName: "12api_key_secret",
-			Err:        fmt.Errorf(invalidSecretNameMessage, "12api_key_secret", dns1123SubdomainRegexp),
+			Err:        fmt.Errorf(invalidSecretNameMessage, "12api_key_secret"),
 		},
 	}
 

--- a/commands/secret_create_test.go
+++ b/commands/secret_create_test.go
@@ -106,3 +106,24 @@ func Test_SecretCreateFromLiteral(t *testing.T) {
 		t.Fatalf("Output is not as expected:\nExpected:\n%s\n Got:\n%s", `(?m:`+secretName+`)`, stdOut)
 	}
 }
+
+func Test_validateSecretName_Valid(t *testing.T) {
+	secretName := "api-key-secret"
+	err := validateSecretName(secretName)
+	if err != nil {
+		t.Errorf("Returned error for valid secret: %s", err.Error())
+	}
+}
+
+func Test_validateSecretName_Invalid(t *testing.T) {
+	secretName := "api_key_@secret"
+	err := validateSecretName(secretName)
+	if err == nil {
+		t.Errorf("Did not return error")
+	}
+
+	errMessage := err.Error()
+	if found, err := regexp.MatchString(`(?m:`+secretName+`)`, errMessage); err != nil || !found {
+		t.Fatalf("Output is not as expected:\nExpected:\n%s\n Got:\n%s", `(?m:`+secretName+`)`, errMessage)
+	}
+}


### PR DESCRIPTION
This commit add validation (subdomain in RFC-1123) for secret name while
creating the secret name.

Fixes #590

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#590 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
./faas-cli secret create my-secret --from-literal=value
Creating secret: my-secret
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Created: 201 Created
➜  faas-cli git:(add_secrent_name_validation) ./faas-cli secret create my_secret --from-literal=value
ERROR: invalid secret name: my_secret, secret name must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (regex used for validation is ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
