### PR TITLE
Default login to username of admin

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -25,19 +25,20 @@ var (
 
 func init() {
 	loginCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
-	loginCmd.Flags().StringVarP(&username, "username", "u", "", "Gateway username")
+	loginCmd.Flags().StringVarP(&username, "username", "u", "admin", "Gateway username")
 	loginCmd.Flags().StringVarP(&password, "password", "p", "", "Gateway password")
-	loginCmd.Flags().BoolVar(&passwordStdin, "password-stdin", false, "Reads the gateway password from stdin")
+	loginCmd.Flags().BoolVarP(&passwordStdin, "password-stdin", "s", false, "Reads the gateway password from stdin")
 	loginCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 
 	faasCmd.AddCommand(loginCmd)
 }
 
 var loginCmd = &cobra.Command{
-	Use:   `login [--username USERNAME] [--password PASSWORD] [--gateway GATEWAY_URL] [--tls-no-verify]`,
+	Use:   `login [--username admin|USERNAME] [--password PASSWORD] [--gateway GATEWAY_URL] [--tls-no-verify]`,
 	Short: "Log in to OpenFaaS gateway",
 	Long:  "Log in to OpenFaaS gateway.\nIf no gateway is specified, the default local one will be used.",
 	Example: `  faas-cli login -u user -p password --gateway http://127.0.0.1:8080
+  echo $PASSWORD | faas-cli login -s
   cat ~/faas_pass.txt | faas-cli login -u user --password-stdin --gateway https://openfaas.mydomain.com`,
 	RunE: runLogin,
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The documentation uses admin as a default, so we can save users
on some typing and complexity by defaulting this CLI parameter.

It can still be overriden if needed.

## Motivation and Context

n/a

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
