### PR TITLE
Rename provider YAML name from faas to openfaas

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Here is an example file using the `stack.yml` file included in the repository.
 
 ```yaml
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
 
 functions:

--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -24,7 +24,7 @@ var generateTestcases = []struct {
 		Name: "Default Namespace and API Version",
 		Input: `
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"      
 functions:
@@ -53,7 +53,7 @@ spec:
 		Name: "Blank namespace",
 		Input: `
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 functions:
@@ -80,7 +80,7 @@ spec:
 		Name: "BranchAndSHA Image format",
 		Input: `
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 functions:
@@ -108,7 +108,7 @@ spec:
 		Name: "Multiple functions",
 		Input: `
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080  
   network: "func_functions"
 functions:

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -215,7 +215,7 @@ func prepareYAMLContent(appendMode bool, gateway string, function *stack.Functio
 	if !appendMode {
 
 		yamlContent = `provider:
-  name: faas
+  name: openfaas
   gateway: ` + gateway + `
 functions:
 ` + yamlContent

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -167,7 +167,7 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 		services := *parsedServices
 
 		var testServices stack.Services
-		testServices.Provider = stack.Provider{Name: "faas", GatewayURL: defaultGateway}
+		testServices.Provider = stack.Provider{Name: "openfaas", GatewayURL: defaultGateway}
 		if !reflect.DeepEqual(services.Provider, testServices.Provider) {
 			t.Fatalf("YAML `provider` section was not created correctly for file %s: got %v", funcYAML, services.Provider)
 		}

--- a/sample/github_hmac/Dockerfile
+++ b/sample/github_hmac/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7.5-alpine
+FROM golang:1.10-alpine
 
 MAINTAINER alexellis2@gmail.com
 ENTRYPOINT []

--- a/sample/hmac.yml
+++ b/sample/hmac.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
 
 functions:

--- a/sample/imagemagick/Dockerfile
+++ b/sample/imagemagick/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.9
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl ca-certificates imagemagick \ 

--- a/stack.yml
+++ b/stack.yml
@@ -1,5 +1,5 @@
 provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080  # can be a remote server
   network: "func_functions"       # this is optional and defaults to func_functions
 

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 const TestData_1 string = `provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 
@@ -44,7 +44,7 @@ functions:
 `
 
 const TestData_2 string = `provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 
@@ -335,7 +335,7 @@ func Test_ParseYAMLData_ProviderValues(t *testing.T) {
 			provider:      "faas",
 			expectedError: "",
 			file: `provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 `,
@@ -345,7 +345,7 @@ func Test_ParseYAMLData_ProviderValues(t *testing.T) {
 			provider:      "faas",
 			expectedError: "",
 			file: `provider:
-  name: faas
+  name: openfaas
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 `,


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rename provider YAML faas to openfaas

## Motivation and Context

The provider name value of faas is archaic and should be changed
to openfaas. The CLI code already supports this but the generated
values use the text faas still.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* 1) Running this in the faas-cli folder:

```
faas-cli up
```

* 2) Running `./make_dist.sh`

* 3) Generating and running `up` on a new function with the updated binary:

Example:

```
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  name:
    lang: go
    handler: ./name
    image: name:latest
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.