### PR TITLE
Add the option to override the image prefix

### DIFF
--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -168,6 +168,8 @@ func runNewFunction(cmd *cobra.Command, args []string) error {
 	fmt.Printf("\nFunction created in folder: %s\n", handlerDir)
 
 	imageName := fmt.Sprintf("%s:latest", functionName)
+	// yaml prefix is empty because we are creating the yaml file, not reading it
+	imagePrefix = getImagePrefix(imagePrefix, os.Getenv(imagePrefixEnvironment), "")
 	if imagePrefix = strings.TrimSpace(imagePrefix); len(imagePrefix) > 0 {
 		imageName = fmt.Sprintf("%s/%s", imagePrefix, imageName)
 	}

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -12,6 +12,7 @@ const (
 	openFaaSURLEnvironment      = "OPENFAAS_URL"
 	templateURLEnvironment      = "OPENFAAS_TEMPLATE_URL"
 	templateStoreURLEnvironment = "OPENFAAS_TEMPLATE_STORE_URL"
+	imagePrefixEnvironment      = "OPENFAAS_IMAGE_PREFIX"
 )
 
 func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) string {
@@ -57,4 +58,23 @@ func getTemplateStoreURL(argumentURL, environmentURL, defaultURL string) string 
 	} else {
 		return defaultURL
 	}
+}
+
+func getImagePrefix(argumentPrefix, environmentPrefix, yamlPrefix string) string {
+	// default prefix is blank/no prefix
+	var prefix string
+
+	if len(yamlPrefix) > 0 {
+		prefix = yamlPrefix
+	}
+
+	if len(environmentPrefix) > 0 {
+		prefix = environmentPrefix
+	}
+
+	if len(argumentPrefix) > 0 {
+		prefix = argumentPrefix
+	}
+
+	return prefix
 }

--- a/commands/priority_test.go
+++ b/commands/priority_test.go
@@ -49,3 +49,45 @@ func Test_getTemplateStoreURL(t *testing.T) {
 		})
 	}
 }
+
+func Test_getImagePrefix(t *testing.T) {
+	tests := []struct {
+		title          string
+		argPrefix      string
+		envPrefix      string
+		yamlPrefix     string
+		expectedPrefix string
+	}{
+		{
+			title:          "No prefixes are set which should return a blank prefix",
+			expectedPrefix: "",
+		},
+		{
+			title:          "Environment prefix should take priority over YAML prefix",
+			envPrefix:      "envuser",
+			yamlPrefix:     "yamluser",
+			expectedPrefix: "envuser",
+		},
+		{
+			title:          "Argument prefix should take priority over both environment and YAML prefixes",
+			envPrefix:      "envuser",
+			argPrefix:      "arguser",
+			yamlPrefix:     "yamluser",
+			expectedPrefix: "arguser",
+		},
+		{
+			title:          "YAML prefix should be used if no others are set",
+			yamlPrefix:     "yamluser",
+			expectedPrefix: "yamluser",
+		},
+	}
+	// defaultURL is always present that is why we don't test that case
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			prefix := getImagePrefix(test.argPrefix, test.envPrefix, test.yamlPrefix)
+			if prefix != test.expectedPrefix {
+				t.Errorf("expected image prefix: `%s` got: `%s`", test.expectedPrefix, prefix)
+			}
+		})
+	}
+}

--- a/commands/push_test.go
+++ b/commands/push_test.go
@@ -40,3 +40,52 @@ func Test_PushValidation(t *testing.T) {
 
 	}
 }
+
+func Test_overrideImagePrefixes(t *testing.T) {
+	testCases := []struct {
+		scenario          string
+		imageName         string
+		argPrefix         string
+		expectedImageName string
+	}{
+		{
+			scenario:          "Empty image name should stay empty",
+			imageName:         "",
+			expectedImageName: "",
+		},
+		{
+			scenario:          "YAML image name without a prefix should be used if no others are provided",
+			imageName:         "yaml-image",
+			expectedImageName: "yaml-image",
+		},
+		{
+			scenario:          "YAML image name with a prefix should be used if no others are provided",
+			imageName:         "yaml-user/yaml-image",
+			expectedImageName: "yaml-user/yaml-image",
+		},
+		{
+			scenario:          "Argument prefix should be added to a YAML image name without a prefix",
+			imageName:         "yaml-image",
+			argPrefix:         "arg-user",
+			expectedImageName: "arg-user/yaml-image",
+		},
+		{
+			scenario:          "Argument prefix should be override the prefix of the image name in YAML",
+			imageName:         "yaml-user/yaml-image",
+			argPrefix:         "arg-user",
+			expectedImageName: "arg-user/yaml-image",
+		},
+	}
+
+	for _, testCase := range testCases {
+		// set cli arg used by functions
+		imagePrefix = testCase.argPrefix
+
+		newImageName := overrideImagePrefix(testCase.imageName)
+
+		if newImageName != testCase.expectedImageName {
+			t.Logf("scenario: %s. wanted image name to change from `%s` to `%s` but instead got `%s`", testCase.scenario, testCase.imageName, testCase.expectedImageName, newImageName)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
This is an attempt to implement the functionality described in #550: add the option to set an image prefix though a CLI argument or environment variable.
## Description
This provides the option to override the image prefix in the stack yaml in the following preference order:

CLI Argument (`--prefix`), fall back to environment variable (`OPENFAAS_IMAGE_PREFIX`), fall back to the `stack.yml` image name.

If `stack.yml` contains an image name _without_ a prefix, but either the CLI arg or Env var (or both) are set, the prefix will be prepended to the image name.
If `stack.yml` contains an image name _with_ a prefix, and either the CLI arg or Env var (or both) are set, the prefix with the highest preference will override the one in `stack.yml`.

This change is added to `new`, `build`, and `push` like so:

* `faas-cli new` allows setting the prefix in an environment variable in
addition to the cli arg
* `faas-cli build` and `faas-cli push` now allow overriding the prefix set in the stack YAML,
provided by a cli arg or env var

Signed-off-by: Kamal Nasser <hello@kamal.io>

## Motivation and Context
With this change, people can easily re-use other people's `stack.yml` files without having to modify them to either add their own prefix or replace the `stack.yml`'s prefix.

## How Has This Been Tested?
Tests were added to the files that were modified.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

I'd like to make sure that the functionality (e.g. overriding existing prefixes) is OK before adding documentation.
