### PR TITLE
Allow shrinkwrap of Dockerfile template

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -7,6 +7,28 @@ import (
 	"github.com/openfaas/faas-cli/stack"
 )
 
+func Test_isLanguageTemplate_Dockerfile(t *testing.T) {
+
+	language := "Dockerfile"
+
+	want := false
+	got := isLanguageTemplate(language)
+	if got != want {
+		t.Errorf("language: %s got %v, want %v", language, got, want)
+	}
+}
+
+func Test_isLanguageTemplate_Node(t *testing.T) {
+
+	language := "node"
+
+	want := true
+	got := isLanguageTemplate(language)
+	if got != want {
+		t.Errorf("language: %s got %v, want %v", language, got, want)
+	}
+}
+
 func Test_getDockerBuildCommand_NoOpts(t *testing.T) {
 	dockerBuildVal := dockerBuild{
 		Image:            "imagename:latest",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- removes custom logic for working with Dockerfile language to
be in-line with the the new Dockerfile template

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

https://github.com/openfaas/openfaas-cloud/issues/421

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- tested with faas-cli build [--shrinkwrap] with Dockerfile
language template and with node template to check for regression

- added unit test for new method

Signed-off-by: Alex Ellis <alexellis2@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
