### PR TITLE
Add url-only flag to describe command

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -17,11 +17,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	urlOnly bool
+)
+
 func init() {
 	describeCmd.Flags().StringVar(&functionName, "name", "", "Name of the function")
 	describeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	describeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	describeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
+	describeCmd.Flags().BoolVar(&urlOnly, "url-only", false, "Return only the function URL")
 
 	faasCmd.AddCommand(describeCmd)
 }
@@ -87,6 +92,11 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	}
 
 	url, asyncURL := getFunctionURLs(gatewayAddress, functionName)
+
+	if urlOnly == true {
+		fmt.Printf("%s\n", url)
+		return nil
+	}
 
 	funcDesc := schema.FunctionDescription{
 		Name:              function.Name,


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This change adds the --url-only flag to describe.  Defaulting to false, when this flag is set the runDescribe function will return as soon as the URL is known.

## Motivation and Context
Describe currently passes out a nice table of various details.  There may be occasions - the workshop being one - where the user only requires the URL element of this table.  Further, by returning a naked URL the describe command can be cleanly embedded into other commands, for example: curl -d 'hello' $(faas describe go-echo --url-only).

## How Has This Been Tested?

### Existing Command
```bash
$ ./faas-cli-darwin describe go-echo
Name:                go-echo
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         4
Image:               rgee0/go-echo:latest
Function process:    ./handler
URL:                 http://127.0.0.1:8080/function/go-echo
Async URL:           http://127.0.0.1:8080/async-function/go-echo
Labels:              com.openfaas.function : go-echo
                     function : true
```

### New Option

```bash
$ ./faas-cli-darwin describe go-echo --url-only
http://127.0.0.1:8080/function/go-echo
```

### New Option Embedded
Note: Intended to demonstrate embedding, in reality a user would use the invoke command for the same effect.  

```bash
$ curl -d 'hello' $(./faas-cli-darwin describe go-echo --url-only)
Hello world, input was: hello
```

```bash
$ faas-cli-darwin describe --help
Display details of an OpenFaaS function

Usage:
  faas-cli describe FUNCTION_NAME [--gateway GATEWAY_URL] [flags]

Examples:
faas-cli describe figlet 
faas-cli describe env --gateway http://127.0.0.1:8080
faas-cli describe echo -g http://127.0.0.1.8080

Flags:
      --envsubst         Substitute environment variables in stack.yml file (default true)
  -g, --gateway string   Gateway URL starting with http(s):// (default "http://127.0.0.1:8080")
  -h, --help             help for describe
      --name string      Name of the function
      --tls-no-verify    Disable TLS validation
      --url-only         Return only the function URL

Global Flags:
      --filter string   Wildcard to match with function names in YAML file
      --regex string    Regex to match with function names in YAML file
  -f, --yaml string     Path to YAML file describing function(s)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
