### PR TITLE
Add rio v1 to generate CRD commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The main commands supported by the CLI are:
 
 * `faas-cli auth` - (alpha) initiates an OAuth2 authorization flow to obtain a cookie
 
+* `faas-cli generate` - generates CRD yaml for your functions.
+
 The default gateway URL of `127.0.0.1:8080` can be overridden in three places including an environmental variable.
 
 * 1st priority `--gateway` flag
@@ -254,6 +256,13 @@ For Docker Swarm use the `--send-registry-auth` flag or its shorthand `-a` which
 ### Use a YAML stack file
 
 Read the [YAML reference guide in the OpenFaaS docs](https://docs.openfaas.com/reference/yaml/).
+
+### Generate CRD with `faas-cli generate` command
+
+You can generate CRD for your functions with `faas-cli generate`. This allows you to script out functions, not just for openfaas but also for [knative](https://cloud.google.com/knative/) or [rio](https://github.com/rancher/rio). You can specify an API type via the `--api` parameter: this can be `openfaas.com/v1alpha2` (for openfaas definitions), `serving.knative.dev/v1alpha1` (for knative) or `rio.cattle.io/v1` (for rio). The `--namespace` parameter is useful for changing the generated namespace in these definitions. 
+For example, the following command will generate your functions (defined in stack.yml) as CRD for rio to be deployed in the default namespace:
+
+```faas-cli generate --api=rio.cattle.io/v1  --namespace default```
 
 #### Quick guide
 

--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -169,6 +169,63 @@ spec:
 		Branch:     "",
 		Version:    "",
 	},
+	{
+		Name: "Knative",
+		Input: `
+provider:
+  name: openfaas
+
+functions:
+  figlet:
+    image: functions/figlet:latest`,
+		Output: []string{`---
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: figlet
+  namespace: default
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: functions/figlet:latest
+`},
+		Format:     schema.DefaultFormat,
+		APIVersion: "serving.knative.dev/v1alpha1",
+		Namespace:  "default",
+		Branch:     "",
+		Version:    "",
+	},
+	{
+		Name: "Rio",
+		Input: `
+provider:
+  name: openfaas
+
+functions:
+  figlet:
+    image: functions/figlet:latest`,
+		Output: []string{`---
+apiVersion: rio.cattle.io/v1
+kind: Service
+metadata:
+  name: figlet
+  namespace: default
+spec:
+  image: functions/figlet:latest
+  ports:
+  - port: 8080
+    protocol: HTTP
+    targetPort: 8080
+`},
+		Format:     schema.DefaultFormat,
+		APIVersion: "rio.cattle.io/v1",
+		Namespace:  "default",
+		Branch:     "",
+		Version:    "",
+	},
 }
 
 func Test_generateCRDYAML(t *testing.T) {
@@ -191,7 +248,7 @@ func Test_generateCRDYAML(t *testing.T) {
 		}
 
 		if !stringInSlice(generatedYAML, testcase.Output) {
-			t.Fatalf("%s failed: ouput is not as expected: %s", testcase.Name, generatedYAML)
+			t.Fatalf("%s failed: output is not as expected: %s, expected: %s", testcase.Name, generatedYAML, testcase.Output)
 		}
 	}
 

--- a/schema/rio/v1/crd.go
+++ b/schema/rio/v1/crd.go
@@ -1,0 +1,36 @@
+// Copyright (c) OpenFaaS Author(s) 2019. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package v1
+
+import "github.com/openfaas/faas-cli/schema"
+
+const APIVersionLatest = "rio.cattle.io/v1"
+
+//RioSpec describe characteristics of the object
+type Spec struct {
+	Env   []EnvPair `yaml:"env,omitempty"`
+	Image string    `yaml:"image"`
+	Ports []Port    `yaml:"ports"`
+}
+
+type Port struct {
+	Port       int    `yaml:"port"`
+	Protocol   string `yaml:"protocol"`
+	TargetPort int    `yaml:"targetPort"`
+}
+
+type EnvPair struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
+//CRD root level YAML definition for the object
+type CRD struct {
+	//APIVersion CRD API version
+	APIVersion string `yaml:"apiVersion"`
+	//Kind kind of the object
+	Kind     string          `yaml:"kind"`
+	Metadata schema.Metadata `yaml:"metadata"`
+	Spec     Spec            `yaml:"spec"`
+}


### PR DESCRIPTION
This commit adds the ability to generate a rio
definition from the Function Store or a stack.yaml file with
a basic definition including: namespace, name, env-vars and
image.

Tested with DigitalOcean using figlet.

Signed-off-by: David Pendray <davidpendray@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolves #640
### Variations from issue
1. Command varies from issue. The issue anticipated command would be:
```
faas-cli generate --api=services.rio.cattle.io
```
but I've implemented for command:
```
faas-cli generate --api=rio.cattle.io/v1  --namespace default
```
This is because specifying ```api``` to match ```apiVersion``` in resulting CRD is consistent with approach used for knative and we have a default namespace of ```openfaas-fn``` currently.
2. We generate less fields than in the original issue: just those needed for curl command to still work.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
I created Digital Ocean kubernetes cluster and installed rio with ```rio install```. I create a ```stack.yml``` with the following contents:
```
provider:
  name: openfaas

functions:
  figlet:
    image: functions/figlet:latest
    environment:
      a: b
```
After building on Windows, I ran ```.\faas-cli generate --api=rio.cattle.io/v1  --namespace default > figlet.yaml``` and then ```kubectl apply -f figlet.yaml```. After waiting for the ```rio ps``` to stop saying ```v0 NotReady```, I confirmed figlet was working with ```curl -d "hello world" -X POST {endPoint from rio ps} --insecure```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.