### PR TITLE
[WIP] Auth command for OAuth2 / OIDC

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -1,0 +1,166 @@
+// Copyright (c) OpenFaaS Author(s) 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	scope         string
+	authURL       string
+	clientID      string
+	audience      string
+	listenPort    int
+	launchBrowser bool
+)
+
+func init() {
+	authCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
+	authCmd.Flags().StringVar(&authURL, "auth-url", "", "OAuth2 auth-url")
+	authCmd.Flags().StringVar(&clientID, "client-id", "", "OAuth2 client_id")
+	authCmd.Flags().IntVar(&listenPort, "listen-port", 31111, "OAuth2 local port for receiving cookie")
+	authCmd.Flags().StringVar(&audience, "audience", "", "OAuth2 audience")
+	authCmd.Flags().BoolVar(&launchBrowser, "launch-browser", true, "Launch browser for OAuth2 redirect")
+
+	faasCmd.AddCommand(authCmd)
+}
+
+var authCmd = &cobra.Command{
+	Use:     `auth [--auth-url AUTH_URL | --client-id CLIENT_ID | --audience AUDIENCE | --scope SCOPE | --launch-browser LAUNCH_BROWSER]`,
+	Short:   "Obtain a token for your OpenFaaS gateway",
+	Long:    "Authenticate to an OpenFaaS gateway using OAuth2.",
+	Example: `faas-cli auth --client-id my-id --auth-url https://auth0.com/authorize --scope "oidc profile" --audience my-id`,
+	RunE:    runAuth,
+}
+
+func runAuth(cmd *cobra.Command, args []string) error {
+	context, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+
+	server := &http.Server{
+		Addr:           fmt.Sprintf(":%d", listenPort),
+		ReadTimeout:    5 * time.Second,
+		WriteTimeout:   5 * time.Second,
+		MaxHeaderBytes: 1 << 20, // Max header of 1MB
+		Handler:        http.HandlerFunc(makeCallbackHandler(cancel)),
+	}
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			panic(err)
+		}
+
+		select {
+		case <-context.Done():
+			break
+		}
+	}()
+	defer server.Shutdown(context)
+
+	q := url.Values{}
+	q.Add("client_id", clientID)
+
+	q.Add("state", fmt.Sprintf("%d", time.Now().UnixNano()))
+	q.Add("nonce", fmt.Sprintf("%d", time.Now().UnixNano()))
+	q.Add("response_type", "token")
+	q.Add("scope", scope)
+	q.Add("audience", audience)
+
+	q.Add("redirect_uri", fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("http://127.0.0.1:%d", listenPort)))
+	authURLVal, _ := url.Parse(authURL)
+	authURLVal.RawQuery = q.Encode()
+
+	browserBase := authURLVal
+
+	fmt.Println("Navigate to:", browserBase)
+	if launchBrowser {
+		err := launchURL(browserBase.String())
+		if err != nil {
+			return errors.Wrap(err, "unable to launch browser")
+		}
+	}
+
+	<-context.Done()
+
+	return nil
+}
+
+// launchURL opens a URL with the default browser for Linux, MacOS or Windows.
+func launchURL(serverURL string) error {
+	ctx := context.Background()
+	var command *exec.Cmd
+	switch runtime.GOOS {
+	case "linux":
+		command = exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf(`xdg-open "%s"`, serverURL))
+	case "darwin":
+		command = exec.CommandContext(ctx, "sh", "-c", fmt.Sprintf(`open "%s"`, serverURL))
+	case "windows":
+		escaped := strings.Replace(serverURL, "&", "^&", -1)
+		command = exec.CommandContext(ctx, "cmd", "/c", fmt.Sprintf(`start %s`, escaped))
+	}
+	command.Stdout = os.Stdout
+	command.Stdin = os.Stdin
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
+func makeCallbackHandler(cancel context.CancelFunc) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		if v := r.URL.Query().Get("fragment"); len(v) > 0 {
+			q, err := url.ParseQuery(v)
+			if err != nil {
+				panic(errors.Wrap(err, "unable to parse fragment response from browser redirect"))
+			}
+
+			if token := q.Get("access_token"); len(token) > 0 {
+				fmt.Printf("Example:\n\t./faas-cli list --gateway \"%s\" --token \"%s\"\n", gateway, token)
+			} else {
+				fmt.Printf("Unable to detect a valid access_token in URL fragment. Check your credentials or contact your administrator.\n")
+			}
+
+			cancel()
+			return
+		}
+
+		if r.Body != nil {
+			defer r.Body.Close()
+		}
+		w.Write([]byte(buildCaptureFragment()))
+	}
+}
+
+func buildCaptureFragment() string {
+	return `
+<html>
+<head>
+<title>OpenFaaS CLI Authorization flow</title>
+<script>
+	var xhttp = new XMLHttpRequest();
+	xhttp.onreadystatechange = function() {
+		if (this.readyState == 4 && this.status == 200) {
+			console.log(xhttp.responseText)
+		}
+	};
+	xhttp.open("GET", "/oauth2/callback?fragment="+document.location.hash.slice(1), true);
+	xhttp.send();
+</script>
+</head>
+<body>
+ Authorization flow complete. Please close this browser window.
+</body>
+</html>`
+}

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -68,7 +68,7 @@ func init() {
 
 	deployCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	deployCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
-
+	deployCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	// Set bash-completion.
 	_ = deployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
 
@@ -282,6 +282,7 @@ Error: %s`, fprocessErr.Error())
 				FunctionResourceRequest: functionResourceRequest,
 				ReadOnlyRootFilesystem:  function.ReadOnlyRootFilesystem,
 				TLSInsecure:             tlsInsecure,
+				Token:                   token,
 			}
 
 			if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {
@@ -313,7 +314,7 @@ Error: %s`, fprocessErr.Error())
 		// default to a readable filesystem until we get more input about the expected behavior
 		// and if we want to add another flag for this case
 		defaultReadOnlyRFS := false
-		statusCode, err := deployImage(image, fprocess, functionName, registryAuth, deployFlags, tlsInsecure, defaultReadOnlyRFS)
+		statusCode, err := deployImage(image, fprocess, functionName, registryAuth, deployFlags, tlsInsecure, defaultReadOnlyRFS, token)
 		if err != nil {
 			return err
 		}
@@ -339,6 +340,7 @@ func deployImage(
 	deployFlags DeployFlags,
 	tlsInsecure bool,
 	readOnlyRootFilesystem bool,
+	token string,
 ) (int, error) {
 
 	var statusCode int
@@ -379,6 +381,7 @@ func deployImage(
 		FunctionResourceRequest: proxy.FunctionResourceRequest{},
 		ReadOnlyRootFilesystem:  readOnlyRFS,
 		TLSInsecure:             tlsInsecure,
+		Token:                   token,
 	}
 
 	if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -22,6 +22,7 @@ func init() {
 	describeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	describeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	describeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
+	describeCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	faasCmd.AddCommand(describeCmd)
 }
@@ -62,13 +63,13 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	}
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	function, err := proxy.GetFunctionInfo(gatewayAddress, functionName, tlsInsecure)
+	function, err := proxy.GetFunctionInfoToken(gatewayAddress, functionName, tlsInsecure, token)
 	if err != nil {
 		return err
 	}
 
 	//To get correct value for invocation count from /system/functions endpoint
-	functionList, err := proxy.ListFunctions(gatewayAddress, tlsInsecure)
+	functionList, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	verboseList bool
+	token       string
 )
 
 func init() {
@@ -23,6 +24,7 @@ func init() {
 	listCmd.Flags().BoolVarP(&verboseList, "verbose", "v", false, "Verbose output for the function list")
 	listCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	listCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
+	listCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	faasCmd.AddCommand(listCmd)
 }
@@ -55,7 +57,7 @@ func runList(cmd *cobra.Command, args []string) error {
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	functions, err := proxy.ListFunctions(gatewayAddress, tlsInsecure)
+	functions, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -17,6 +17,7 @@ func init() {
 	removeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	removeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	removeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
+	removeCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	faasCmd.AddCommand(removeCmd)
 }
@@ -66,7 +67,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			function.Name = k
 			fmt.Printf("Deleting: %s.\n", function.Name)
 
-			proxy.DeleteFunction(gatewayAddress, function.Name, tlsInsecure)
+			proxy.DeleteFunctionToken(gatewayAddress, function.Name, tlsInsecure, token)
 		}
 	} else {
 		if len(args) < 1 {
@@ -75,7 +76,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
-		proxy.DeleteFunction(gatewayAddress, functionName, tlsInsecure)
+		proxy.DeleteFunctionToken(gatewayAddress, functionName, tlsInsecure, token)
 	}
 
 	return nil

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -42,6 +42,7 @@ func init() {
 	secretCreateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
 	secretCreateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretCreateCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
+	secretCreateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretCmd.AddCommand(secretCreateCmd)
 }
 
@@ -108,7 +109,7 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Creating secret: " + secret.Name)
-	_, output := proxy.CreateSecret(gatewayAddress, secret, tlsInsecure)
+	_, output := proxy.CreateSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	fmt.Printf(output)
 
 	return nil

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -29,6 +29,7 @@ faas-cli secret list --gateway=http://127.0.0.1:8080`,
 func init() {
 	secretListCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretListCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
+	secretListCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	secretCmd.AddCommand(secretListCmd)
 }
@@ -45,7 +46,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		fmt.Println(msg)
 	}
 
-	secrets, err := proxy.GetSecretList(gatewayAddress, tlsInsecure)
+	secrets, err := proxy.GetSecretListToken(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -26,7 +26,7 @@ faas-cli secret remove NAME --gateway=http://127.0.0.1:8080`,
 func init() {
 	secretRemoveCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretRemoveCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
-
+	secretRemoveCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretCmd.AddCommand(secretRemoveCmd)
 }
 
@@ -52,7 +52,7 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 	secret := schema.Secret{
 		Name: args[0],
 	}
-	err := proxy.RemoveSecret(gatewayAddress, secret, tlsInsecure)
+	err := proxy.RemoveSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -33,7 +33,7 @@ func init() {
 	secretUpdateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretUpdateCmd.Flags().StringVar(&literalSecret, "from-literal", "", "Value of the secret")
 	secretUpdateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
-
+	secretUpdateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretCmd.AddCommand(secretUpdateCmd)
 }
 
@@ -95,7 +95,7 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Updating secret: " + secret.Name)
-	_, output := proxy.UpdateSecret(gatewayAddress, secret, tlsInsecure)
+	_, output := proxy.UpdateSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	fmt.Printf(output)
 
 	return nil

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -27,6 +27,7 @@ func init() {
 	storeDeployCmd.Flags().BoolVarP(&storeDeployFlags.sendRegistryAuth, "send-registry-auth", "a", false, "send registryAuth from Docker credentials manager with the request")
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.annotationOpts, "annotation", "", []string{}, "Set one or more annotation (ANNOTATION=VALUE)")
 	storeDeployCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
+	storeDeployCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	// Set bash-completion.
 	_ = storeDeployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
@@ -122,7 +123,7 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure, item.ReadOnlyRootFilesystem)
+	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure, item.ReadOnlyRootFilesystem, token)
 
 	if badStatusCode(statusCode) {
 		failedStatusCode := map[string]int{itemName: statusCode}

--- a/commands/version.go
+++ b/commands/version.go
@@ -26,7 +26,7 @@ func init() {
 	versionCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	versionCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	versionCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
-
+	versionCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	faasCmd.AddCommand(versionCmd)
 }
 
@@ -71,7 +71,7 @@ func printServerVersions() {
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	info, err := proxy.GetSystemInfo(gatewayAddress, tlsInsecure)
+	info, err := proxy.GetSystemInfo(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return
 	}

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -19,3 +19,8 @@ func SetAuth(req *http.Request, gateway string) {
 
 	req.SetBasicAuth(username, password)
 }
+
+//SetToken sets authentication token
+func SetToken(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+}

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -16,6 +16,11 @@ import (
 
 // DeleteFunction delete a function from the OpenFaaS server
 func DeleteFunction(gateway string, functionName string, tlsInsecure bool) error {
+	return DeleteFunctionToken(gateway, functionName, tlsInsecure, "")
+}
+
+//DeleteFunctionToken delete a function with token as auth
+func DeleteFunctionToken(gateway string, functionName string, tlsInsecure bool, token string) error {
 	gateway = strings.TrimRight(gateway, "/")
 	delReq := requests.DeleteFunctionRequest{FunctionName: functionName}
 	reqBytes, _ := json.Marshal(&delReq)
@@ -28,7 +33,13 @@ func DeleteFunction(gateway string, functionName string, tlsInsecure bool) error
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	SetAuth(req, gateway)
+
+	if len(token) > 0 {
+		SetToken(req, token)
+	} else {
+		SetAuth(req, gateway)
+	}
+
 	delRes, delErr := c.Do(req)
 
 	if delErr != nil {

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -45,6 +45,7 @@ type DeployFunctionSpec struct {
 	FunctionResourceRequest FunctionResourceRequest
 	ReadOnlyRootFilesystem  bool
 	TLSInsecure             bool
+	Token                   string
 }
 
 // DeployFunction first tries to deploy a function and if it exists will then attempt
@@ -141,7 +142,12 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 
 	var err error
 	request, err = http.NewRequest(method, gateway+"/system/functions", reader)
-	SetAuth(request, gateway)
+	if len(spec.Token) > 0 {
+		SetToken(request, spec.Token)
+	} else {
+		SetAuth(request, gateway)
+	}
+
 	if err != nil {
 		deployOutput += fmt.Sprintln(err)
 		return http.StatusInternalServerError, deployOutput

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -50,6 +50,7 @@ func runDeployProxyTest(t *testing.T, deployTest deployProxyTest) {
 			FunctionResourceRequest{},
 			false,
 			tlsNoVerify,
+			"",
 		})
 	})
 
@@ -112,6 +113,7 @@ func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 			FunctionResourceRequest{},
 			false,
 			tlsNoVerify,
+			"",
 		})
 	})
 

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -16,6 +16,11 @@ import (
 
 //GetFunctionInfo get an OpenFaaS function information
 func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (requests.Function, error) {
+	return GetFunctionInfoToken(gateway, functionName, tlsInsecure, "")
+}
+
+//GetFunctionInfoToken get a function information with a token as auth
+func GetFunctionInfoToken(gateway string, functionName string, tlsInsecure bool, token string) (requests.Function, error) {
 	var result requests.Function
 
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
@@ -30,7 +35,12 @@ func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (req
 	if err != nil {
 		return result, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}
-	SetAuth(getRequest, gateway)
+
+	if len(token) > 0 {
+		SetToken(getRequest, token)
+	} else {
+		SetAuth(getRequest, gateway)
+	}
 
 	res, err := client.Do(getRequest)
 	if err != nil {

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -13,13 +13,22 @@ import (
 
 // GetSecretList get secrets list
 func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
+	return GetSecretListToken(gateway, tlsInsecure, "")
+}
+
+// GetSecretListToken get secrets lists with taken as auth
+func GetSecretListToken(gateway string, tlsInsecure bool, token string) ([]schema.Secret, error) {
 	var results []schema.Secret
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 
 	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/secrets", nil)
-	SetAuth(getRequest, gateway)
+	if len(token) > 0 {
+		SetToken(getRequest, token)
+	} else {
+		SetAuth(getRequest, gateway)
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
@@ -62,6 +71,11 @@ func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
 
 // UpdateSecret update a secret via the OpenFaaS API by name
 func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, string) {
+	return UpdateSecretToken(gateway, secret, tlsInsecure, "")
+}
+
+// UpdateSecretToken update a secret with token as auth
+func UpdateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) (int, string) {
 	var output string
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -70,7 +84,11 @@ func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 	reqBytes, _ := json.Marshal(&secret)
 
 	putRequest, err := http.NewRequest(http.MethodPut, gateway+"/system/secrets", bytes.NewBuffer(reqBytes))
-	SetAuth(putRequest, gateway)
+	if len(token) > 0 {
+		SetToken(putRequest, token)
+	} else {
+		SetAuth(putRequest, gateway)
+	}
 
 	if err != nil {
 		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s", gateway)
@@ -110,6 +128,11 @@ func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 
 // RemoveSecret remove a secret via the OpenFaaS API by name
 func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error {
+	return RemoveSecretToken(gateway, secret, tlsInsecure, "")
+}
+
+// RemoveSecretToken remove a secret with token as auth
+func RemoveSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) error {
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
@@ -117,7 +140,12 @@ func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error 
 	body, _ := json.Marshal(secret)
 
 	getRequest, err := http.NewRequest(http.MethodDelete, gateway+"/system/secrets", bytes.NewBuffer(body))
-	SetAuth(getRequest, gateway)
+
+	if len(token) > 0 {
+		SetToken(getRequest, token)
+	} else {
+		SetAuth(getRequest, gateway)
+	}
 
 	if err != nil {
 		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
@@ -152,6 +180,11 @@ func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error 
 
 // CreateSecret create secret
 func CreateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, string) {
+	return CreateSecretToken(gateway, secret, tlsInsecure, "")
+}
+
+// CreateSecretToken create secret with token as auth
+func CreateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) (int, string) {
 	var output string
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -161,7 +194,12 @@ func CreateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 	request, err := http.NewRequest(http.MethodPost, gateway+"/system/secrets", reader)
-	SetAuth(request, gateway)
+
+	if len(token) > 0 {
+		SetToken(request, token)
+	} else {
+		SetAuth(request, gateway)
+	}
 
 	if err != nil {
 		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s\n", gateway)

--- a/proxy/version.go
+++ b/proxy/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 //GetSystemInfo get system information from /system/info endpoint
-func GetSystemInfo(gateway string, tlsInsecure bool) (map[string]interface{}, error) {
+func GetSystemInfo(gateway string, tlsInsecure bool, token string) (map[string]interface{}, error) {
 	infoEndPoint := gateway + "/system/info"
 	timeout := 5 * time.Second
 
@@ -21,9 +21,11 @@ func GetSystemInfo(gateway string, tlsInsecure bool) (map[string]interface{}, er
 	if err != nil {
 		return nil, fmt.Errorf("invalid HTTP method or invalid URL")
 	}
-
-	SetAuth(req, gateway)
-
+	if len(token) > 0 {
+		SetToken(req, token)
+	} else {
+		SetAuth(req, gateway)
+	}
 	response, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Opens browser for user to authenticate using the implicit grant
flow. https://oauth.net/2/grant-types/implicit/

A temporary HTTP server is started to receive the token, which
is only available via JavaScript in a URL fragment. The embedded
JavaScript is used to send the token to the server to be
returned to the user.

The patch includes a temporary update to the list command so
that a --token argument can be passed in instead of basic-auth.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Part of #647 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested e2e with my oidc-plugin and Auth0.

Special thanks to @LucasRoesler for his input.

Begin the auth workflow:

```
./faas-cli auth -g http://my-gateway-online:8080 \
     --client-id=myid  \
     --auth-url=https://tenant-goes-here.eu.auth0.com/authorize  \
     --audience https://tenant-goes-here.eu.auth0.com/api/v2/
```

```
Navigate to: https://my-tenant.com/authorize?audience=https%3A%2F%2Fmy-tenant.eu.auth0.com%2Fapi%2Fv2%2F&client_id=my-id-here&nonce=1561058292527931186&redirect_uri=http%3A%2F%2F127.0.0.1%3A31111%2Foauth%2Fcallback&response_type=token&scope=&state=156
1058292527930502
```

![Screenshot 2019-06-20 at 20 26 32](https://user-images.githubusercontent.com/6358735/59875847-b5bf4000-9399-11e9-8c93-b6b300d0e749.png)

Now the CLI prints:

```
Example:
        ./faas-cli list --gateway "http://my-gateway-online:8080" --token "JWT-SHOWN-HERE"
```

Try it out:

```
./faas-cli list --gateway "http://my-gateway-url:8080" --token "$TOKEN"
Function                        Invocations     Replicas
certinfo                        5               1    
nodeinfo-open                   45              1    
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.