### PR TITLE
Add token to commands

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -68,7 +68,7 @@ func init() {
 
 	deployCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	deployCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
-
+	deployCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	// Set bash-completion.
 	_ = deployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
 
@@ -282,6 +282,7 @@ Error: %s`, fprocessErr.Error())
 				FunctionResourceRequest: functionResourceRequest,
 				ReadOnlyRootFilesystem:  function.ReadOnlyRootFilesystem,
 				TLSInsecure:             tlsInsecure,
+				Token:                   token,
 			}
 
 			if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {
@@ -313,7 +314,7 @@ Error: %s`, fprocessErr.Error())
 		// default to a readable filesystem until we get more input about the expected behavior
 		// and if we want to add another flag for this case
 		defaultReadOnlyRFS := false
-		statusCode, err := deployImage(image, fprocess, functionName, registryAuth, deployFlags, tlsInsecure, defaultReadOnlyRFS)
+		statusCode, err := deployImage(image, fprocess, functionName, registryAuth, deployFlags, tlsInsecure, defaultReadOnlyRFS, token)
 		if err != nil {
 			return err
 		}
@@ -339,6 +340,7 @@ func deployImage(
 	deployFlags DeployFlags,
 	tlsInsecure bool,
 	readOnlyRootFilesystem bool,
+	token string,
 ) (int, error) {
 
 	var statusCode int
@@ -379,6 +381,7 @@ func deployImage(
 		FunctionResourceRequest: proxy.FunctionResourceRequest{},
 		ReadOnlyRootFilesystem:  readOnlyRFS,
 		TLSInsecure:             tlsInsecure,
+		Token:                   token,
 	}
 
 	if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -22,6 +22,7 @@ func init() {
 	describeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	describeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	describeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
+	describeCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	faasCmd.AddCommand(describeCmd)
 }
@@ -62,13 +63,13 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	}
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	function, err := proxy.GetFunctionInfo(gatewayAddress, functionName, tlsInsecure)
+	function, err := proxy.GetFunctionInfoToken(gatewayAddress, functionName, tlsInsecure, token)
 	if err != nil {
 		return err
 	}
 
 	//To get correct value for invocation count from /system/functions endpoint
-	functionList, err := proxy.ListFunctions(gatewayAddress, tlsInsecure)
+	functionList, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -17,6 +17,7 @@ func init() {
 	removeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	removeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	removeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
+	removeCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	faasCmd.AddCommand(removeCmd)
 }
@@ -66,7 +67,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			function.Name = k
 			fmt.Printf("Deleting: %s.\n", function.Name)
 
-			proxy.DeleteFunction(gatewayAddress, function.Name, tlsInsecure)
+			proxy.DeleteFunctionToken(gatewayAddress, function.Name, tlsInsecure, token)
 		}
 	} else {
 		if len(args) < 1 {
@@ -75,7 +76,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
-		proxy.DeleteFunction(gatewayAddress, functionName, tlsInsecure)
+		proxy.DeleteFunctionToken(gatewayAddress, functionName, tlsInsecure, token)
 	}
 
 	return nil

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -42,6 +42,7 @@ func init() {
 	secretCreateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
 	secretCreateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretCreateCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
+	secretCreateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretCmd.AddCommand(secretCreateCmd)
 }
 
@@ -108,7 +109,7 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Creating secret: " + secret.Name)
-	_, output := proxy.CreateSecret(gatewayAddress, secret, tlsInsecure)
+	_, output := proxy.CreateSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	fmt.Printf(output)
 
 	return nil

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -29,6 +29,7 @@ faas-cli secret list --gateway=http://127.0.0.1:8080`,
 func init() {
 	secretListCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretListCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
+	secretListCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	secretCmd.AddCommand(secretListCmd)
 }
@@ -45,7 +46,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		fmt.Println(msg)
 	}
 
-	secrets, err := proxy.GetSecretList(gatewayAddress, tlsInsecure)
+	secrets, err := proxy.GetSecretListToken(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -26,7 +26,7 @@ faas-cli secret remove NAME --gateway=http://127.0.0.1:8080`,
 func init() {
 	secretRemoveCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretRemoveCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
-
+	secretRemoveCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretCmd.AddCommand(secretRemoveCmd)
 }
 
@@ -52,7 +52,7 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 	secret := schema.Secret{
 		Name: args[0],
 	}
-	err := proxy.RemoveSecret(gatewayAddress, secret, tlsInsecure)
+	err := proxy.RemoveSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -33,7 +33,7 @@ func init() {
 	secretUpdateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretUpdateCmd.Flags().StringVar(&literalSecret, "from-literal", "", "Value of the secret")
 	secretUpdateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
-
+	secretUpdateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretCmd.AddCommand(secretUpdateCmd)
 }
 
@@ -95,7 +95,7 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Updating secret: " + secret.Name)
-	_, output := proxy.UpdateSecret(gatewayAddress, secret, tlsInsecure)
+	_, output := proxy.UpdateSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	fmt.Printf(output)
 
 	return nil

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -27,6 +27,7 @@ func init() {
 	storeDeployCmd.Flags().BoolVarP(&storeDeployFlags.sendRegistryAuth, "send-registry-auth", "a", false, "send registryAuth from Docker credentials manager with the request")
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.annotationOpts, "annotation", "", []string{}, "Set one or more annotation (ANNOTATION=VALUE)")
 	storeDeployCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
+	storeDeployCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 
 	// Set bash-completion.
 	_ = storeDeployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
@@ -122,7 +123,7 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure, item.ReadOnlyRootFilesystem)
+	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure, item.ReadOnlyRootFilesystem, token)
 
 	if badStatusCode(statusCode) {
 		failedStatusCode := map[string]int{itemName: statusCode}

--- a/commands/version.go
+++ b/commands/version.go
@@ -26,7 +26,7 @@ func init() {
 	versionCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	versionCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	versionCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
-
+	versionCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	faasCmd.AddCommand(versionCmd)
 }
 
@@ -71,7 +71,7 @@ func printServerVersions() {
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	info, err := proxy.GetSystemInfo(gatewayAddress, tlsInsecure)
+	info, err := proxy.GetSystemInfo(gatewayAddress, tlsInsecure, token)
 	if err != nil {
 		return
 	}

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -19,3 +19,8 @@ func SetAuth(req *http.Request, gateway string) {
 
 	req.SetBasicAuth(username, password)
 }
+
+//SetToken sets authentication token
+func SetToken(req *http.Request, token string) {
+	req.Header.Set("Authorization", "Bearer "+token)
+}

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -16,6 +16,11 @@ import (
 
 // DeleteFunction delete a function from the OpenFaaS server
 func DeleteFunction(gateway string, functionName string, tlsInsecure bool) error {
+	return DeleteFunctionToken(gateway, functionName, tlsInsecure, "")
+}
+
+//DeleteFunctionToken delete a function with token as auth
+func DeleteFunctionToken(gateway string, functionName string, tlsInsecure bool, token string) error {
 	gateway = strings.TrimRight(gateway, "/")
 	delReq := requests.DeleteFunctionRequest{FunctionName: functionName}
 	reqBytes, _ := json.Marshal(&delReq)
@@ -28,7 +33,13 @@ func DeleteFunction(gateway string, functionName string, tlsInsecure bool) error
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	SetAuth(req, gateway)
+
+	if len(token) > 0 {
+		SetToken(req, token)
+	} else {
+		SetAuth(req, gateway)
+	}
+
 	delRes, delErr := c.Do(req)
 
 	if delErr != nil {

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -45,6 +45,7 @@ type DeployFunctionSpec struct {
 	FunctionResourceRequest FunctionResourceRequest
 	ReadOnlyRootFilesystem  bool
 	TLSInsecure             bool
+	Token                   string
 }
 
 // DeployFunction first tries to deploy a function and if it exists will then attempt
@@ -141,7 +142,12 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 
 	var err error
 	request, err = http.NewRequest(method, gateway+"/system/functions", reader)
-	SetAuth(request, gateway)
+	if len(spec.Token) > 0 {
+		SetToken(request, spec.Token)
+	} else {
+		SetAuth(request, gateway)
+	}
+
 	if err != nil {
 		deployOutput += fmt.Sprintln(err)
 		return http.StatusInternalServerError, deployOutput

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -50,6 +50,7 @@ func runDeployProxyTest(t *testing.T, deployTest deployProxyTest) {
 			FunctionResourceRequest{},
 			false,
 			tlsNoVerify,
+			"",
 		})
 	})
 
@@ -112,6 +113,7 @@ func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 			FunctionResourceRequest{},
 			false,
 			tlsNoVerify,
+			"",
 		})
 	})
 

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -16,6 +16,11 @@ import (
 
 //GetFunctionInfo get an OpenFaaS function information
 func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (requests.Function, error) {
+	return GetFunctionInfoToken(gateway, functionName, tlsInsecure, "")
+}
+
+//GetFunctionInfoToken get a function information with a token as auth
+func GetFunctionInfoToken(gateway string, functionName string, tlsInsecure bool, token string) (requests.Function, error) {
 	var result requests.Function
 
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
@@ -30,7 +35,12 @@ func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (req
 	if err != nil {
 		return result, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}
-	SetAuth(getRequest, gateway)
+
+	if len(token) > 0 {
+		SetToken(getRequest, token)
+	} else {
+		SetAuth(getRequest, gateway)
+	}
 
 	res, err := client.Do(getRequest)
 	if err != nil {

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -13,13 +13,22 @@ import (
 
 // GetSecretList get secrets list
 func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
+	return GetSecretListToken(gateway, tlsInsecure, "")
+}
+
+// GetSecretListToken get secrets lists with taken as auth
+func GetSecretListToken(gateway string, tlsInsecure bool, token string) ([]schema.Secret, error) {
 	var results []schema.Secret
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 
 	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/secrets", nil)
-	SetAuth(getRequest, gateway)
+	if len(token) > 0 {
+		SetToken(getRequest, token)
+	} else {
+		SetAuth(getRequest, gateway)
+	}
 
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
@@ -62,6 +71,11 @@ func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
 
 // UpdateSecret update a secret via the OpenFaaS API by name
 func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, string) {
+	return UpdateSecretToken(gateway, secret, tlsInsecure, "")
+}
+
+// UpdateSecretToken update a secret with token as auth
+func UpdateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) (int, string) {
 	var output string
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -70,7 +84,11 @@ func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 	reqBytes, _ := json.Marshal(&secret)
 
 	putRequest, err := http.NewRequest(http.MethodPut, gateway+"/system/secrets", bytes.NewBuffer(reqBytes))
-	SetAuth(putRequest, gateway)
+	if len(token) > 0 {
+		SetToken(putRequest, token)
+	} else {
+		SetAuth(putRequest, gateway)
+	}
 
 	if err != nil {
 		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s", gateway)
@@ -110,6 +128,11 @@ func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 
 // RemoveSecret remove a secret via the OpenFaaS API by name
 func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error {
+	return RemoveSecretToken(gateway, secret, tlsInsecure, "")
+}
+
+// RemoveSecretToken remove a secret with token as auth
+func RemoveSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) error {
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
@@ -117,7 +140,12 @@ func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error 
 	body, _ := json.Marshal(secret)
 
 	getRequest, err := http.NewRequest(http.MethodDelete, gateway+"/system/secrets", bytes.NewBuffer(body))
-	SetAuth(getRequest, gateway)
+
+	if len(token) > 0 {
+		SetToken(getRequest, token)
+	} else {
+		SetAuth(getRequest, gateway)
+	}
 
 	if err != nil {
 		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
@@ -152,6 +180,11 @@ func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error 
 
 // CreateSecret create secret
 func CreateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, string) {
+	return CreateSecretToken(gateway, secret, tlsInsecure, "")
+}
+
+// CreateSecretToken create secret with token as auth
+func CreateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) (int, string) {
 	var output string
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -161,7 +194,12 @@ func CreateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, 
 
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 	request, err := http.NewRequest(http.MethodPost, gateway+"/system/secrets", reader)
-	SetAuth(request, gateway)
+
+	if len(token) > 0 {
+		SetToken(request, token)
+	} else {
+		SetAuth(request, gateway)
+	}
 
 	if err != nil {
 		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s\n", gateway)

--- a/proxy/version.go
+++ b/proxy/version.go
@@ -12,7 +12,7 @@ import (
 )
 
 //GetSystemInfo get system information from /system/info endpoint
-func GetSystemInfo(gateway string, tlsInsecure bool) (map[string]interface{}, error) {
+func GetSystemInfo(gateway string, tlsInsecure bool, token string) (map[string]interface{}, error) {
 	infoEndPoint := gateway + "/system/info"
 	timeout := 5 * time.Second
 
@@ -21,9 +21,11 @@ func GetSystemInfo(gateway string, tlsInsecure bool) (map[string]interface{}, er
 	if err != nil {
 		return nil, fmt.Errorf("invalid HTTP method or invalid URL")
 	}
-
-	SetAuth(req, gateway)
-
+	if len(token) > 0 {
+		SetToken(req, token)
+	} else {
+		SetAuth(req, gateway)
+	}
 	response, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested all the commands changes on my cluster.

```
Test

/faas-cli-darwin deploy  -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
Deploying: stronghash.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/stronghash

Deploying: nodejs-echo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/nodejs-echo

Deploying: shrink-image.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/shrink-image

Deploying: ruby-echo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/ruby-echo

Deploying: url-ping.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/url-ping


.faas-cli-darwin deploy --name env --fprocess="env" --image="functions/alpine:latest" -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/env



./faas-cli-darwin describe nodejs-echo -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
Name:                nodejs-echo
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               alexellis/faas-nodejs-echo:0.1
Function process:    node index.js
URL:                 http://gw.viveksyngh.me:31112/function/nodejs-echo
Async URL:           http://gw.viveksyngh.me:31112/async-function/nodejs-echo
Labels:Annotations:%

./faas-cli-darwin remove env -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
Deleting: echo.
Removing old function.

./faas-cli-darwin secret create test-secret --from-literal=test -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
Created: 202 Accepted
➜  faas-cli git:(add_token_to_commands) ./faas-cli-darwin secret list -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(add_token_to_commands) ./faas-cli-darwin secret update test-secret --from-literal=value  -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret
Updated: 202 Accepted
➜  faas-cli git:(add_token_to_commands) ./faas-cli-darwin secret update test-secret --from-literal=value  -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
➜  faas-cli git:(add_token_to_commands) ./faas-cli-darwin secret remove test-secret -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(add_token_to_commands) ./faas-cli-darwin secret list -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.


 ./faas-cli-darwin store deploy nodeinfo -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me:31112/function/nodeinfo


./faas-cli-darwin remove env -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
Deleting: env.
Removing old function.

./faas-cli-darwin version  -g "http://gw.viveksyngh.me:31112" --token "$TOKEN"
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  45f1a757cd6a27be125fe1044f9f9478bebee4b7
 version: dev

Gateway
 uri:     http://gw.viveksyngh.me:31112
 version: 0.13.9
 sha:     6481b683f233c39f2f724a7a6318e445c4176b8c
 commit:  Add ca-certs to multi-arch gateways


Provider
 name:          openfaas-operator
 orchestration: kubernetes
 version:       0.9.4
 sha:           51bf99bfb695fdd27777e8b56412b1a5303a8651
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
