### PR TITLE
Add empty flag validation to auth command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The main commands supported by the CLI are:
 
 * `faas-cli secret` - manage secrets for your functions
 
+* `faas-cli auth` - (alpha) initiates an OAuth2 authorization flow to obtain a cookie
+
+
 The default gateway URL of `127.0.0.1:8080` can be overridden in three places including an environmental variable.
 
 * 1st priority `--gateway` flag

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -48,6 +48,13 @@ var authCmd = &cobra.Command{
 }
 
 func preRunAuth(cmd *cobra.Command, args []string) error {
+	return checkValues(authURL,
+		clientID,
+	)
+}
+
+func checkValues(authURL, clientID string) error {
+
 	if len(authURL) == 0 {
 		return fmt.Errorf("--auth-url is required and must be a valid OIDC /authorize URL")
 	}

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) OpenFaaS Author(s) 2019. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package commands
+
+import (
+	"testing"
+)
+
+func Test_auth(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		authURL  string
+		clientID string
+		wantErr  string
+	}{
+		{
+			name:     "Default parameters",
+			authURL:  "",
+			clientID: "",
+			wantErr:  "--auth-url is required and must be a valid OIDC /authorize URL",
+		},
+		{
+			name:     "Invalid auth-url",
+			authURL:  "xyz",
+			clientID: "",
+			wantErr:  "--auth-url is an invalid URL: xyz",
+		},
+		{
+			name:     "Valid auth-url, invalid client-id",
+			authURL:  "http://xyz",
+			clientID: "",
+			wantErr:  "--client-id is required",
+		},
+		{
+			name:     "Valid auth-url and client-id",
+			authURL:  "http://xyz",
+			clientID: "abc",
+			wantErr:  "",
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		t.Run(testCase.name, func(t *testing.T) {
+			err := checkValues(testCase.authURL, testCase.clientID)
+			gotErr := ""
+			if err != nil {
+				gotErr = err.Error()
+			}
+
+			if testCase.wantErr != gotErr {
+				t.Errorf("want %q, got %q", testCase.wantErr, gotErr)
+				t.Fail()
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Alex Ellis <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When passing no parameters or empty values the current version
was attempting to initiate an OAuth2 flow, when it would have
been invalid.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This patch fixes that and has been tested end-to-end so show the error presents.

```
alext:faas-cli alex$ ./faas-cli auth
--auth-url is required and must be a valid OIDC /authorize URL

alext:faas-cli alex$ ./faas-cli auth --auth-url x
--auth-url is an invalid URL: x

alext:faas-cli alex$ ./faas-cli auth --auth-url http://x/authorize
--client-id is required

alext:faas-cli alex$ ./faas-cli auth --auth-url http://x/authorize --client-id=123
Starting local token server on port 31111
Launching browser: http://x/authorize?audience=&client_id=123&nonce=1561621756972359000&redirect_uri=http%3A%2F%2F127.0.0.1%3A31111%2Foauth%2Fca
llback&response_type=token&scope=&state=1561621756972358000
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.