### PR TITLE
Add client_credentials to auth command for machine-to-machine auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ The main commands supported by the CLI are:
 
 * `faas-cli auth` - (alpha) initiates an OAuth2 authorization flow to obtain a cookie
 
-
 The default gateway URL of `127.0.0.1:8080` can be overridden in three places including an environmental variable.
 
 * 1st priority `--gateway` flag
@@ -103,6 +102,42 @@ Help for all of the commands supported by the CLI can be found by running:
 * `faas-cli help` or `faas-cli [command] --help`
 
 You can chose between using a [programming language template](https://github.com/openfaas/templates/tree/master/template) where you only need to provide a handler file, or a Docker that you can build yourself.
+
+#### `faas-cli auth`
+
+The `auth` command is currently available for alpha testing. Use the `auth` command to obtain a JWT to use as a Bearer token.
+
+Two flow-types are supported in the CLI.
+
+##### `code` grant - default
+
+Use this flow to obtain a token.
+
+At this time the `token` cannot be saved or retained in your OpenFaaS config file. You can pass the token using a CLI flag of `--token=$TOKEN`.
+
+Example:
+
+```sh
+faas-cli auth \
+  --auth-url https://tenant0.eu.auth0.com/authorize \
+  --audience http://gw.example.com \
+  --client-id "${OAUTH_CLIENT_ID}"
+```
+
+##### `client_credentials` grant
+
+Use this flow for machine to machine communication such as when you want to deploy a function to a gateway that uses OAuth2 / OIDC.
+
+Example:
+
+```sh
+faas-cli auth \
+  --grant client_credentials \
+  --auth-url https://tenant0.eu.auth0.com/oauth/token \
+  --client-id "${OAUTH_CLIENT_ID}" \
+  --client-secret "${OAUTH_CLIENT_SECRET}"\
+  --audience http://gw.example.com
+```
 
 ##### Environment variable substitution
 

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -19,7 +19,7 @@ func Test_auth(t *testing.T) {
 			name:     "Default parameters",
 			authURL:  "",
 			clientID: "",
-			wantErr:  "--auth-url is required and must be a valid OIDC /authorize URL",
+			wantErr:  "--auth-url is required and must be a valid OIDC URL",
 		},
 		{
 			name:     "Invalid auth-url",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds client_credentials to auth command for machine-to-machine auth
such as CI/CD.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Feature for: #647

This patch adds the client_credentials flow so that it can be
used in CI/CD processes for deploying to the OpenFaaS gateway
without using an interactive flow.    

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested e2e with Auth0 and a Machine2Machine App type.
Tested that there is no regression in UI / gateway code flow, or
the implicit flow.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.