### PR TITLE
Fix `template store list` command

### DIFF
--- a/commands/template_store_list.go
+++ b/commands/template_store_list.go
@@ -106,15 +106,15 @@ func getTemplateInfo(repository string) ([]TemplateInfo, error) {
 }
 
 func formatTemplatesOutput(templates []TemplateInfo, verbose bool, platform string) string {
+
 	if platform != mainPlatform {
-		for templatesLength, template := range templates {
-			if strings.EqualFold(template.Platform, platform) {
-				break
-			}
-			if len(template.Platform)-1 == templatesLength {
-				return ""
-			}
-		}
+		templates = filterTemplate(templates, platform)
+	} else {
+		templates = filterTemplate(templates, mainPlatform)
+	}
+
+	if len(templates) == 0 {
+		return ""
 	}
 
 	var buff bytes.Buffer
@@ -122,9 +122,9 @@ func formatTemplatesOutput(templates []TemplateInfo, verbose bool, platform stri
 
 	fmt.Fprintln(lineWriter)
 	if verbose {
-		formatVerboseOutput(lineWriter, templates, platform)
+		formatVerboseOutput(lineWriter, templates)
 	} else {
-		formatBasicOutput(lineWriter, templates, platform)
+		formatBasicOutput(lineWriter, templates)
 	}
 	fmt.Fprintln(lineWriter)
 
@@ -133,12 +133,8 @@ func formatTemplatesOutput(templates []TemplateInfo, verbose bool, platform stri
 	return buff.String()
 }
 
-func formatBasicOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo, platform string) {
-	if platform != mainPlatform {
-		templates = filterTemplate(templates, platform)
-	} else {
-		templates = filterTemplate(templates, mainPlatform)
-	}
+func formatBasicOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo) {
+
 	fmt.Fprintf(lineWriter, "NAME\tSOURCE\tDESCRIPTION\n")
 	for _, template := range templates {
 		fmt.Fprintf(lineWriter, "%s\t%s\t%s\n",
@@ -148,12 +144,8 @@ func formatBasicOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo, p
 	}
 }
 
-func formatVerboseOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo, platform string) {
-	if platform != mainPlatform {
-		templates = filterTemplate(templates, platform)
-	} else {
-		templates = filterTemplate(templates, mainPlatform)
-	}
+func formatVerboseOutput(lineWriter *tabwriter.Writer, templates []TemplateInfo) {
+
 	fmt.Fprintf(lineWriter, "NAME\tLANGUAGE\tPLATFORM\tSOURCE\tDESCRIPTION\n")
 	for _, template := range templates {
 		fmt.Fprintf(lineWriter, "%s\t%s\t%s\t%s\t%s\n",
@@ -178,6 +170,7 @@ type TemplateInfo struct {
 
 func filterTemplate(templates []TemplateInfo, platform string) []TemplateInfo {
 	var filteredTemplates []TemplateInfo
+
 	for _, template := range templates {
 		if strings.EqualFold(template.Platform, platform) {
 			filteredTemplates = append(filteredTemplates, template)


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description

Move the call to `filterTemplate()` into the `formatTemplatesOutput()` function and then test for a non-zero slice length before proceeding.  As the templates slice is filtered higher up this removes the need to call in to `filterTemplate()` within the two output functions, which consequently also removes the need to pass platform into them.

## Motivation and Context
An issue existed whereby `arm64` templates would not display in the `template list` command.

The cause was located within the `formatTemplatesOutput()` function which was seemingly doing some pre-filtering to ascertain whether the output should return empty if no templates matching the supplied pattern were found.  Within this function a comparison was being performed of the template.Platform string length and the range index of the current slice.  This meant that as `arm64` didn't occur within the first 6/7 elements the function would return and empty string.

- [x] I have raised an issue to propose this change (fixes #653)

## How Has This Been Tested?

### Establish version
```
$ ./faas-cli-darwin version


[34m  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

[0mCLI:
 commit:  1af08a023d8b6032fa2705c004f157d106e0929a
 version: dev

Gateway
 uri:     http://127.0.0.1:8080
 version: 0.12.0
 sha:     ebc41933b7115e100b0a63137de43bd6abe34293
 commit:  Remove prometheus changes


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.6.1 
 sha:           3cac0ccc2e8bb7f567739a33f7d414cdb58440aa
```

### Basic `armhf` output

```
$ ./faas-cli-darwin template store list --platform=armhf

NAME                    SOURCE             DESCRIPTION
dockerfile-armhf        openfaas           Official Dockerfile armhf template
go-armhf                openfaas           Official Golang armhf template
node-armhf              openfaas           Official NodeJS 8 armhf template
python-armhf            openfaas           Official Python 2.7 armhf template
python3-armhf           openfaas           Official Python 3.6 armhf template
node10-express-armhf    openfaas-incubator Node.js 10 powered by express armhf template
python3-flask-armhf     openfaas-incubator Python 3.6 Flask armhf template
python3-http-armhf      openfaas-incubator Python 3.6 with Flask and HTTP for ARMHF
node8-express-armhf     openfaas-incubator Node.js 8 powered by express armhf template
golang-http-armhf       openfaas-incubator Golang HTTP armhf template
golang-middleware-armhf openfaas-incubator Golang Middleware armhf template
```

### Basic `arm64` output

```
$ ./faas-cli-darwin template store list --platform=arm64

NAME                 SOURCE             DESCRIPTION
node-arm64           openfaas           Official NodeJS 8 arm64 template
node10-express-arm64 openfaas-incubator Node.js 10 powered by express arm64 template
```

### Basic `x86_64` output

```
$ ./faas-cli-darwin template store list --platform=x86_64

NAME                     SOURCE             DESCRIPTION
csharp                   openfaas           Official C# template
dockerfile               openfaas           Official Dockerfile template
go                       openfaas           Official Golang template
java8                    openfaas           Official Java 8 template
node                     openfaas           Official NodeJS 8 template
php7                     openfaas           Official PHP 7 template
python                   openfaas           Official Python 2.7 template
python3                  openfaas           Official Python 3.6 template
ruby                     openfaas           Official Ruby 2.5 template
node10-express           openfaas-incubator Node.js 10 powered by express template
ruby-http                openfaas-incubator Ruby 2.4 HTTP template
python27-flask           openfaas-incubator Python 2.7 Flask template
python3-flask            openfaas-incubator Python 3.6 Flask template
python3-http             openfaas-incubator Python 3.6 with Flask and HTTP
node8-express            openfaas-incubator Node.js 8 powered by express template
golang-http              openfaas-incubator Golang HTTP template
golang-middleware        openfaas-incubator Golang Middleware template
python3-debian           openfaas-incubator Python 3.6 Debian template
powershell-template      openfaas-incubator Powershell Core Ubuntu:16.04 template
powershell-http-template openfaas-incubator Powershell Core HTTP Ubuntu:16.04 template
rust                     booyaa             Rust template
crystal                  tpei               Crystal template
csharp-httprequest       distantcam         C# HTTP template
vertx-native             pmlopes            Eclipse Vert.x native image template
swift                    affix              Swift 4.2 Template
lua53                    affix              Lua 5.3 Template
vala                     affix              Vala Template
vala-http                affix              Non-Forking Vala Template
quarkus-native           pmlopes            Quarkus.io native image template
perl-alpine              tmiklas            Perl language template based on Alpine image
node10-express-service   openfaas-incubator Node.js 10 express.js microservice template
```

### Basic default (`x86_64`) output

```
$ ./faas-cli-darwin template store list

NAME                     SOURCE             DESCRIPTION
csharp                   openfaas           Official C# template
dockerfile               openfaas           Official Dockerfile template
go                       openfaas           Official Golang template
java8                    openfaas           Official Java 8 template
node                     openfaas           Official NodeJS 8 template
php7                     openfaas           Official PHP 7 template
python                   openfaas           Official Python 2.7 template
python3                  openfaas           Official Python 3.6 template
ruby                     openfaas           Official Ruby 2.5 template
node10-express           openfaas-incubator Node.js 10 powered by express template
ruby-http                openfaas-incubator Ruby 2.4 HTTP template
python27-flask           openfaas-incubator Python 2.7 Flask template
python3-flask            openfaas-incubator Python 3.6 Flask template
python3-http             openfaas-incubator Python 3.6 with Flask and HTTP
node8-express            openfaas-incubator Node.js 8 powered by express template
golang-http              openfaas-incubator Golang HTTP template
golang-middleware        openfaas-incubator Golang Middleware template
python3-debian           openfaas-incubator Python 3.6 Debian template
powershell-template      openfaas-incubator Powershell Core Ubuntu:16.04 template
powershell-http-template openfaas-incubator Powershell Core HTTP Ubuntu:16.04 template
rust                     booyaa             Rust template
crystal                  tpei               Crystal template
csharp-httprequest       distantcam         C# HTTP template
vertx-native             pmlopes            Eclipse Vert.x native image template
swift                    affix              Swift 4.2 Template
lua53                    affix              Lua 5.3 Template
vala                     affix              Vala Template
vala-http                affix              Non-Forking Vala Template
quarkus-native           pmlopes            Quarkus.io native image template
perl-alpine              tmiklas            Perl language template based on Alpine image
node10-express-service   openfaas-incubator Node.js 10 express.js microservice template
```

### Verbose `armhf` output

```
$ ./faas-cli-darwin template store list --platform=armhf --verbose

NAME                    LANGUAGE   PLATFORM SOURCE             DESCRIPTION
dockerfile-armhf        Dockerfile armhf    openfaas           Official Dockerfile armhf template
go-armhf                Go         armhf    openfaas           Official Golang armhf template
node-armhf              NodeJS     armhf    openfaas           Official NodeJS 8 armhf template
python-armhf            Python     armhf    openfaas           Official Python 2.7 armhf template
python3-armhf           Python     armhf    openfaas           Official Python 3.6 armhf template
node10-express-armhf    NodeJS     armhf    openfaas-incubator Node.js 10 powered by express armhf template
python3-flask-armhf     Python     armhf    openfaas-incubator Python 3.6 Flask armhf template
python3-http-armhf      Python     armhf    openfaas-incubator Python 3.6 with Flask and HTTP for ARMHF
node8-express-armhf     NodeJS     armhf    openfaas-incubator Node.js 8 powered by express armhf template
golang-http-armhf       Go         armhf    openfaas-incubator Golang HTTP armhf template
golang-middleware-armhf Go         armhf    openfaas-incubator Golang Middleware armhf template
```

### Verbose `arm64` output

```
$ ./faas-cli-darwin template store list --platform=arm64 --verbose

NAME                 LANGUAGE PLATFORM SOURCE             DESCRIPTION
node-arm64           NodeJS   arm64    openfaas           Official NodeJS 8 arm64 template
node10-express-arm64 NodeJS   arm64    openfaas-incubator Node.js 10 powered by express arm64 template
```

### Verbose `x86_64` output

```
$ ./faas-cli-darwin template store list --platform=x86_64 --verbose

NAME                     LANGUAGE   PLATFORM SOURCE             DESCRIPTION
csharp                   C#         x86_64   openfaas           Official C# template
dockerfile               Dockerfile x86_64   openfaas           Official Dockerfile template
go                       Go         x86_64   openfaas           Official Golang template
java8                    Java       x86_64   openfaas           Official Java 8 template
node                     NodeJS     x86_64   openfaas           Official NodeJS 8 template
php7                     PHP        x86_64   openfaas           Official PHP 7 template
python                   Python     x86_64   openfaas           Official Python 2.7 template
python3                  Python     x86_64   openfaas           Official Python 3.6 template
ruby                     Ruby       x86_64   openfaas           Official Ruby 2.5 template
node10-express           NodeJS     x86_64   openfaas-incubator Node.js 10 powered by express template
ruby-http                Ruby       x86_64   openfaas-incubator Ruby 2.4 HTTP template
python27-flask           Python     x86_64   openfaas-incubator Python 2.7 Flask template
python3-flask            Python     x86_64   openfaas-incubator Python 3.6 Flask template
python3-http             Python     x86_64   openfaas-incubator Python 3.6 with Flask and HTTP
node8-express            NodeJS     x86_64   openfaas-incubator Node.js 8 powered by express template
golang-http              Go         x86_64   openfaas-incubator Golang HTTP template
golang-middleware        Go         x86_64   openfaas-incubator Golang Middleware template
python3-debian           Python     x86_64   openfaas-incubator Python 3.6 Debian template
powershell-template      Python     x86_64   openfaas-incubator Powershell Core Ubuntu:16.04 template
powershell-http-template Python     x86_64   openfaas-incubator Powershell Core HTTP Ubuntu:16.04 template
rust                     Rust       x86_64   booyaa             Rust template
crystal                  Crystal    x86_64   tpei               Crystal template
csharp-httprequest       C#         x86_64   distantcam         C# HTTP template
vertx-native             Java       x86_64   pmlopes            Eclipse Vert.x native image template
swift                    Swift      x86_64   affix              Swift 4.2 Template
lua53                    Lua        x86_64   affix              Lua 5.3 Template
vala                     Vala       x86_64   affix              Vala Template
vala-http                Vala       x86_64   affix              Non-Forking Vala Template
quarkus-native           Java       x86_64   pmlopes            Quarkus.io native image template
perl-alpine              Perl       x86_64   tmiklas            Perl language template based on Alpine image
node10-express-service   NodeJS     x86_64   openfaas-incubator Node.js 10 express.js microservice template
```

### Verbose default (`x86_64`) output

```
$ ./faas-cli-darwin template store list --verbose

NAME                     LANGUAGE   PLATFORM SOURCE             DESCRIPTION
csharp                   C#         x86_64   openfaas           Official C# template
dockerfile               Dockerfile x86_64   openfaas           Official Dockerfile template
go                       Go         x86_64   openfaas           Official Golang template
java8                    Java       x86_64   openfaas           Official Java 8 template
node                     NodeJS     x86_64   openfaas           Official NodeJS 8 template
php7                     PHP        x86_64   openfaas           Official PHP 7 template
python                   Python     x86_64   openfaas           Official Python 2.7 template
python3                  Python     x86_64   openfaas           Official Python 3.6 template
ruby                     Ruby       x86_64   openfaas           Official Ruby 2.5 template
node10-express           NodeJS     x86_64   openfaas-incubator Node.js 10 powered by express template
ruby-http                Ruby       x86_64   openfaas-incubator Ruby 2.4 HTTP template
python27-flask           Python     x86_64   openfaas-incubator Python 2.7 Flask template
python3-flask            Python     x86_64   openfaas-incubator Python 3.6 Flask template
python3-http             Python     x86_64   openfaas-incubator Python 3.6 with Flask and HTTP
node8-express            NodeJS     x86_64   openfaas-incubator Node.js 8 powered by express template
golang-http              Go         x86_64   openfaas-incubator Golang HTTP template
golang-middleware        Go         x86_64   openfaas-incubator Golang Middleware template
python3-debian           Python     x86_64   openfaas-incubator Python 3.6 Debian template
powershell-template      Python     x86_64   openfaas-incubator Powershell Core Ubuntu:16.04 template
powershell-http-template Python     x86_64   openfaas-incubator Powershell Core HTTP Ubuntu:16.04 template
rust                     Rust       x86_64   booyaa             Rust template
crystal                  Crystal    x86_64   tpei               Crystal template
csharp-httprequest       C#         x86_64   distantcam         C# HTTP template
vertx-native             Java       x86_64   pmlopes            Eclipse Vert.x native image template
swift                    Swift      x86_64   affix              Swift 4.2 Template
lua53                    Lua        x86_64   affix              Lua 5.3 Template
vala                     Vala       x86_64   affix              Vala Template
vala-http                Vala       x86_64   affix              Non-Forking Vala Template
quarkus-native           Java       x86_64   pmlopes            Quarkus.io native image template
perl-alpine              Perl       x86_64   tmiklas            Perl language template based on Alpine image
node10-express-service   NodeJS     x86_64   openfaas-incubator Node.js 10 express.js microservice template
```

### Basic null output

```
$ ./faas-cli-darwin template store list --platform=burt

```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
