### PR TITLE
Handle '409 CONFLICT' during secret creation.'

### DIFF
--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -223,6 +223,9 @@ func CreateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, t
 	case http.StatusUnauthorized:
 		output += fmt.Sprintln("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
 
+	case http.StatusConflict:
+		output += fmt.Sprintf("secret with the name %q already exists\n", secret.Name)
+
 	default:
 		bytesOut, err := ioutil.ReadAll(res.Body)
 		if err == nil {

--- a/proxy/secret_test.go
+++ b/proxy/secret_test.go
@@ -169,3 +169,22 @@ func Test_CreateSecret_Unauthorized401(t *testing.T) {
 		t.Fatalf("Error not matched: %s", output)
 	}
 }
+
+func Test_CreateSecret_Conflict409(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusConflict)
+
+	secret := schema.Secret{
+		Name:  "secret-name",
+		Value: "secret-value",
+	}
+	status, output := CreateSecret(s.URL, secret, true)
+
+	if status != http.StatusConflict {
+		t.Errorf("want: %d, got: %d", http.StatusConflict, status)
+	}
+
+	r := regexp.MustCompile(`(?m:secret with the name "` + secret.Name + `" already exists)`)
+	if !r.MatchString(output) {
+		t.Fatalf("Error not matched: %s", output)
+	}
+}


### PR DESCRIPTION
## Description

This PR adds support for handling `409 CONFLICT` status codes returned by the OpenFaaS gateway when trying to create a secret that already exists. It is a companion PR to https://github.com/openfaas/faas-netes/pull/468.

## Motivation and Context

I believe https://github.com/openfaas/faas-netes/pull/468 contains all the required details.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

I've tested it by extending the existing unit tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
