### PR TITLE
Add token auth support to the logs cmd

### DIFF
--- a/commands/logs.go
+++ b/commands/logs.go
@@ -26,6 +26,7 @@ type logFlags struct {
 	sinceTime flags.TimestampFlag
 	follow    bool
 	tail      int
+	token     string
 }
 
 func init() {
@@ -65,6 +66,7 @@ func initLogCmdFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(&logFlagValues.sinceTime, "since-time", "include logs since the given timestamp (RFC3339)")
 	cmd.Flags().IntVar(&logFlagValues.tail, "tail", -1, "number of recent log lines file to display. Defaults to -1, unlimited if <=0")
 	cmd.Flags().BoolVar(&logFlagValues.follow, "follow", true, "continue printing new logs until the end of the request, up to 30s")
+	cmd.Flags().StringVarP(&logFlagValues.token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 }
 
 func runLogs(cmd *cobra.Command, args []string) error {
@@ -75,7 +77,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	logRequest := logRequestFromFlags(cmd, args)
-	logEvents, err := proxy.GetLogs(gatewayAddress, tlsInsecure, logRequest)
+	logEvents, err := proxy.GetLogs(gatewayAddress, tlsInsecure, logRequest, logFlagValues.token)
 	if err != nil {
 		return err
 	}

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -32,7 +32,7 @@ func ListFunctionsToken(gateway string, tlsInsecure bool, token string) ([]reque
 	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/functions", nil)
 
 	if len(token) > 0 {
-		getRequest.Header.Set("Authorization", "Bearer "+token)
+		SetToken(getRequest, token)
 	} else {
 		SetAuth(getRequest, gateway)
 	}

--- a/proxy/logs.go
+++ b/proxy/logs.go
@@ -16,16 +16,21 @@ import (
 )
 
 // GetLogs list deployed functions
-func GetLogs(gateway string, tlsInsecure bool, params logs.Request) (<-chan logs.Message, error) {
+func GetLogs(gateway string, tlsInsecure bool, params logs.Request, token string) (<-chan logs.Message, error) {
 
 	gateway = strings.TrimRight(gateway, "/")
 	// replace with a client that allows keep alive, Default?
 	client := makeStreamingHTTPClient(tlsInsecure)
 
 	logRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/logs", nil)
-	SetAuth(logRequest, gateway)
 	if err != nil {
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
+	}
+
+	if len(token) > 0 {
+		SetToken(logRequest, token)
+	} else {
+		SetAuth(logRequest, gateway)
 	}
 
 	logRequest.URL.RawQuery = reqAsQueryValues(params).Encode()

--- a/proxy/logs_test.go
+++ b/proxy/logs_test.go
@@ -1,0 +1,125 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openfaas/faas-cli/test"
+	"github.com/openfaas/faas-provider/logs"
+)
+
+func Test_GetLogs_TokenAuth(t *testing.T) {
+	expectedToken := "abc123"
+	params := logs.Request{Name: "testFunc"}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenValue := r.Header.Get("Authorization")
+		if tokenValue != "Bearer "+expectedToken {
+			t.Fatalf("Expected header token %v, got %v", expectedToken, tokenValue)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	_, err := GetLogs(srv.URL, true, params, expectedToken)
+	if err != nil {
+		t.Fatalf("Error returned: %s", err.Error())
+	}
+
+}
+
+func Test_GetLogs_200OK(t *testing.T) {
+
+	params := logs.Request{Name: "testFunc"}
+
+	lines := []logs.Message{
+		logs.Message{Name: params.Name, Text: "test"},
+		logs.Message{Name: params.Name, Text: "test2"},
+	}
+
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			ResponseStatusCode: http.StatusOK,
+			ResponseBody:       logRespBody(lines...),
+		},
+	})
+	defer s.Close()
+
+	logs, err := GetLogs(s.URL, true, params, "")
+	if err != nil {
+		t.Errorf("Error returned: %s", err.Error())
+	}
+
+	var sent int
+	for line := range logs {
+		expected := lines[sent]
+		if expected.Text != line.Text {
+			t.Fatalf("Expeceted: %#v - Actual: %#v", expected.Text, line.Text)
+		}
+		sent++
+	}
+}
+
+func Test_GetLogs_401Unauthorized(t *testing.T) {
+
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			ResponseStatusCode: http.StatusUnauthorized,
+			ResponseBody:       "not allowed",
+		},
+	})
+	defer s.Close()
+
+	params := logs.Request{Name: "test"}
+	_, err := GetLogs(s.URL, true, params, "")
+	if err == nil {
+		t.Fatal("Expected error, got: nil")
+	}
+
+	if err.Error() != "unauthorized access, run \"faas-cli login\" to setup authentication for this server" {
+		t.Fatalf("Expected unauthorized error, got: %#v", err)
+	}
+}
+
+func Test_GetLogs_UnexpectedStatus(t *testing.T) {
+
+	cases := []int{
+		http.StatusBadRequest, http.StatusForbidden, http.StatusInternalServerError,
+	}
+
+	for _, v := range cases {
+		s := test.MockHttpServer(t, []test.Request{
+			{
+				ResponseStatusCode: v,
+				ResponseBody:       "bad request, try again",
+			},
+		})
+		defer s.Close()
+
+		_, err := GetLogs(s.URL, true, logs.Request{Name: "test"}, "")
+		if err == nil {
+			t.Fatal("Expected error, got: nil")
+		}
+
+		expectedErr := fmt.Sprintf("server returned unexpected status code: %d - bad request, try again", v)
+		if err.Error() != expectedErr {
+			t.Fatalf("Expected %#v, got: %#v", expectedErr, err)
+		}
+	}
+}
+
+// create new-line delimited json string to treat as a logs response body
+func logRespBody(messages ...logs.Message) string {
+	var s strings.Builder
+
+	e := json.NewEncoder(&s)
+	for _, m := range messages {
+		e.Encode(m)
+	}
+
+	return s.String()
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add the token flag to the logs command, this allows users to oauth as
well as basic auth.
- additionally add some basic test for the GetLogs method and use the
SetToken helper in the List command

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #656 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A new unit test in the proxy package verifies the behavior

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
