### PR TITLE
Trim newlines from log messages

### DIFF
--- a/commands/logs.go
+++ b/commands/logs.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/openfaas/faas-cli/flags"
@@ -83,7 +84,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	for logMsg := range logEvents {
-		fmt.Fprintln(os.Stdout, logMsg.String())
+		fmt.Fprintln(os.Stdout, strings.TrimRight(logMsg.String(), "\n"))
 	}
 
 	return nil


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Remove trailing newlines from log messages to avoid double spacing the
log stream when it is printed to stdout.  The current implementation
results in empty lines between each log line, this looks odd for users.
This commit ensures there is not an empty line between log lines.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #659

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested using the faas-netes local development cluster
1. in faas-cli, run `make local-install`
2. in faas-netes, run `make start-kind`
3. deploy figlet
    ```
    $ export OFG=http://127.0.0.1:31112
    $ faas-cli store deploy figlet -g=$OFG

    Post http://127.0.0.1:31112/function/figlet: EOF

    $ echo "tester" | faas-cli invoke echo -g=$OFG
    _            _
    | |_ ___  ___| |_ ___ _ __
    | __/ _ \/ __| __/ _ \ '__|
    | ||  __/\__ \ ||  __/ |
    \__\___||___/\__\___|_|
    ```
4. check the logs with `kubectl` and `faas-cli`

   ```
    $ faas-cli logs figlet -g=$OFG --tls-no-verify
    2019-07-08 18:52:50.0914285 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:52:50 Version: 0.13.0	SHA: fa93655d90d1518b04e7cfca7d7548d7d133a34e
    2019-07-08 18:52:50.0919969 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:52:50 Read/write timeout: 5s, 5s. Port: 8080
    2019-07-08 18:52:50.0930294 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:52:50 Writing lock-file to: /tmp/.lock
    2019-07-08 18:52:50.0936703 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:52:50 Metrics server. Port: 8081
    2019-07-08 18:53:06.4066927 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:53:06 Forking fprocess.
    2019-07-08 18:53:06.4107382 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:53:06 Wrote 168 Bytes - Duration: 0.004138 seconds
    2019-07-08 18:56:14.3380825 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:56:14 Forking fprocess.
    2019-07-08 18:56:14.3404682 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:56:14 Wrote 168 Bytes - Duration: 0.002305 seconds
    2019-07-08 18:57:28.1728139 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:57:28 Forking fprocess.
    2019-07-08 18:57:28.1807267 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:57:28 Wrote 168 Bytes - Duration: 0.007908 seconds
    2019-07-08 18:59:00.2107759 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:59:00 Forking fprocess.
    2019-07-08 18:59:00.2142166 +0000 UTC figlet (figlet-7f5d95df96-5tcld) 2019/07/08 18:59:00 Wrote 168 Bytes - Duration: 0.003352 seconds


    $ export KUBECONFIG="$(kind get kubeconfig-path --name="kind")
    $ kubectl logs deploy/figlet -n openfaas-fn
    2019/07/08 18:52:50 Version: 0.13.0	SHA: fa93655d90d1518b04e7cfca7d7548d7d133a34e
    2019/07/08 18:52:50 Read/write timeout: 5s, 5s. Port: 8080
    2019/07/08 18:52:50 Writing lock-file to: /tmp/.lock
    2019/07/08 18:52:50 Metrics server. Port: 8081
    2019/07/08 18:53:06 Forking fprocess.
    2019/07/08 18:53:06 Wrote 168 Bytes - Duration: 0.004138 seconds
    2019/07/08 18:56:14 Forking fprocess.
    2019/07/08 18:56:14 Wrote 168 Bytes - Duration: 0.002305 seconds
    2019/07/08 18:57:28 Forking fprocess.
    2019/07/08 18:57:28 Wrote 168 Bytes - Duration: 0.007908 seconds
    2019/07/08 18:59:00 Forking fprocess.
    2019/07/08 18:59:00 Wrote 168 Bytes - Duration: 0.003352 seconds
   ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
