### PR TITLE
Add template pull stack

### DIFF
--- a/commands/fetch_templates.go
+++ b/commands/fetch_templates.go
@@ -116,3 +116,27 @@ func moveTemplates(repoPath string, overwrite bool) ([]string, []string, error) 
 
 	return existingLanguages, fetchedLanguages, nil
 }
+
+func pullTemplate(repository string) error {
+	if _, err := os.Stat(repository); err != nil {
+		if !versioncontrol.IsGitRemote(repository) && !versioncontrol.IsPinnedGitRemote(repository) {
+			return fmt.Errorf("The repository URL must be a valid git repo uri")
+		}
+	}
+
+	repository, refName := versioncontrol.ParsePinnedRemote(repository)
+
+	if err := versioncontrol.GitCheckRefName.Invoke("", map[string]string{"refname": refName}); err != nil {
+		fmt.Printf("Invalid tag or branch name `%s`\n", refName)
+		fmt.Println("See https://git-scm.com/docs/git-check-ref-format for more details of the rules Git enforces on branch and reference names.")
+
+		return err
+	}
+
+	fmt.Printf("Fetch templates from repository: %s at %s\n", repository, refName)
+	if err := fetchTemplates(repository, refName, overwrite); err != nil {
+		return fmt.Errorf("error while fetching templates: %s", err)
+	}
+
+	return nil
+}

--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -4,9 +4,7 @@ package commands
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/openfaas/faas-cli/versioncontrol"
 	"github.com/spf13/cobra"
 )
 
@@ -44,28 +42,8 @@ func runTemplatePull(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		repository = args[0]
 	}
-	repository = getTemplateURL(repository, os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
 
-	if _, err := os.Stat(repository); err != nil {
-		if !versioncontrol.IsGitRemote(repository) && !versioncontrol.IsPinnedGitRemote(repository) {
-			return fmt.Errorf("The repository URL must be a valid git repo uri")
-		}
-	}
-
-	repository, refName := versioncontrol.ParsePinnedRemote(repository)
-
-	if err := versioncontrol.GitCheckRefName.Invoke("", map[string]string{"refname": refName}); err != nil {
-		fmt.Printf("Invalid tag or branch name `%s`\n", refName)
-		fmt.Println("See https://git-scm.com/docs/git-check-ref-format for more details of the rules Git enforces on branch and reference names.")
-
-		return err
-	}
-
-	fmt.Printf("Fetch templates from repository: %s at %s\n", repository, refName)
-	if err := fetchTemplates(repository, refName, overwrite); err != nil {
-		return fmt.Errorf("error while fetching templates: %s", err)
-	}
-	return nil
+	return pullTemplate(repository)
 }
 
 func pullDebugPrint(message string) {

--- a/commands/template_pull_stack.go
+++ b/commands/template_pull_stack.go
@@ -1,0 +1,111 @@
+package commands
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/openfaas/faas-cli/stack"
+	"github.com/spf13/cobra"
+)
+
+var (
+	templateURL    string
+	customRepoName string
+)
+
+func init() {
+	templatePullStackCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing templates?")
+	templatePullStackCmd.Flags().BoolVar(&pullDebug, "debug", false, "Enable debug output")
+	templatePullStackCmd.PersistentFlags().StringVarP(&customRepoName, "repo", "r", "", "The custom name of the template repo")
+
+	templatePullCmd.AddCommand(templatePullStackCmd)
+}
+
+var templatePullStackCmd = &cobra.Command{
+	Use:   `stack`,
+	Short: `Downloads templates specified in the function definition yaml file`,
+	Long: `Downloads templates specified in the function yaml file, in the current directory
+	`,
+	Example: `
+  faas-cli template pull stack
+  faas-cli template pull stack -f myfunction.yml
+  faas-cli template pull stack -r custom_repo_name
+`,
+	RunE: runTemplatePullStack,
+}
+
+func runTemplatePullStack(cmd *cobra.Command, args []string) error {
+	templatesConfig, err := loadTemplateConfig()
+	if err != nil {
+		return err
+	}
+	if len(customRepoName) > 0 {
+		return pullSpecificTemplate(templatesConfig, customRepoName, cmd)
+	}
+	return pullAllTemplates(templatesConfig, cmd)
+}
+
+func loadTemplateConfig() ([]stack.TemplateSource, error) {
+	stackConfig, err := readStackConfig()
+	if err != nil {
+		return nil, err
+	}
+	return stackConfig.StackConfig.TemplateConfigs, nil
+}
+
+func readStackConfig() (stack.Configuration, error) {
+	configField := stack.Configuration{}
+
+	configFieldBytes, err := ioutil.ReadFile(yamlFile)
+	if err != nil {
+		return configField, fmt.Errorf("Error while reading files %s", err.Error())
+	}
+	unmarshallErr := yaml.Unmarshal(configFieldBytes, &configField)
+	if unmarshallErr != nil {
+		return configField, fmt.Errorf("Error while reading configuration: %s", err.Error())
+	}
+	if len(configField.StackConfig.TemplateConfigs) == 0 {
+		return configField, fmt.Errorf("Error while reading configuration: no template repos currently configured")
+	}
+	return configField, nil
+}
+
+func pullAllTemplates(templateInfo []stack.TemplateSource, cmd *cobra.Command) error {
+	for _, val := range templateInfo {
+		fmt.Printf("Pulling template: %s from configuration file: %s\n", val.Name, yamlFile)
+		if len(val.Source) == 0 {
+			pullErr := runTemplateStorePull(cmd, []string{val.Name})
+			if pullErr != nil {
+				return pullErr
+			}
+		} else {
+			pullErr := pullTemplate(val.Source)
+			if pullErr != nil {
+				return pullErr
+			}
+		}
+	}
+	return nil
+}
+
+func findTemplate(templateInfo []stack.TemplateSource, customName string) (specificTemplate *stack.TemplateSource) {
+	for _, val := range templateInfo {
+		if val.Name == customName {
+			return &val
+		}
+	}
+	return nil
+}
+
+func pullSpecificTemplate(templateInfo []stack.TemplateSource, customName string, cmd *cobra.Command) error {
+	desiredTemplate := findTemplate(templateInfo, customName)
+	if desiredTemplate == nil {
+		return fmt.Errorf("Unable to find template repo with name: `%s`", customName)
+	}
+	if len(desiredTemplate.Source) == 0 {
+		return runTemplateStorePull(cmd, []string{desiredTemplate.Name})
+	}
+	return pullTemplate(desiredTemplate.Source)
+}

--- a/commands/template_pull_stack_test.go
+++ b/commands/template_pull_stack_test.go
@@ -1,0 +1,168 @@
+package commands
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/openfaas/faas-cli/stack"
+)
+
+func Test_findTemplate(t *testing.T) {
+	tests := []struct {
+		title             string
+		desiredTemplate   string
+		existingTemplates []stack.TemplateSource
+		expectedTemplate  *stack.TemplateSource
+	}{
+		{
+			title:           "Desired template is found",
+			desiredTemplate: "powershell",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "powershell", Source: "exampleURL"},
+				{Name: "rust", Source: "exampleURL"},
+			},
+			expectedTemplate: &stack.TemplateSource{Name: "powershell", Source: "exampleURL"},
+		},
+		{
+			title:           "Desired template is not found",
+			desiredTemplate: "golang",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "powershell", Source: "exampleURL"},
+				{Name: "rust", Source: "exampleURL"},
+			},
+			expectedTemplate: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			result := findTemplate(test.existingTemplates, test.desiredTemplate)
+			if !reflect.DeepEqual(result, test.expectedTemplate) {
+				t.Errorf("Wanted template: `%s` got `%s`", test.expectedTemplate, result)
+			}
+		})
+	}
+}
+
+func Test_pullAllTemplates(t *testing.T) {
+	tests := []struct {
+		title             string
+		existingTemplates []stack.TemplateSource
+		expectedError     bool
+	}{
+		{
+			title: "Pull specific Template",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: false,
+		},
+		{
+			title: "Pull all templates",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: false,
+		},
+		{
+			title: "Pull custom template and template from store without source",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "perl-alpine"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: false,
+		},
+		{
+			title: "Pull non-existant template",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "invalidURL"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: true,
+		},
+		{
+			title: "Pull template with invalid URL",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "invalidURL"},
+			},
+			expectedError: true,
+		},
+		{
+			title: "Pull template which does not exist in store",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell"},
+			},
+			expectedError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			actualError := pullAllTemplates(test.existingTemplates, templatePullStackCmd)
+			if actualError != nil && test.expectedError == false {
+				t.Errorf("Unexpected error: %s", actualError.Error())
+			}
+		})
+	}
+}
+
+func Test_pullSpecificTemplate(t *testing.T) {
+	tests := []struct {
+		title             string
+		desiredTemplate   string
+		existingTemplates []stack.TemplateSource
+		expectedError     bool
+	}{
+		{
+			title:           "Pull custom named template",
+			desiredTemplate: "my_powershell",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: false,
+		},
+		{
+			title:           "Pull missing template",
+			desiredTemplate: "my_perl",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: true,
+		},
+		{
+			title:           "Pull custom template from store",
+			desiredTemplate: "perl-alpine",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "perl-alpine"},
+				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+			},
+			expectedError: false,
+		},
+		{
+			title:           "Pull specific template with invalid URL",
+			desiredTemplate: "my_powershell",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell", Source: "invalidURL"},
+			},
+			expectedError: true,
+		},
+		{
+			title:           "Pull template missing from store",
+			desiredTemplate: "my_powershell",
+			existingTemplates: []stack.TemplateSource{
+				{Name: "my_powershell"},
+			},
+			expectedError: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			actualError := pullSpecificTemplate(test.existingTemplates, test.desiredTemplate, templatePullStackCmd)
+			if actualError != nil && test.expectedError == false {
+				t.Errorf("Unexpected error: %s", actualError.Error())
+			}
+		})
+	}
+}

--- a/commands/template_pull_test.go
+++ b/commands/template_pull_test.go
@@ -60,7 +60,7 @@ func Test_templatePull(t *testing.T) {
 		faasCmd.SetArgs([]string{"template", "pull", localTemplateRepository, "--overwrite"})
 		err = faasCmd.Execute()
 		if err != nil {
-			fmt.Errorf("unexpected error while executing template pull with --overwrite: %s", err.Error())
+			t.Errorf("unexpected error while executing template pull with --overwrite: %s", err.Error())
 		}
 
 		str := buf.String()

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -61,6 +61,19 @@ type Function struct {
 	Namespace string `yaml:"namespace,omitempty"`
 }
 
+type Configuration struct {
+	StackConfig StackConfiguration `yaml:"configuration"`
+}
+
+type StackConfiguration struct {
+	TemplateConfigs []TemplateSource `yaml:"templates"`
+}
+
+type TemplateSource struct {
+	Name   string `yaml:"name"`
+	Source string `yaml:"source,omitempty"`
+}
+
 // FunctionResources Memory and CPU
 type FunctionResources struct {
 	Memory string `yaml:"memory"`


### PR DESCRIPTION
Adding template pull stack command which will pull template
from configuration field in the function yaml or from separate
yaml file with that same field

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adding `template pull stack` command to the cli to pull templates configured in yaml file in field looking the following way:
```
configuration:
  templates:
    - name: perl-alpine
    - name: rusta
      source: https://github.com/openfaas-incubator/openfaas-rust-template
```
The output is in the following format when `--repo` flag is not present:
```
Pulling template: perl-alpine from configuration file: stack.yml
Fetch templates from repository: https://github.com/tmiklas/openfaas-perl-templates at master
2019/10/21 23:21:36 Attempting to expand templates from https://github.com/tmiklas/openfaas-perl-templates
2019/10/21 23:21:37 Cannot overwrite the following 1 template(s): [perl-alpine]
2019/10/21 23:21:37 Fetched 0 template(s) : [] from https://github.com/tmiklas/openfaas-perl-templates
Pulling template: rusta from configuration file: stack.yml
Fetch templates from repository: https://github.com/openfaas-incubator/openfaas-rust-template at master
2019/10/21 23:21:37 Attempting to expand templates from https://github.com/openfaas-incubator/openfaas-rust-template
2019/10/21 23:21:39 Cannot overwrite the following 1 template(s): [rust]
2019/10/21 23:21:39 Fetched 0 template(s) : [] from https://github.com/openfaas-incubator/openfaas-rust-template
```
When `--repo` flag present it is just the chosen template, when missing, error is shown.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Closes #617 
The `configuration` field is purposely not added to `Services` struct. It can be part of the `stack.yml` or different YAML file at the moment. Read discussion in the issue for context.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manual testing, I mostly used already existing functionality which is unit tested.
Tested the pull command for regression manually.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
