### PR TITLE
Move to use faas-provider vs gateway for function structs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -93,15 +93,16 @@
   version = "0.8.8"
 
 [[projects]]
-  digest = "1:978f9a2199f9d63160619adf9cea50a8387c66269b81e299afe092bf51a0fd64"
+  digest = "1:9b722ccd1133047bfb2f75dd837021153a2daef66840e6869ae56362553241d5"
   name = "github.com/openfaas/faas-provider"
   packages = [
     "httputil",
     "logs",
+    "types",
   ]
   pruneopts = "UT"
-  revision = "0ca8ae603fee9736e011b81fbf02777d89a4ea85"
-  version = "0.9.2"
+  revision = "45a3391b385208bd34690f84abcc1dfab6c1730b"
+  version = "0.9.4"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"
@@ -171,6 +172,7 @@
     "github.com/mitchellh/go-homedir",
     "github.com/morikuni/aec",
     "github.com/openfaas/faas-provider/logs",
+    "github.com/openfaas/faas-provider/types",
     "github.com/openfaas/faas/gateway/requests",
     "github.com/pkg/errors",
     "github.com/ryanuber/go-glob",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -85,12 +85,12 @@
   revision = "39771216ff4c63d11f5e604076f9c45e8be1067b"
 
 [[projects]]
-  digest = "1:cd4844d2c87206efa7faa9ea920f936e4f16512ac3fa342e7534dfb6d804a63b"
+  digest = "1:0250441ac9f681c839722297897952ee6d633f2a37dc254eca9d6d21bd1e877d"
   name = "github.com/openfaas/faas"
   packages = ["gateway/requests"]
   pruneopts = "UT"
-  revision = "4cbb7d968d21f4ae2daacfb27213c9371d4d4449"
-  version = "0.8.8"
+  revision = "df97efafae36ce7093ad353e3e6acc0e93d6300e"
+  version = "0.16.0"
 
 [[projects]]
   digest = "1:9b722ccd1133047bfb2f75dd837021153a2daef66840e6869ae56362553241d5"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas"
-  version = "0.8.8"
+  version = "0.16.0"
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,6 +15,10 @@
   version = "0.8.8"
 
 [[constraint]]
+  name = "github.com/openfaas/faas-provider"
+  version = "0.9.4"
+
+[[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"
 

--- a/commands/list_test.go
+++ b/commands/list_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 
 	"github.com/openfaas/faas-cli/test"
-	"github.com/openfaas/faas/gateway/requests"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 func Test_list(t *testing.T) {
-	expectedListResponse := []requests.Function{
+	expectedListResponse := []types.FunctionStatus{
 		{
 			Name:            "function-test-1",
 			Image:           "image-test-1",

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -13,7 +13,8 @@ import (
 	"time"
 
 	"github.com/openfaas/faas-cli/stack"
-	"github.com/openfaas/faas/gateway/requests"
+
+	types "github.com/openfaas/faas-provider/types"
 )
 
 var (
@@ -85,7 +86,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 		DeleteFunction(gateway, spec.FunctionName, spec.TLSInsecure)
 	}
 
-	req := requests.CreateFunctionRequest{
+	req := types.FunctionDeployment{
 		EnvProcess:             fprocessTemplate,
 		Image:                  spec.Image,
 		RegistryAuth:           spec.RegistryAuth,
@@ -100,7 +101,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 	}
 
 	hasLimits := false
-	req.Limits = &requests.FunctionResources{}
+	req.Limits = &types.FunctionResources{}
 	if spec.FunctionResourceRequest.Limits != nil && len(spec.FunctionResourceRequest.Limits.Memory) > 0 {
 		hasLimits = true
 		req.Limits.Memory = spec.FunctionResourceRequest.Limits.Memory
@@ -114,7 +115,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 	}
 
 	hasRequests := false
-	req.Requests = &requests.FunctionResources{}
+	req.Requests = &types.FunctionResources{}
 	if spec.FunctionResourceRequest.Requests != nil && len(spec.FunctionResourceRequest.Requests.Memory) > 0 {
 		hasRequests = true
 		req.Requests.Memory = spec.FunctionResourceRequest.Requests.Memory

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -11,17 +11,17 @@ import (
 	"net/url"
 	"path"
 
-	"github.com/openfaas/faas/gateway/requests"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 //GetFunctionInfo get an OpenFaaS function information
-func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (requests.Function, error) {
+func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (types.FunctionStatus, error) {
 	return GetFunctionInfoToken(gateway, functionName, tlsInsecure, "")
 }
 
 //GetFunctionInfoToken get a function information with a token as auth
-func GetFunctionInfoToken(gateway string, functionName string, tlsInsecure bool, token string) (requests.Function, error) {
-	var result requests.Function
+func GetFunctionInfoToken(gateway string, functionName string, tlsInsecure bool, token string) (types.FunctionStatus, error) {
+	var result types.FunctionStatus
 
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 

--- a/proxy/describe_test.go
+++ b/proxy/describe_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/openfaas/faas-cli/test"
-	"github.com/openfaas/faas/gateway/requests"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 func Test_GetFunctionInfo(t *testing.T) {
@@ -76,7 +76,7 @@ func Test_GetFunctionInfo_NotFound(t *testing.T) {
 
 }
 
-var expectedGetFunctionInfoResponse = requests.Function{
+var expectedGetFunctionInfoResponse = types.FunctionStatus{
 	Name:            "func-test1",
 	Image:           "image-test1",
 	Replicas:        1,

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -11,17 +11,17 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/openfaas/faas/gateway/requests"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 // ListFunctions list deployed functions
-func ListFunctions(gateway string, tlsInsecure bool) ([]requests.Function, error) {
+func ListFunctions(gateway string, tlsInsecure bool) ([]types.FunctionStatus, error) {
 	return ListFunctionsToken(gateway, tlsInsecure, "")
 }
 
 // ListFunctionsToken list deployed functions with a token as auth
-func ListFunctionsToken(gateway string, tlsInsecure bool, token string) ([]requests.Function, error) {
-	var results []requests.Function
+func ListFunctionsToken(gateway string, tlsInsecure bool, token string) ([]types.FunctionStatus, error) {
+	var results []types.FunctionStatus
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/openfaas/faas-cli/test"
-	"github.com/openfaas/faas/gateway/requests"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 func Test_ListFunctions(t *testing.T) {
@@ -64,7 +64,7 @@ func Test_ListFunctions_MissingURLPrefix(t *testing.T) {
 	}
 }
 
-var expectedListFunctionsResponse = []requests.Function{
+var expectedListFunctionsResponse = []types.FunctionStatus{
 	{
 		Name:            "func-test1",
 		Image:           "image-test1",

--- a/vendor/github.com/openfaas/faas-provider/types/config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/config.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"net/http"
+	"time"
+)
+
+// FaaSHandlers provide handlers for OpenFaaS
+type FaaSHandlers struct {
+	FunctionReader http.HandlerFunc
+	DeployHandler  http.HandlerFunc
+	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
+	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.
+	FunctionProxy  http.HandlerFunc
+	DeleteHandler  http.HandlerFunc
+	ReplicaReader  http.HandlerFunc
+	ReplicaUpdater http.HandlerFunc
+	SecretHandler  http.HandlerFunc
+	// LogHandler provides streaming json logs of functions
+	LogHandler http.HandlerFunc
+
+	// Optional: Update an existing function
+	UpdateHandler http.HandlerFunc
+	HealthHandler http.HandlerFunc
+	InfoHandler   http.HandlerFunc
+}
+
+// FaaSConfig set config for HTTP handlers
+type FaaSConfig struct {
+	TCPPort         *int
+	ReadTimeout     time.Duration
+	WriteTimeout    time.Duration
+	EnableHealth    bool
+	EnableBasicAuth bool
+	SecretMountPath string
+}

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -1,0 +1,85 @@
+package types
+
+// FunctionDeployment represents a request to create or update a Function.
+type FunctionDeployment struct {
+
+	// Service corresponds to a Service
+	Service string `json:"service"`
+
+	// Image corresponds to a Docker image
+	Image string `json:"image"`
+
+	// Network is specific to Docker Swarm - default overlay network is: func_functions
+	Network string `json:"network"`
+
+	// EnvProcess corresponds to the fprocess variable for your container watchdog.
+	EnvProcess string `json:"envProcess"`
+
+	// EnvVars provides overrides for functions.
+	EnvVars map[string]string `json:"envVars"`
+
+	// RegistryAuth is the registry authentication (optional)
+	// in the same encoded format as Docker native credentials
+	// (see ~/.docker/config.json)
+	RegistryAuth string `json:"registryAuth,omitempty"`
+
+	// Constraints are specific to back-end orchestration platform
+	Constraints []string `json:"constraints"`
+
+	// Secrets list of secrets to be made available to function
+	Secrets []string `json:"secrets"`
+
+	// Labels are metadata for functions which may be used by the
+	// back-end for making scheduling or routing decisions
+	Labels *map[string]string `json:"labels"`
+
+	// Annotations are metadata for functions which may be used by the
+	// back-end for management, orchestration, events and build tasks
+	Annotations *map[string]string `json:"annotations"`
+
+	// Limits for function
+	Limits *FunctionResources `json:"limits"`
+
+	// Requests of resources requested by function
+	Requests *FunctionResources `json:"requests"`
+
+	// ReadOnlyRootFilesystem removes write-access from the root filesystem
+	// mount-point.
+	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
+}
+
+// FunctionResources Memory and CPU
+type FunctionResources struct {
+	Memory string `json:"memory"`
+	CPU    string `json:"cpu"`
+}
+
+// FunctionStatus exported for system/functions endpoint
+type FunctionStatus struct {
+
+	// Name corresponds to a Service
+	Name string `json:"name"`
+
+	// Image corresponds to a Docker image
+	Image string `json:"image"`
+
+	// InvocationCount count of invocations
+	InvocationCount float64 `json:"invocationCount"`
+
+	// Replicas desired within the cluster
+	Replicas uint64 `json:"replicas"`
+
+	// EnvProcess is the process to pass to the watchdog, if in use
+	EnvProcess string `json:"envProcess"`
+
+	// AvailableReplicas is the count of replicas ready to receive invocations as reported by the backend
+	AvailableReplicas uint64 `json:"availableReplicas"`
+
+	// Labels are metadata for functions which may be used by the
+	// backend for making scheduling or routing decisions
+	Labels *map[string]string `json:"labels"`
+
+	// Annotations are metadata for functions which may be used by the
+	// backend for management, orchestration, events and build tasks
+	Annotations *map[string]string `json:"annotations"`
+}

--- a/vendor/github.com/openfaas/faas-provider/types/requests.go
+++ b/vendor/github.com/openfaas/faas-provider/types/requests.go
@@ -1,0 +1,22 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+type ScaleServiceRequest struct {
+	ServiceName string `json:"serviceName"`
+	Replicas    uint64 `json:"replicas"`
+}
+
+// InfoRequest provides information about the underlying provider
+type InfoRequest struct {
+	Provider      string          `json:"provider"`
+	Version       ProviderVersion `json:"version"`
+	Orchestration string          `json:"orchestration"`
+}
+
+// ProviderVersion provides the commit sha and release version number of the underlying provider
+type ProviderVersion struct {
+	SHA     string `json:"sha"`
+	Release string `json:"release"`
+}

--- a/vendor/github.com/openfaas/faas/LICENSE
+++ b/vendor/github.com/openfaas/faas/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016-2017 Alex Ellis
+Copyright (c) 2016-2018 Alex Ellis
+Copyright (c) 2018 OpenFaaS Author(s)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/github.com/openfaas/faas/gateway/requests/requests.go
+++ b/vendor/github.com/openfaas/faas/gateway/requests/requests.go
@@ -1,81 +1,9 @@
 // Copyright (c) Alex Ellis 2017. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Package requests package provides a client SDK or library for
+// the OpenFaaS gateway REST API
 package requests
-
-// CreateFunctionRequest create a function in the swarm.
-type CreateFunctionRequest struct {
-
-	// Service corresponds to a Docker Service
-	Service string `json:"service"`
-
-	// Image corresponds to a Docker image
-	Image string `json:"image"`
-
-	// Network is specific to Docker Swarm - default overlay network is: func_functions
-	Network string `json:"network"`
-
-	// EnvProcess corresponds to the fprocess variable for your container watchdog.
-	EnvProcess string `json:"envProcess"`
-
-	// EnvVars provides overrides for functions.
-	EnvVars map[string]string `json:"envVars"`
-
-	// RegistryAuth is the registry authentication (optional)
-	// in the same encoded format as Docker native credentials
-	// (see ~/.docker/config.json)
-	RegistryAuth string `json:"registryAuth,omitempty"`
-
-	// Constraints are specific to back-end orchestration platform
-	Constraints []string `json:"constraints"`
-
-	// Secrets list of secrets to be made available to function
-	Secrets []string `json:"secrets"`
-
-	// Labels are metadata for functions which may be used by the
-	// back-end for making scheduling or routing decisions
-	Labels *map[string]string `json:"labels"`
-
-	// Annotations are metadata for functions which may be used by the
-	// back-end for management, orchestration, events and build tasks
-	Annotations *map[string]string `json:"annotations"`
-
-	// Limits for function
-	Limits *FunctionResources `json:"limits"`
-
-	// Requests of resources requested by function
-	Requests *FunctionResources `json:"requests"`
-
-	// ReadOnlyRootFilesystem removes write-access from the root filesystem
-	// mount-point.
-	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
-}
-
-// FunctionResources Memory and CPU
-type FunctionResources struct {
-	Memory string `json:"memory"`
-	CPU    string `json:"cpu"`
-}
-
-// Function exported for system/functions endpoint
-type Function struct {
-	Name            string  `json:"name"`
-	Image           string  `json:"image"`
-	InvocationCount float64 `json:"invocationCount"` // TODO: shouldn't this be int64?
-	Replicas        uint64  `json:"replicas"`
-	EnvProcess      string  `json:"envProcess"`
-
-	// AvailableReplicas is the count of replicas ready to receive invocations as reported by the back-end
-	AvailableReplicas uint64 `json:"availableReplicas"`
-
-	// Labels are metadata for functions which may be used by the
-	// back-end for making scheduling or routing decisions
-	Labels *map[string]string `json:"labels"`
-
-	// Annotations are metadata for functions which may be used by the
-	// back-end for management, orchestration, events and build tasks
-	Annotations *map[string]string `json:"annotations"`
-}
 
 // AsyncReport is the report from a function executed on a queue worker.
 type AsyncReport struct {
@@ -87,4 +15,10 @@ type AsyncReport struct {
 // DeleteFunctionRequest delete a deployed function
 type DeleteFunctionRequest struct {
 	FunctionName string `json:"functionName"`
+}
+
+// Secret for underlying orchestrator
+type Secret struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Move to use faas-provider vs gateway for function structs

## Motivation and Context

This patch moves the CLI away from using the gateway function
structs from the requests package and over to the faas-provider.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with e2e testing and build_redist.sh

## Types of changes

Refactoring.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.