### PR TITLE
Add flags to control the log output format

### DIFF
--- a/commands/logs_format.go
+++ b/commands/logs_format.go
@@ -1,0 +1,89 @@
+package commands
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/openfaas/faas-cli/flags"
+	"github.com/openfaas/faas-provider/logs"
+)
+
+// LogFormatter is a function that converts a log message to a string based on the supplied options
+type LogFormatter func(msg logs.Message, timeFormat string, includeName, includeInstance bool) string
+
+// GetLogFormatter maps a formatter name to a LogFormatter method
+func GetLogFormatter(name string) LogFormatter {
+	switch name {
+	case string(flags.JSONLogFormat):
+		return JSONFormatMessage
+	case string(flags.KeyValueLogFormat):
+		return KeyValueFormatMessage
+	default:
+		return PlainFormatMessage
+	}
+}
+
+// JSONFormatMessage is a JSON formatting for log messages, the options are ignored and the entire log
+// message json serialized
+func JSONFormatMessage(msg logs.Message, timeFormat string, includeName, includeInstance bool) string {
+	// error really can't happen here because of how simple the msg object is
+	b, _ := json.Marshal(msg)
+	return string(b)
+}
+
+// KeyValueFormatMessage returns the message in the format "timestamp=<> name=<> instance=<> message=<>"
+func KeyValueFormatMessage(msg logs.Message, timeFormat string, includeName, includeInstance bool) string {
+	var b strings.Builder
+
+	// note that WriteString's error is always nil and safe to ignore here
+	if timeFormat != "" {
+		b.WriteString("timestamp=\"")
+		b.WriteString(msg.Timestamp.Format(timeFormat))
+		b.WriteString("\" ")
+	}
+
+	if includeName {
+		b.WriteString("name=\"")
+		b.WriteString(msg.Name)
+		b.WriteString("\" ")
+	}
+
+	if includeInstance {
+		b.WriteString("instance=\"")
+		b.WriteString(msg.Instance)
+		b.WriteString("\" ")
+	}
+
+	b.WriteString("text=\"")
+	b.WriteString(strings.TrimRight(msg.Text, "\n"))
+	b.WriteString("\" ")
+
+	return b.String()
+}
+
+// PlainFormatMessage formats a log message as "<timestamp> <name> (<instance>) <text>"
+func PlainFormatMessage(msg logs.Message, timeFormat string, includeName, includeInstance bool) string {
+	var b strings.Builder
+
+	// note that WriteString's error is always nil and safe to ignore here
+	if timeFormat != "" {
+		b.WriteString(msg.Timestamp.Format(timeFormat))
+		b.WriteString(" ")
+	}
+
+	if includeName {
+		b.WriteString(msg.Name)
+		b.WriteString(" ")
+	}
+
+	if includeInstance {
+		b.WriteString("(")
+		b.WriteString(msg.Instance)
+		b.WriteString(")")
+		b.WriteString(" ")
+	}
+
+	b.WriteString(msg.Text)
+
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/commands/logs_format_test.go
+++ b/commands/logs_format_test.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openfaas/faas-provider/logs"
+)
+
+func Test_JSONLogFormatter(t *testing.T) {
+	now := time.Now()
+	msg := logs.Message{
+		Timestamp: now,
+		Name:      "test-func",
+		Instance:  "123test",
+		Text:      "test message\n",
+	}
+	msgJSON, _ := json.Marshal(msg)
+
+	cases := []struct {
+		name            string
+		timeFormat      string
+		includeName     bool
+		includeInstance bool
+		expected        string
+	}{
+		{"default behavior", "rfc3339", true, true, string(msgJSON)},
+		{"default behavior with all empty options", "", false, false, string(msgJSON)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := JSONFormatMessage(msg, tc.timeFormat, tc.includeName, tc.includeInstance)
+			if formatted != tc.expected {
+				t.Fatalf("incorrect message format:\n got %s\n expected %s\n", formatted, tc.expected)
+			}
+		})
+	}
+}
+
+func Test_PlainLogFormatter(t *testing.T) {
+	ts := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	msg := logs.Message{
+		Timestamp: ts,
+		Name:      "test-func",
+		Instance:  "123test",
+		Text:      "test message\n",
+	}
+
+	cases := []struct {
+		name            string
+		timeFormat      string
+		includeName     bool
+		includeInstance bool
+		expected        string
+	}{
+		{"default settings", time.RFC3339, true, true, "2009-11-10T23:00:00Z test-func (123test) test message"},
+		{"default can modify timestamp", "2006-01-02 15:04:05.999999999 -0700 MST", true, true, msg.String()},
+		{"can hide name", time.RFC3339, false, true, "2009-11-10T23:00:00Z (123test) test message"},
+		{"can hide instance", time.RFC3339, true, false, "2009-11-10T23:00:00Z test-func test message"},
+		{"can hide all metadata", "", false, false, "test message"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := PlainFormatMessage(msg, tc.timeFormat, tc.includeName, tc.includeInstance)
+			if strings.TrimSpace(formatted) != strings.TrimSpace(tc.expected) {
+				t.Fatalf("incorrect message format:\n got %s\n expected %s\n", formatted, tc.expected)
+			}
+		})
+	}
+}
+
+func Test_KeyValueLogFormatter(t *testing.T) {
+	ts := time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+	msg := logs.Message{
+		Timestamp: ts,
+		Name:      "test-func",
+		Instance:  "123test",
+		Text:      "test message\n",
+	}
+
+	cases := []struct {
+		name            string
+		timeFormat      string
+		includeName     bool
+		includeInstance bool
+		expected        string
+	}{
+		{"default settings", time.RFC3339, true, true, "timestamp=\"2009-11-10T23:00:00Z\" name=\"test-func\" instance=\"123test\" text=\"test message\""},
+		{"default settings", "2006-01-02 15:04:05.999999999 -0700 MST", true, true, "timestamp=\"2009-11-10 23:00:00 +0000 UTC\" name=\"test-func\" instance=\"123test\" text=\"test message\""},
+		{"can hide name", time.RFC3339, false, true, "timestamp=\"2009-11-10T23:00:00Z\" instance=\"123test\" text=\"test message\""},
+		{"can hide instance", time.RFC3339, true, false, "timestamp=\"2009-11-10T23:00:00Z\" name=\"test-func\" text=\"test message\""},
+		{"can hide all metadata", "", false, false, "text=\"test message\""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			formatted := KeyValueFormatMessage(msg, tc.timeFormat, tc.includeName, tc.includeInstance)
+			if strings.TrimSpace(formatted) != strings.TrimSpace(tc.expected) {
+				t.Fatalf("incorrect message format:\n got %s\n expected %s\n", formatted, tc.expected)
+			}
+		})
+	}
+}

--- a/flags/log_format.go
+++ b/flags/log_format.go
@@ -1,0 +1,37 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LogFormat determines the output format of the log stream
+type LogFormat string
+
+const PlainLogFormat LogFormat = "plain"
+const KeyValueLogFormat LogFormat = "keyvalue"
+const JSONLogFormat LogFormat = "json"
+
+// Type implements pflag.Value
+func (l *LogFormat) Type() string {
+	return "logformat"
+}
+
+// String implements Stringer
+func (l *LogFormat) String() string {
+	if l == nil {
+		return ""
+	}
+	return string(*l)
+}
+
+// Set implements pflag.Value
+func (l *LogFormat) Set(value string) error {
+	switch strings.ToLower(value) {
+	case "plain", "keyvalue", "json":
+		*l = LogFormat(value)
+	default:
+		return fmt.Errorf("unknown log format: '%s'", value)
+	}
+	return nil
+}

--- a/flags/log_format_test.go
+++ b/flags/log_format_test.go
@@ -1,0 +1,33 @@
+package flags
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestLogFormat(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		err   error
+	}{
+		{"can accept plain", "plain", nil},
+		{"can accept keyvalue", "keyvalue", nil},
+		{"can accept json", "json", nil},
+		{"unknown strings cause error string", "nonsense", errors.New("unknown log format: 'nonsense'")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f LogFormat
+			err := f.Set(tc.value)
+			if tc.err != nil && tc.err.Error() != err.Error() {
+				t.Fatalf("expected error %s, got %s", tc.err, err)
+			}
+			if tc.err == nil && f.String() != tc.value {
+				t.Errorf("expected format %s, got %s", tc.value, f.String())
+			}
+		})
+	}
+
+}

--- a/flags/time_format.go
+++ b/flags/time_format.go
@@ -1,0 +1,64 @@
+package flags
+
+import (
+	"strings"
+	"time"
+)
+
+// TimeFormat is a timestamp format string that also accepts the following RFC names as shortcuts
+//
+//  ANSIC       = "Mon Jan _2 15:04:05 2006"
+// 	UnixDate    = "Mon Jan _2 15:04:05 MST 2006"
+// 	RubyDate    = "Mon Jan 02 15:04:05 -0700 2006"
+// 	RFC822      = "02 Jan 06 15:04 MST"
+// 	RFC822Z     = "02 Jan 06 15:04 -0700" // RFC822 with numeric zone
+// 	RFC850      = "Monday, 02-Jan-06 15:04:05 MST"
+// 	RFC1123     = "Mon, 02 Jan 2006 15:04:05 MST"
+// 	RFC1123Z    = "Mon, 02 Jan 2006 15:04:05 -0700" // RFC1123 with numeric zone
+// 	RFC3339     = "2006-01-02T15:04:05Z07:00"
+// 	RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
+//
+// Any string is accepted
+type TimeFormat string
+
+// Type implements pflag.Value
+func (l *TimeFormat) Type() string {
+	return "timeformat"
+}
+
+// String implements Stringer
+func (l *TimeFormat) String() string {
+	if l == nil {
+		return ""
+	}
+	return string(*l)
+}
+
+// Set implements pflag.Value
+func (l *TimeFormat) Set(value string) error {
+	switch strings.ToLower(value) {
+	case "ansic":
+		*l = TimeFormat(time.ANSIC)
+	case "unixdate":
+		*l = TimeFormat(time.UnixDate)
+	case "rubydate":
+		*l = TimeFormat(time.RubyDate)
+	case "rfc822":
+		*l = TimeFormat(time.RFC822)
+	case "rfc822z":
+		*l = TimeFormat(time.RFC822Z)
+	case "rfc850":
+		*l = TimeFormat(time.RFC850)
+	case "rfc1123":
+		*l = TimeFormat(time.RFC1123)
+	case "rfc1123z":
+		*l = TimeFormat(time.RFC1123Z)
+	case "rfc3339":
+		*l = TimeFormat(time.RFC3339)
+	case "rfc3339nano":
+		*l = TimeFormat(time.RFC3339Nano)
+	default:
+		*l = TimeFormat(value)
+	}
+	return nil
+}

--- a/flags/time_format_test.go
+++ b/flags/time_format_test.go
@@ -1,0 +1,32 @@
+package flags
+
+import (
+	"testing"
+)
+
+func TestTimeFormat(t *testing.T) {
+
+	cases := []struct {
+		name     string
+		value    string
+		expected string
+	}{
+		{"can parse short name rfc850", "rfc850", "Monday, 02-Jan-06 15:04:05 MST"},
+		{"can accept an arbitrary format string", "2006-01-02 15:04:05.999999999 -0700 MST", "2006-01-02 15:04:05.999999999 -0700 MST"},
+		{"can accept arbitrary string", "nonsense", "nonsense"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var f TimeFormat
+			err := f.Set(tc.value)
+			if err != nil {
+				t.Fatalf("should not be able to error")
+			}
+			if f.String() != tc.expected {
+				t.Errorf("expected time %s, got %s", tc.expected, f.String())
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add new flags to toggle the name, instance, and timestamp fields.
Additionally, the new `time-format` also allows controlling the actual
timestamp format.
- Also provide the log format flag to allow printing the output as JSON,
key-values, or the plain format.  This should make it easy to integrate
with other tools, like JQ etc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #671 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Additional unit tests are provided for the formatters. Additionally, this has been tested in the faas-netes test environment
```sh
# in faas-netes project
$ make start-kind

# in faas-cli repo
$ make local-install

$ echo "test" | faas-cli --gateway=http://localhost:31112 invoke echo
test
$ echo "test" | faas-cli --gateway=http://localhost:31112 invoke echo
test
$ echo "test" | faas-cli --gateway=http://localhost:31112 invoke echo
test

$ faas-cli --gateway=http://localhost:31112 logs echo --time-format='' --name=true --format=plain
echo (echo-5cf679b455-8p8kv) 2019/08/10 17:55:32 Forking fprocess.
echo (echo-5cf679b455-8p8kv) 2019/08/10 17:55:32 Wrote 5 Bytes - Duration: 0.001326 seconds
echo (echo-5cf679b455-8p8kv) 2019/08/10 17:55:33 Forking fprocess.
echo (echo-5cf679b455-8p8kv) 2019/08/10 17:55:33 Wrote 5 Bytes - Duration: 0.001975 seconds
echo (echo-5cf679b455-8p8kv) 2019/08/10 17:55:33 Forking fprocess.
echo (echo-5cf679b455-8p8kv) 2019/08/10 17:55:33 Wrote 5 Bytes - Duration: 0.001551 seconds

$ faas-cli --gateway=http://localhost:31112 logs echo --time-format='' --name=true --format=json
{"name":"echo","instance":"echo-5cf679b455-8p8kv","timestamp":"2019-08-10T17:55:32.2775529Z","text":"2019/08/10 17:55:32 Forking fprocess.\n"}
{"name":"echo","instance":"echo-5cf679b455-8p8kv","timestamp":"2019-08-10T17:55:32.2788885Z","text":"2019/08/10 17:55:32 Wrote 5 Bytes - Duration: 0.001326 seconds\n"}
{"name":"echo","instance":"echo-5cf679b455-8p8kv","timestamp":"2019-08-10T17:55:33.2454843Z","text":"2019/08/10 17:55:33 Forking fprocess.\n"}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
