### PR TITLE
Respect env var for template url for `new` and `build`

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -149,7 +149,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if pullErr := PullTemplates(DefaultTemplateRepository); pullErr != nil {
+	templateAddress := getTemplateURL("", os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
+	if pullErr := PullTemplates(templateAddress); pullErr != nil {
 		return fmt.Errorf("could not pull templates for OpenFaaS: %v", pullErr)
 	}
 

--- a/commands/build_test.go
+++ b/commands/build_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func Test_build(t *testing.T) {
+	templatePullLocalTemplateRepo(t)
+	defer tearDownFetchTemplates(t)
 
 	aTests := [][]string{
 		{"build"},

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -115,7 +115,8 @@ Download templates:
 		return nil
 	}
 
-	PullTemplates(DefaultTemplateRepository)
+	templateAddress := getTemplateURL("", os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
+	PullTemplates(templateAddress)
 
 	if !stack.IsValidTemplate(language) {
 		return fmt.Errorf("%s is unavailable or not supported", language)

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -341,6 +341,31 @@ func Test_duplicateFunctionName(t *testing.T) {
 	}
 }
 
+func Test_backfillTemplates(t *testing.T) {
+	resetForTest()
+	const functionName = "samplefunc"
+	const functionLang = "ruby"
+
+	// Delete cached templates
+	localTemplateRepository := setupLocalTemplateRepo(t)
+	defer os.RemoveAll(localTemplateRepository)
+	defer tearDownNewFunction(t, functionName)
+
+	os.Setenv(templateURLEnvironment, localTemplateRepository)
+	defer os.Unsetenv(templateURLEnvironment)
+
+	parameters := []string{
+		"new",
+		functionName,
+		"--lang=" + functionLang,
+	}
+	faasCmd.SetArgs(parameters)
+	err := faasCmd.Execute()
+	if err != nil {
+		t.Fatalf("Failed to create function with custom template dir: %s\n", err.Error())
+	}
+}
+
 func tearDownNewFunction(t *testing.T, functionName string) {
 	if _, err := os.Stat(".gitignore"); err == nil {
 		if err := os.Remove(".gitignore"); err != nil {


### PR DESCRIPTION
## Description
Adds priority checking for the environment variable override for the remote url to pull templates from.  This was already being respected in `template pull` but was being ignored when opportunistically pulling templates during `build` and `new`.

## Motivation and Context
Addresses issue #685 which properly points out that these commands were ignoring the environment variable.

## How Has This Been Tested?
Starting with an empty directory:
```bash
$ ./faas-cli new --lang=go test-fn
2019/09/05 11:54:48 No templates found in current directory.
2019/09/05 11:54:48 Attempting to expand templates from https://github.com/openfaas/templates.git
2019/09/05 11:54:48 Fetched 17 template(s) : [csharp csharp-armhf dockerfile dockerfile-armhf go go-armhf java12 java8 node node-arm64 node-armhf php7 python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates.git
Folder: test-fn created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: test-fn
Stack file written: test-fn.yml

Notes:
You have created a new function which uses Golang 1.10.10
To include third-party dependencies, use a vendoring tool like dep:
dep documentation: https://github.com/golang/dep#installation 
```

Then with the env var set:
```
$ OPENFAAS_TEMPLATE_URL=https://github.com/openfaas-incubator/golang-http-template ./faas-cli new --lang=golang-http test-fn
2019/09/05 11:56:59 No templates found in current directory.
2019/09/05 11:56:59 Attempting to expand templates from https://github.com/openfaas-incubator/golang-http-template
2019/09/05 11:57:00 Fetched 4 template(s) : [golang-http golang-http-armhf golang-middleware golang-middleware-armhf] from https://github.com/openfaas-incubator/golang-http-template
Folder: test-fn created.
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|


Function created in folder: test-fn
Stack file written: test-fn.yml
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
