### PR TITLE
Add support for namespaces

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -93,7 +93,7 @@
   version = "0.16.0"
 
 [[projects]]
-  digest = "1:9b722ccd1133047bfb2f75dd837021153a2daef66840e6869ae56362553241d5"
+  digest = "1:30dd53fb3e50077a707e4fb79a909251b5829e19fee4fe6c6a1273f2d19ecc27"
   name = "github.com/openfaas/faas-provider"
   packages = [
     "httputil",
@@ -101,8 +101,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "45a3391b385208bd34690f84abcc1dfab6c1730b"
-  version = "0.9.4"
+  revision = "eafd85a3b360d8e0982c3a1db43e6d5fee9b85e2"
+  version = "0.10.2"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"
-  version = "0.9.4"
+  version = "0.10.2"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -53,6 +53,7 @@ func init() {
 	deployCmd.Flags().StringVar(&language, "lang", "", "Programming language template")
 	deployCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
 	deployCmd.Flags().StringVar(&network, "network", defaultNetwork, "Name of the network")
+	deployCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 
 	// Setup flags that are used only by this command (variables defined above)
 	deployCmd.Flags().StringArrayVarP(&deployFlags.envvarOpts, "env", "e", []string{}, "Set one or more environment variables (ENVVAR=VALUE)")
@@ -284,6 +285,7 @@ Error: %s`, fprocessErr.Error())
 				ReadOnlyRootFilesystem:  function.ReadOnlyRootFilesystem,
 				TLSInsecure:             tlsInsecure,
 				Token:                   token,
+				Namespace:               function.Namespace,
 			}
 
 			if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {
@@ -315,7 +317,8 @@ Error: %s`, fprocessErr.Error())
 		// default to a readable filesystem until we get more input about the expected behavior
 		// and if we want to add another flag for this case
 		defaultReadOnlyRFS := false
-		statusCode, err := deployImage(image, fprocess, functionName, registryAuth, deployFlags, tlsInsecure, defaultReadOnlyRFS, token)
+		statusCode, err := deployImage(image, fprocess, functionName, registryAuth, deployFlags,
+			tlsInsecure, defaultReadOnlyRFS, token, functionNamespace)
 		if err != nil {
 			return err
 		}
@@ -342,6 +345,7 @@ func deployImage(
 	tlsInsecure bool,
 	readOnlyRootFilesystem bool,
 	token string,
+	namespace string,
 ) (int, error) {
 
 	var statusCode int
@@ -383,6 +387,7 @@ func deployImage(
 		ReadOnlyRootFilesystem:  readOnlyRFS,
 		TLSInsecure:             tlsInsecure,
 		Token:                   token,
+		Namespace:               namespace,
 	}
 
 	if msg := checkTLSInsecure(deploySpec.Gateway, deploySpec.TLSInsecure); len(msg) > 0 {

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -23,6 +23,7 @@ func init() {
 	describeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	describeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
 	describeCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	describeCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 
 	faasCmd.AddCommand(describeCmd)
 }
@@ -63,13 +64,13 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	}
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	function, err := proxy.GetFunctionInfoToken(gatewayAddress, functionName, tlsInsecure, token)
+	function, err := proxy.GetFunctionInfoToken(gatewayAddress, functionName, tlsInsecure, token, functionNamespace)
 	if err != nil {
 		return err
 	}
 
 	//To get correct value for invocation count from /system/functions endpoint
-	functionList, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token)
+	functionList, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token, functionNamespace)
 	if err != nil {
 		return err
 	}

--- a/commands/list.go
+++ b/commands/list.go
@@ -20,7 +20,7 @@ var (
 func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
 	listCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
-
+	listCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace of the function")
 	listCmd.Flags().BoolVarP(&verboseList, "verbose", "v", false, "Verbose output for the function list")
 	listCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	listCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
@@ -56,8 +56,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
-
-	functions, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token)
+	functions, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token, namespace)
 	if err != nil {
 		return err
 	}

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -18,6 +18,7 @@ func init() {
 	removeCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	removeCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
 	removeCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	removeCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 
 	faasCmd.AddCommand(removeCmd)
 }
@@ -44,6 +45,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	var services stack.Services
 	var gatewayAddress string
 	var yamlGateway string
+
 	if len(yamlFile) > 0 {
 		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter, envsubst)
 		if err != nil {
@@ -67,7 +69,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			function.Name = k
 			fmt.Printf("Deleting: %s.\n", function.Name)
 
-			proxy.DeleteFunctionToken(gatewayAddress, function.Name, tlsInsecure, token)
+			proxy.DeleteFunctionToken(gatewayAddress, function.Name, tlsInsecure, token, functionNamespace)
 		}
 	} else {
 		if len(args) < 1 {
@@ -76,7 +78,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
-		proxy.DeleteFunctionToken(gatewayAddress, functionName, tlsInsecure, token)
+		proxy.DeleteFunctionToken(gatewayAddress, functionName, tlsInsecure, token, functionNamespace)
 	}
 
 	return nil

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -17,6 +17,7 @@ func init() {
 	storeDeployCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	storeDeployCmd.Flags().StringVar(&network, "network", "", "Name of the network")
 	storeDeployCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function (overriding name from the store)")
+	storeDeployCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 	// Setup flags that are used only by deploy command (variables defined above)
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.envvarOpts, "env", "e", []string{}, "Adds one or more environment variables to the defined ones by store (ENVVAR=VALUE)")
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.labelOpts, "label", "l", []string{}, "Set one or more label (LABEL=VALUE)")
@@ -123,7 +124,8 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
-	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags, tlsInsecure, item.ReadOnlyRootFilesystem, token)
+	statusCode, err := deployImage(item.Image, item.Fprocess, itemName, registryAuth, storeDeployFlags,
+		tlsInsecure, item.ReadOnlyRootFilesystem, token, functionNamespace)
 
 	if badStatusCode(statusCode) {
 		failedStatusCode := map[string]int{itemName: statusCode}

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -15,19 +15,25 @@ import (
 )
 
 // DeleteFunction delete a function from the OpenFaaS server
-func DeleteFunction(gateway string, functionName string, tlsInsecure bool) error {
-	return DeleteFunctionToken(gateway, functionName, tlsInsecure, "")
+func DeleteFunction(gateway string, functionName string, tlsInsecure bool, namespace string) error {
+	return DeleteFunctionToken(gateway, functionName, tlsInsecure, "", namespace)
 }
 
 //DeleteFunctionToken delete a function with token as auth
-func DeleteFunctionToken(gateway string, functionName string, tlsInsecure bool, token string) error {
+func DeleteFunctionToken(gateway string, functionName string, tlsInsecure bool, token string, namespace string) error {
 	gateway = strings.TrimRight(gateway, "/")
 	delReq := requests.DeleteFunctionRequest{FunctionName: functionName}
 	reqBytes, _ := json.Marshal(&delReq)
 	reader := bytes.NewReader(reqBytes)
 
 	c := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
-	req, err := http.NewRequest("DELETE", gateway+"/system/functions", reader)
+
+	deleteEndpoint, err := createSystemEndpoint(gateway, namespace)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("DELETE", deleteEndpoint, reader)
 	if err != nil {
 		fmt.Println(err)
 		return err

--- a/proxy/delete_test.go
+++ b/proxy/delete_test.go
@@ -19,7 +19,7 @@ func Test_DeleteFunction(t *testing.T) {
 	defer s.Close()
 
 	stdout := test.CaptureStdout(func() {
-		DeleteFunction(s.URL, "function-to-delete", false)
+		DeleteFunction(s.URL, "function-to-delete", false, "")
 	})
 
 	r := regexp.MustCompile(`(?m:Removing old function.)`)
@@ -33,7 +33,7 @@ func Test_DeleteFunction_404(t *testing.T) {
 	defer s.Close()
 
 	stdout := test.CaptureStdout(func() {
-		DeleteFunction(s.URL, "function-to-delete", false)
+		DeleteFunction(s.URL, "function-to-delete", false, "")
 	})
 
 	r := regexp.MustCompile(`(?m:No existing function to remove)`)
@@ -47,7 +47,7 @@ func Test_DeleteFunction_Not2xxAnd404(t *testing.T) {
 	defer s.Close()
 
 	stdout := test.CaptureStdout(func() {
-		DeleteFunction(s.URL, "function-to-delete", false)
+		DeleteFunction(s.URL, "function-to-delete", false, "")
 	})
 
 	r := regexp.MustCompile(`(?m:Server returned unexpected status code)`)
@@ -59,13 +59,11 @@ func Test_DeleteFunction_Not2xxAnd404(t *testing.T) {
 func Test_DeleteFunction_MissingURLPrefix(t *testing.T) {
 	url := "127.0.0.1:8080"
 
-	stdout := test.CaptureStdout(func() {
-		DeleteFunction(url, "function-to-delete", false)
-	})
+	err := DeleteFunction(url, "function-to-delete", false, "")
 
 	expectedErrMsg := "first path segment in URL cannot contain colon"
 	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
-	if !r.MatchString(stdout) {
-		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, stdout)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, err.Error())
 	}
 }

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -47,6 +47,7 @@ type DeployFunctionSpec struct {
 	ReadOnlyRootFilesystem  bool
 	TLSInsecure             bool
 	Token                   string
+	Namespace               string
 }
 
 // DeployFunction first tries to deploy a function and if it exists will then attempt
@@ -83,7 +84,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 	gateway := strings.TrimRight(spec.Gateway, "/")
 
 	if spec.Replace {
-		DeleteFunction(gateway, spec.FunctionName, spec.TLSInsecure)
+		DeleteFunction(gateway, spec.FunctionName, spec.TLSInsecure, "")
 	}
 
 	req := types.FunctionDeployment{
@@ -98,6 +99,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 		Labels:                 &spec.Labels,
 		Annotations:            &spec.Annotations,
 		ReadOnlyRootFilesystem: spec.ReadOnlyRootFilesystem,
+		Namespace:              spec.Namespace,
 	}
 
 	hasLimits := false

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -51,6 +51,7 @@ func runDeployProxyTest(t *testing.T, deployTest deployProxyTest) {
 			false,
 			tlsNoVerify,
 			"",
+			"",
 		})
 	})
 
@@ -113,6 +114,7 @@ func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 			FunctionResourceRequest{},
 			false,
 			tlsNoVerify,
+			"",
 			"",
 		})
 	})

--- a/proxy/describe.go
+++ b/proxy/describe.go
@@ -8,30 +8,27 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"net/url"
-	"path"
 
 	types "github.com/openfaas/faas-provider/types"
 )
 
 //GetFunctionInfo get an OpenFaaS function information
-func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool) (types.FunctionStatus, error) {
-	return GetFunctionInfoToken(gateway, functionName, tlsInsecure, "")
+func GetFunctionInfo(gateway string, functionName string, tlsInsecure bool, namespace string) (types.FunctionStatus, error) {
+	return GetFunctionInfoToken(gateway, functionName, tlsInsecure, "", namespace)
 }
 
 //GetFunctionInfoToken get a function information with a token as auth
-func GetFunctionInfoToken(gateway string, functionName string, tlsInsecure bool, token string) (types.FunctionStatus, error) {
+func GetFunctionInfoToken(gateway string, functionName string, tlsInsecure bool, token string, namespace string) (types.FunctionStatus, error) {
 	var result types.FunctionStatus
 
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
 
-	gatewayURL, err := url.Parse(gateway)
+	gatewayURL, err := createFunctionEndpoint(gateway, functionName, namespace)
 	if err != nil {
-		return result, fmt.Errorf("invalid gateway URL: %s", gateway)
+		return result, err
 	}
-	gatewayURL.Path = path.Join(gatewayURL.Path, "/system/function/", functionName)
 
-	getRequest, err := http.NewRequest(http.MethodGet, gatewayURL.String(), nil)
+	getRequest, err := http.NewRequest(http.MethodGet, gatewayURL, nil)
 	if err != nil {
 		return result, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}

--- a/proxy/describe_test.go
+++ b/proxy/describe_test.go
@@ -22,7 +22,7 @@ func Test_GetFunctionInfo(t *testing.T) {
 	})
 
 	defer s.Close()
-	result, err := GetFunctionInfo(s.URL, "func-test1", !tlsNoVerify)
+	result, err := GetFunctionInfo(s.URL, "func-test1", !tlsNoVerify, "")
 	if err != nil {
 		t.Fatalf("Error returned: %s", err)
 	}
@@ -34,7 +34,7 @@ func Test_GetFunctionInfo(t *testing.T) {
 func Test_GetFunctionInfo_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
 
-	_, err := GetFunctionInfo(s.URL, "func-test1", tlsNoVerify)
+	_, err := GetFunctionInfo(s.URL, "func-test1", tlsNoVerify, "")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -47,7 +47,7 @@ func Test_GetFunctionInfo_Not200(t *testing.T) {
 }
 
 func Test_GetFunctionInfo_MissingURLPrefix(t *testing.T) {
-	_, err := GetFunctionInfo("127.0.0.1:8080", "func-test", tlsNoVerify)
+	_, err := GetFunctionInfo("127.0.0.1:8080", "func-test", tlsNoVerify, "")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -64,7 +64,7 @@ func Test_GetFunctionInfo_NotFound(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusNotFound)
 	functionName := "funct-test"
 
-	_, err := GetFunctionInfo(s.URL, functionName, tlsNoVerify)
+	_, err := GetFunctionInfo(s.URL, functionName, tlsNoVerify, "")
 	if err == nil {
 		t.Fatalf("Error was not returned")
 	}

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -15,12 +15,12 @@ import (
 )
 
 // ListFunctions list deployed functions
-func ListFunctions(gateway string, tlsInsecure bool) ([]types.FunctionStatus, error) {
-	return ListFunctionsToken(gateway, tlsInsecure, "")
+func ListFunctions(gateway string, tlsInsecure bool, namespace string) ([]types.FunctionStatus, error) {
+	return ListFunctionsToken(gateway, tlsInsecure, "", namespace)
 }
 
 // ListFunctionsToken list deployed functions with a token as auth
-func ListFunctionsToken(gateway string, tlsInsecure bool, token string) ([]types.FunctionStatus, error) {
+func ListFunctionsToken(gateway string, tlsInsecure bool, token string, namespace string) ([]types.FunctionStatus, error) {
 	var results []types.FunctionStatus
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -29,7 +29,12 @@ func ListFunctionsToken(gateway string, tlsInsecure bool, token string) ([]types
 		return http.ErrUseLastResponse
 	}
 
-	getRequest, err := http.NewRequest(http.MethodGet, gateway+"/system/functions", nil)
+	getEndpoint, err := createSystemEndpoint(gateway, namespace)
+	if err != nil {
+		return results, err
+	}
+
+	getRequest, err := http.NewRequest(http.MethodGet, getEndpoint, nil)
 
 	if len(token) > 0 {
 		SetToken(getRequest, token)

--- a/proxy/list_test.go
+++ b/proxy/list_test.go
@@ -23,7 +23,7 @@ func Test_ListFunctions(t *testing.T) {
 	})
 	defer s.Close()
 
-	result, err := ListFunctions(s.URL, !tlsNoVerify)
+	result, err := ListFunctions(s.URL, !tlsNoVerify, "")
 
 	if err != nil {
 		t.Fatalf("Error returned: %s", err)
@@ -38,7 +38,7 @@ func Test_ListFunctions(t *testing.T) {
 func Test_ListFunctions_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
 
-	_, err := ListFunctions(s.URL, tlsNoVerify)
+	_, err := ListFunctions(s.URL, tlsNoVerify, "")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -51,13 +51,13 @@ func Test_ListFunctions_Not200(t *testing.T) {
 }
 
 func Test_ListFunctions_MissingURLPrefix(t *testing.T) {
-	_, err := ListFunctions("127.0.0.1:8080", tlsNoVerify)
+	_, err := ListFunctions("127.0.0.1:8080", tlsNoVerify, "")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
 	}
 
-	expectedErrMsg := "cannot connect to OpenFaaS on URL:"
+	expectedErrMsg := "first path segment in URL cannot contain colon"
 	r := regexp.MustCompile(fmt.Sprintf("(?m:%s)", expectedErrMsg))
 	if !r.MatchString(err.Error()) {
 		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, err.Error())

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+)
+
+const (
+	systemPath   = "/system/functions"
+	functionPath = "/system/function"
+)
+
+func createSystemEndpoint(gateway, namespace string) (string, error) {
+	gatewayURL, err := url.Parse(gateway)
+	if err != nil {
+		return "", fmt.Errorf("invalid gateway URL: %s", err.Error())
+	}
+	gatewayURL.Path = path.Join(gatewayURL.Path, systemPath)
+	if len(namespace) > 0 {
+		q := gatewayURL.Query()
+		q.Set("namespace", namespace)
+		gatewayURL.RawQuery = q.Encode()
+	}
+	return gatewayURL.String(), nil
+}
+
+func createFunctionEndpoint(gateway, functionName, namespace string) (string, error) {
+	gatewayURL, err := url.Parse(gateway)
+	if err != nil {
+		return "", fmt.Errorf("invalid gateway URL: %s", err.Error())
+	}
+	gatewayURL.Path = path.Join(gatewayURL.Path, functionPath, functionName)
+	if len(namespace) > 0 {
+		q := gatewayURL.Query()
+		q.Set("namespace", namespace)
+		gatewayURL.RawQuery = q.Encode()
+	}
+	return gatewayURL.String(), nil
+}

--- a/proxy/utils_test.go
+++ b/proxy/utils_test.go
@@ -1,0 +1,100 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func Test_createSystemEndpoint(t *testing.T) {
+	tests := []struct {
+		title            string
+		gateway          string
+		namespace        string
+		exptectedErr     bool
+		expectedEndpoint string
+	}{
+		{
+			title:            "Namespace is set",
+			gateway:          "http://127.0.0.1:8080",
+			namespace:        "production",
+			exptectedErr:     false,
+			expectedEndpoint: "http://127.0.0.1:8080/system/functions?namespace=production",
+		},
+		{
+			title:            "Namespace is not set",
+			gateway:          "http://127.0.0.1:8080",
+			namespace:        "",
+			exptectedErr:     false,
+			expectedEndpoint: "http://127.0.0.1:8080/system/functions",
+		},
+		{
+			title:            "Bad gateway formatting",
+			gateway:          "127.0.0.1:8080",
+			namespace:        "production",
+			exptectedErr:     true,
+			expectedEndpoint: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			output, err := createSystemEndpoint(test.gateway, test.namespace)
+			if output != test.expectedEndpoint {
+				t.Errorf("Expected format of the gateway: %s found: %s",
+					test.expectedEndpoint,
+					output)
+			}
+			if err != nil && test.exptectedErr == false {
+				t.Errorf("Expected nil error, got: %s",
+					err.Error())
+			}
+		})
+	}
+}
+
+func Test_createFunctionEndpoint(t *testing.T) {
+	tests := []struct {
+		title            string
+		gateway          string
+		namespace        string
+		functionName     string
+		exptectedErr     bool
+		expectedEndpoint string
+	}{
+		{
+			title:            "Namespace is set",
+			gateway:          "http://127.0.0.1:8080",
+			namespace:        "production",
+			functionName:     "cows",
+			exptectedErr:     false,
+			expectedEndpoint: "http://127.0.0.1:8080/system/function/cows?namespace=production",
+		},
+		{
+			title:            "Namespace is not set",
+			gateway:          "http://127.0.0.1:8080",
+			functionName:     "cows",
+			namespace:        "",
+			exptectedErr:     false,
+			expectedEndpoint: "http://127.0.0.1:8080/system/function/cows",
+		},
+		{
+			title:            "Bad gateway formatting",
+			gateway:          "127.0.0.1:8080",
+			namespace:        "production",
+			exptectedErr:     true,
+			expectedEndpoint: "",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			output, err := createFunctionEndpoint(test.gateway, test.functionName, test.namespace)
+			if output != test.expectedEndpoint {
+				t.Errorf("Expected format of the gateway: %s found: %s",
+					test.expectedEndpoint,
+					output)
+			}
+			if err != nil && test.exptectedErr == false {
+				t.Errorf("Expected nil error, got: %s",
+					err.Error())
+			}
+		})
+	}
+}

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -56,6 +56,9 @@ type Function struct {
 
 	// Annotations
 	Annotations *map[string]string `yaml:"annotations"`
+
+	// Namespace of the function
+	Namespace string `yaml:"namespace,omitempty"`
 }
 
 // FunctionResources Memory and CPU

--- a/vendor/github.com/openfaas/faas-provider/logs/handler.go
+++ b/vendor/github.com/openfaas/faas-provider/logs/handler.go
@@ -115,6 +115,7 @@ func parseRequest(r *http.Request) (logRequest Request, err error) {
 			return logRequest, err
 		}
 	}
+
 	// ignore error because it will default to false if we can't parse it
 	logRequest.Follow, _ = strconv.ParseBool(getValue(query, "follow"))
 

--- a/vendor/github.com/openfaas/faas-provider/types/config.go
+++ b/vendor/github.com/openfaas/faas-provider/types/config.go
@@ -7,11 +7,13 @@ import (
 
 // FaaSHandlers provide handlers for OpenFaaS
 type FaaSHandlers struct {
-	FunctionReader http.HandlerFunc
-	DeployHandler  http.HandlerFunc
 	// FunctionProxy provides the function invocation proxy logic.  Use proxy.NewHandlerFunc to
 	// use the standard OpenFaaS proxy implementation or provide completely custom proxy logic.
-	FunctionProxy  http.HandlerFunc
+	FunctionProxy http.HandlerFunc
+
+	FunctionReader http.HandlerFunc
+	DeployHandler  http.HandlerFunc
+
 	DeleteHandler  http.HandlerFunc
 	ReplicaReader  http.HandlerFunc
 	ReplicaUpdater http.HandlerFunc
@@ -19,10 +21,11 @@ type FaaSHandlers struct {
 	// LogHandler provides streaming json logs of functions
 	LogHandler http.HandlerFunc
 
-	// Optional: Update an existing function
-	UpdateHandler http.HandlerFunc
-	HealthHandler http.HandlerFunc
-	InfoHandler   http.HandlerFunc
+	// UpdateHandler an existing function/service
+	UpdateHandler        http.HandlerFunc
+	HealthHandler        http.HandlerFunc
+	InfoHandler          http.HandlerFunc
+	ListNamespaceHandler http.HandlerFunc
 }
 
 // FaaSConfig set config for HTTP handlers

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -46,6 +46,9 @@ type FunctionDeployment struct {
 	// ReadOnlyRootFilesystem removes write-access from the root filesystem
 	// mount-point.
 	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem"`
+
+	// Namespace for the function to be deployed into
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // FunctionResources Memory and CPU
@@ -72,7 +75,8 @@ type FunctionStatus struct {
 	// EnvProcess is the process to pass to the watchdog, if in use
 	EnvProcess string `json:"envProcess"`
 
-	// AvailableReplicas is the count of replicas ready to receive invocations as reported by the backend
+	// AvailableReplicas is the count of replicas ready to receive
+	// invocations as reported by the backend
 	AvailableReplicas uint64 `json:"availableReplicas"`
 
 	// Labels are metadata for functions which may be used by the
@@ -82,4 +86,13 @@ type FunctionStatus struct {
 	// Annotations are metadata for functions which may be used by the
 	// backend for management, orchestration, events and build tasks
 	Annotations *map[string]string `json:"annotations"`
+
+	// Namespace where the function can be accessed
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// Secret for underlying orchestrator
+type Secret struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
 }


### PR DESCRIPTION
Adding support for namespaces on the following commands:
 - delete
 - deploy
 - describe
 - list
 - store deploy
 - remove

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding support for the namespaces feature for the cli https://github.com/openfaas/faas-netes/issues/511 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Closes #693 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually and unit tests on Kubernetes.

The commands let you deploy functions in namespaces with the `-n` flag. In order to make that work, deploy the latest `faas-netes` and create namespace with `openfaas=1` annotation.

To deploy function from file, you just have to add `namespace: <your_namespace>` below the function, aligned with `image: ..` `annotations: ...`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
