### PR TITLE
Add new completion command supporting bash and zsh

### DIFF
--- a/commands/completion.go
+++ b/commands/completion.go
@@ -1,0 +1,223 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var shell string
+
+var completionCmd = &cobra.Command{
+	Use:   "completion SHELL",
+	Short: "Generates shell auto completion",
+	Long:  "Generates shell auto completion for Bash or ZSH.",
+	Example: `  faas-cli completion --shell bash
+  faas-cli completion --shell zsh`,
+	RunE: runCompletion,
+}
+
+func init() {
+	completionCmd.Flags().StringVar(&shell, "shell", "", "Outputs shell completion, must be bash or zsh")
+	completionCmd.MarkFlagRequired("shell")
+
+	faasCmd.AddCommand(completionCmd)
+}
+
+func runCompletion(cmd *cobra.Command, args []string) (err error) {
+	if shell == "" {
+		return fmt.Errorf("--shell is required and must be bash or zsh")
+	}
+
+	switch shell {
+	case "bash":
+		err = generateBashCompletion()
+		if err != nil {
+			return err
+		}
+		return nil
+
+	case "zsh":
+		err = generateZshCompletion()
+		if err != nil {
+			return err
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("%q shell not supported, must be bash or zsh", shell)
+	}
+}
+
+func generateBashCompletion() error {
+	err := faasCmd.GenBashCompletion(os.Stdout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func generateZshCompletion() error {
+	zshHead := "#compdef faas-cli\n"
+
+	out := os.Stdout
+
+	_, err := out.Write([]byte(zshHead))
+	if err != nil {
+		return err
+	}
+
+	zshInitialization := `
+__faas-cli_bash_source() {
+	alias shopt=':'
+	alias _expand=_bash_expand
+	alias _complete=_bash_comp
+	emulate -L sh
+	setopt kshglob noshglob braceexpand
+	source "$@"
+}
+__faas-cli_type() {
+	# -t is not supported by zsh
+	if [ "$1" == "-t" ]; then
+		shift
+		# fake Bash 4 to disable "complete -o nospace". Instead
+		# "compopt +-o nospace" is used in the code to toggle trailing
+		# spaces. We don't support that, but leave trailing spaces on
+		# all the time
+		if [ "$1" = "__faas-cli_compopt" ]; then
+			echo builtin
+			return 0
+		fi
+	fi
+	type "$@"
+}
+__faas-cli_compgen() {
+	local completions w
+	completions=( $(compgen "$@") ) || return $?
+	# filter by given word as prefix
+	while [[ "$1" = -* && "$1" != -- ]]; do
+		shift
+		shift
+	done
+	if [[ "$1" == -- ]]; then
+		shift
+	fi
+	for w in "${completions[@]}"; do
+		if [[ "${w}" = "$1"* ]]; then
+			echo "${w}"
+		fi
+	done
+}
+__faas-cli_compopt() {
+	true # don't do anything. Not supported by bashcompinit in zsh
+}
+__faas-cli_ltrim_colon_completions()
+{
+	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
+		# Remove colon-word prefix from COMPREPLY items
+		local colon_word=${1%${1##*:}}
+		local i=${#COMPREPLY[*]}
+		while [[ $((--i)) -ge 0 ]]; do
+			COMPREPLY[$i]=${COMPREPLY[$i]#"$colon_word"}
+		done
+	fi
+}
+__faas-cli_get_comp_words_by_ref() {
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	prev="${COMP_WORDS[${COMP_CWORD}-1]}"
+	words=("${COMP_WORDS[@]}")
+	cword=("${COMP_CWORD[@]}")
+}
+__faas-cli_filedir() {
+	local RET OLD_IFS w qw
+	__faas-cli_debug "_filedir $@ cur=$cur"
+	if [[ "$1" = \~* ]]; then
+		# somehow does not work. Maybe, zsh does not call this at all
+		eval echo "$1"
+		return 0
+	fi
+	OLD_IFS="$IFS"
+	IFS=$'\n'
+	if [ "$1" = "-d" ]; then
+		shift
+		RET=( $(compgen -d) )
+	else
+		RET=( $(compgen -f) )
+	fi
+	IFS="$OLD_IFS"
+	IFS="," __faas-cli_debug "RET=${RET[@]} len=${#RET[@]}"
+	for w in ${RET[@]}; do
+		if [[ ! "${w}" = "${cur}"* ]]; then
+			continue
+		fi
+		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
+			qw="$(__faas-cli_quote "${w}")"
+			if [ -d "${w}" ]; then
+				COMPREPLY+=("${qw}/")
+			else
+				COMPREPLY+=("${qw}")
+			fi
+		fi
+	done
+}
+__faas-cli_quote() {
+	if [[ $1 == \'* || $1 == \"* ]]; then
+		# Leave out first character
+		printf %q "${1:1}"
+	else
+	printf %q "$1"
+	fi
+}
+autoload -U +X bashcompinit && bashcompinit
+# use word boundary patterns for BSD or GNU sed
+LWORD='[[:<:]]'
+RWORD='[[:>:]]'
+if sed --help 2>&1 | grep -q GNU; then
+	LWORD='\<'
+	RWORD='\>'
+fi
+__faas-cli_convert_bash_to_zsh() {
+	sed \
+	-e 's/declare -F/whence -w/' \
+	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
+	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
+	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
+	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \
+	-e "s/${LWORD}_filedir${RWORD}/__faas-cli_filedir/g" \
+	-e "s/${LWORD}_get_comp_words_by_ref${RWORD}/__faas-cli_get_comp_words_by_ref/g" \
+	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__faas-cli_ltrim_colon_completions/g" \
+	-e "s/${LWORD}compgen${RWORD}/__faas-cli_compgen/g" \
+	-e "s/${LWORD}compopt${RWORD}/__faas-cli_compopt/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
+	-e "s/\\\$(type${RWORD}/\$(__faas-cli_type/g" \
+	<<'BASH_COMPLETION_EOF'
+`
+	_, err = out.Write([]byte(zshInitialization))
+	if err != nil {
+		return err
+	}
+
+	buf := new(bytes.Buffer)
+	faasCmd.GenBashCompletion(buf)
+
+	_, err = out.Write(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	zshTail := `
+BASH_COMPLETION_EOF
+}
+__faas-cli_bash_source <(__faas-cli_convert_bash_to_zsh)
+_complete faas-cli 2>/dev/null
+`
+	_, err = out.Write([]byte(zshTail))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/commands/completion_test.go
+++ b/commands/completion_test.go
@@ -1,0 +1,24 @@
+package commands
+
+import (
+	"testing"
+)
+
+func Test_ValidShell(t *testing.T) {
+
+	testArgs := [][]string{
+		{"completion", "--shell", "bash"},
+		{"completion", "--shell", "zsh"},
+	}
+
+	for _, arg := range testArgs {
+		faasCmd.SetArgs(arg)
+
+		err := faasCmd.Execute()
+
+		if err != nil {
+			t.Errorf("err was supposed to be nil but it was: %s", err)
+			t.Fail()
+		}
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a new command called `completion` which generates auto complete shell configuration for Bash and ZSH. Heavily inspired by [kubectl](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/completion/completion.go).

## Motivation and Context
- [x] I have raised an issue to propose this change. #691.

## How can I test this?
Added code testing in `commands/completion_test.go`.

## Using it
The installation and testing of the auto completion is heavily inspired by the [kubectl docs](https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion). 

The PR has a 99% copy and paste piece of code from [kubectl](https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/completion/completion.go#L145). Basically, `cobra`'s `GenZshCompletion` function is broken and what the copied code does is convert the `GenBashCompletion` to work with ZSH. **I don't understand all of that code**, is some very heavy Bash scripting, but it works 🤷‍♀ 

**On top of this, there are improvements we could make. [This](https://github.com/spf13/cobra/blob/master/bash_completions.md) document shows how we can improve event more, like using `cmd.MarkFlagRequired()` to show `--` flags (the `completion` command is using it).**

Is the below examples `faas-cli` means a binary built from this branch. Even if you generate the auto completion configuration from an adhoc binary, if will work with your current installed version.

### Requirements
* Bash v4.1+
* ZSH 

### Testing on Linux + Bash
```shell
# Install bash-completion
$ apt-get install bash-completion 
# or
$ yum install bash-completion

# Enable auto completion
$ echo 'source /usr/share/bash-completion/bash_completion' >> ~/.bashrc

# Add faas-cli auto completion
$ echo 'source <(faas-cli completion --shell bash)' >> ~/.bashrc
# or
$ faas-cli completion --shell bash >/etc/bash_completion.d/faas-cli
```

### Testing on MacOS + Bash
- [Install latest Bash](https://itnext.io/upgrading-bash-on-macos-7138bd1066ba)

```shell
# Install new bash-completion
$ brew install bash-completion@2

# Add following to your ~/.bashrc
export BASH_COMPLETION_COMPAT_DIR="/usr/local/etc/bash_completion.d"
[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"

# Add faas-cli auto completion
$ echo 'source <(faas-cli completion --shell bash)' >> ~/.bashrc
# or
$ faas-cli completion --shell bash >/etc/bash_completion.d/faas-cli
```

### Testing ZSH
Add the following to your ~/.zshrc file:
```shell
source <(faas-cli completion --shell zsh)
```

## TODO
- [x] Write code
- [x] Write tests
- [ ] Write docs (like the one in `kubectl`)
- [ ] Add link to docs after executing the command, instructing the user of next steps
- [ ] Add deprecated warning to `faas-cli bashcompletion` (should I? how could I do it?)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
