### PR TITLE
Final touches completion command

### DIFF
--- a/commands/bash_completion.go
+++ b/commands/bash_completion.go
@@ -23,7 +23,7 @@ var bashcompletionCmd = &cobra.Command{
 This currently only works on Bash version 4, and is hidden
 pending a merge of https://github.com/spf13/cobra/pull/520.`,
 	Hidden:     true,
-	Deprecated: "please use the `completion` command",
+	Deprecated: `please use the "completion" command`,
 	RunE:       runBashcompletion,
 }
 

--- a/commands/bash_completion.go
+++ b/commands/bash_completion.go
@@ -22,8 +22,9 @@ var bashcompletionCmd = &cobra.Command{
 
 This currently only works on Bash version 4, and is hidden
 pending a merge of https://github.com/spf13/cobra/pull/520.`,
-	Hidden: true,
-	RunE:   runBashcompletion,
+	Hidden:     true,
+	Deprecated: "please use the `completion` command",
+	RunE:       runBashcompletion,
 }
 
 func runBashcompletion(cmd *cobra.Command, args []string) error {

--- a/commands/completion.go
+++ b/commands/completion.go
@@ -13,7 +13,10 @@ var shell string
 var completionCmd = &cobra.Command{
 	Use:   "completion SHELL",
 	Short: "Generates shell auto completion",
-	Long:  "Generates shell auto completion for Bash or ZSH.",
+	Long: `Generates shell auto completion for Bash or ZSH.
+
+Please follow the instructions in the link below to activate the shell auto completion in your environment:
+https://docs.openfaas.com/cli/completion/`,
 	Example: `  faas-cli completion --shell bash
   faas-cli completion --shell zsh`,
 	RunE: runCompletion,


### PR DESCRIPTION
## Description
This PR add the final touches in the `completion` command.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) #691 

## How Has This Been Tested?
- `./faas-cli bashcompletion` should emit deprecated message
- `./faas-cli completion --help` should display docs link

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
