### PR TITLE
Remove deprecated auto completion section from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,32 +216,3 @@ Generate a personal access token in GitHub and use it to update the CHANGELOG.md
 $ export CHANGELOG_GITHUB_TOKEN=TOKEN_VALUE
 $ github_changelog_generator
 ```
-
-## Misc
-
-**Bash Auto-completion [experimental]**
-
-An experimental initial Bash auto-completion script for `faas-cli` is available at `contrib/bash/faas-cli`.
-
-Please raise issues with feedback and suggestions on improvements to the auto-completion support.
-
-This may be enabled it as follows.
-
-*Enabling Bash auto-completion on OSX*
-
-Brew install the `bash_completions` package.
-```
-$ brew install bash-completion
-```
-Add the following line to your `~/.bash_profile` if not already present.
-```
-[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
-```
-Copy the provided `faas-cli` bash completion script from this repo.
-```
-cp contrib/bash/faas-cli /usr/local/etc/bash_completion.d/
-```
-
-*Enabling Bash auto-completion on Linux*
-
-Refer to your distributions instructions on installing and enabling `bash-completion`, then copy the `faas-cli` completion script from `contrib/bash/` into the appropriate completion directory.


### PR DESCRIPTION
Signed-off-by: Jonatas Baldin <jonatas.baldin@gmail.com>

## Description
Remove deprecated `Bash Auto-Completion` section from CONTRIBUTING. I also didn't add about the new `completion` command because it's already documented in the docs.

## Motivation and Context
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)). Relates to #691.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
