### PR TITLE
Use Secret struct from faas-provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -93,7 +93,7 @@
   version = "0.16.0"
 
 [[projects]]
-  digest = "1:30dd53fb3e50077a707e4fb79a909251b5829e19fee4fe6c6a1273f2d19ecc27"
+  digest = "1:690dfc3640e08c64ef54f044d92029e4bbd19cb6dd5d738c1a776ce0c37756d7"
   name = "github.com/openfaas/faas-provider"
   packages = [
     "httputil",
@@ -101,8 +101,8 @@
     "types",
   ]
   pruneopts = "UT"
-  revision = "eafd85a3b360d8e0982c3a1db43e6d5fee9b85e2"
-  version = "0.10.2"
+  revision = "478f741b64cbcfaaee852156b060514be56623b3"
+  version = "0.12.0"
 
 [[projects]]
   digest = "1:cf31692c14422fa27c83a05292eb5cbe0fb2775972e8f1f8446a71549bd8980b"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -16,7 +16,7 @@
 
 [[constraint]]
   name = "github.com/openfaas/faas-provider"
-  version = "0.10.2"
+  version = "0.12.0"
 
 [[constraint]]
   name = "github.com/spf13/cobra"

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/openfaas/faas-cli/proxy"
-	"github.com/openfaas/faas-cli/schema"
+	types "github.com/openfaas/faas-provider/types"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +68,7 @@ func preRunSecretCreate(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretCreate(cmd *cobra.Command, args []string) error {
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name: args[0],
 	}
 

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/openfaas/faas-cli/proxy"
-	"github.com/openfaas/faas-cli/schema"
+	types "github.com/openfaas/faas-provider/types"
 	"github.com/spf13/cobra"
 )
 
@@ -61,7 +61,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func renderSecretList(secrets []schema.Secret) string {
+func renderSecretList(secrets []types.Secret) string {
 	var b bytes.Buffer
 	w := tabwriter.NewWriter(&b, 0, 0, 1, ' ', 0)
 	fmt.Fprintln(w)

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/openfaas/faas-cli/proxy"
-	"github.com/openfaas/faas-cli/schema"
+	types "github.com/openfaas/faas-provider/types"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +49,7 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 		fmt.Println(msg)
 	}
 
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name: args[0],
 	}
 	err := proxy.RemoveSecretToken(gatewayAddress, secret, tlsInsecure, token)

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/openfaas/faas-cli/proxy"
-	"github.com/openfaas/faas-cli/schema"
+	types "github.com/openfaas/faas-provider/types"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +60,7 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 		fmt.Println(msg)
 	}
 
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name: args[0],
 	}
 

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -8,17 +8,17 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/openfaas/faas-cli/schema"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 // GetSecretList get secrets list
-func GetSecretList(gateway string, tlsInsecure bool) ([]schema.Secret, error) {
+func GetSecretList(gateway string, tlsInsecure bool) ([]types.Secret, error) {
 	return GetSecretListToken(gateway, tlsInsecure, "")
 }
 
 // GetSecretListToken get secrets lists with taken as auth
-func GetSecretListToken(gateway string, tlsInsecure bool, token string) ([]schema.Secret, error) {
-	var results []schema.Secret
+func GetSecretListToken(gateway string, tlsInsecure bool, token string) ([]types.Secret, error) {
+	var results []types.Secret
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
@@ -70,12 +70,12 @@ func GetSecretListToken(gateway string, tlsInsecure bool, token string) ([]schem
 }
 
 // UpdateSecret update a secret via the OpenFaaS API by name
-func UpdateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, string) {
+func UpdateSecret(gateway string, secret types.Secret, tlsInsecure bool) (int, string) {
 	return UpdateSecretToken(gateway, secret, tlsInsecure, "")
 }
 
 // UpdateSecretToken update a secret with token as auth
-func UpdateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) (int, string) {
+func UpdateSecretToken(gateway string, secret types.Secret, tlsInsecure bool, token string) (int, string) {
 	var output string
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -127,12 +127,12 @@ func UpdateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, t
 }
 
 // RemoveSecret remove a secret via the OpenFaaS API by name
-func RemoveSecret(gateway string, secret schema.Secret, tlsInsecure bool) error {
+func RemoveSecret(gateway string, secret types.Secret, tlsInsecure bool) error {
 	return RemoveSecretToken(gateway, secret, tlsInsecure, "")
 }
 
 // RemoveSecretToken remove a secret with token as auth
-func RemoveSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) error {
+func RemoveSecretToken(gateway string, secret types.Secret, tlsInsecure bool, token string) error {
 
 	gateway = strings.TrimRight(gateway, "/")
 	client := MakeHTTPClient(&defaultCommandTimeout, tlsInsecure)
@@ -179,12 +179,12 @@ func RemoveSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, t
 }
 
 // CreateSecret create secret
-func CreateSecret(gateway string, secret schema.Secret, tlsInsecure bool) (int, string) {
+func CreateSecret(gateway string, secret types.Secret, tlsInsecure bool) (int, string) {
 	return CreateSecretToken(gateway, secret, tlsInsecure, "")
 }
 
 // CreateSecretToken create secret with token as auth
-func CreateSecretToken(gateway string, secret schema.Secret, tlsInsecure bool, token string) (int, string) {
+func CreateSecretToken(gateway string, secret types.Secret, tlsInsecure bool, token string) (int, string) {
 	var output string
 
 	gateway = strings.TrimRight(gateway, "/")

--- a/proxy/secret_test.go
+++ b/proxy/secret_test.go
@@ -5,8 +5,8 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/openfaas/faas-cli/schema"
 	"github.com/openfaas/faas-cli/test"
+	types "github.com/openfaas/faas-provider/types"
 )
 
 func Test_GetSecretList_200OK(t *testing.T) {
@@ -81,7 +81,7 @@ func Test_GetSecretList_Unauthorized401(t *testing.T) {
 	}
 }
 
-var expectedSecretList = []schema.Secret{
+var expectedSecretList = []types.Secret{
 	{
 		Name: "Secret1",
 	},
@@ -92,7 +92,7 @@ var expectedSecretList = []schema.Secret{
 
 func Test_CreateSecret_200OK(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusOK)
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name:  "secret-name",
 		Value: "secret-value",
 	}
@@ -106,7 +106,7 @@ func Test_CreateSecret_200OK(t *testing.T) {
 
 func Test_CreateSecret_201Created(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusCreated)
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name:  "secret-name",
 		Value: "secret-value",
 	}
@@ -120,7 +120,7 @@ func Test_CreateSecret_201Created(t *testing.T) {
 
 func Test_CreateSecret_202Accepted(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusAccepted)
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name:  "secret-name",
 		Value: "secret-value",
 	}
@@ -135,7 +135,7 @@ func Test_CreateSecret_202Accepted(t *testing.T) {
 func Test_CreateSecret_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
 
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name:  "secret-name",
 		Value: "secret-value",
 	}
@@ -154,7 +154,7 @@ func Test_CreateSecret_Not200(t *testing.T) {
 func Test_CreateSecret_Unauthorized401(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusUnauthorized)
 
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name:  "secret-name",
 		Value: "secret-value",
 	}
@@ -173,7 +173,7 @@ func Test_CreateSecret_Unauthorized401(t *testing.T) {
 func Test_CreateSecret_Conflict409(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusConflict)
 
-	secret := schema.Secret{
+	secret := types.Secret{
 		Name:  "secret-name",
 		Value: "secret-value",
 	}

--- a/schema/secret.go
+++ b/schema/secret.go
@@ -11,9 +11,3 @@ type KubernetesSecretMetadata struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
 }
-
-//Secret secret type
-type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
-}

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -93,6 +93,7 @@ type FunctionStatus struct {
 
 // Secret for underlying orchestrator
 type Secret struct {
-	Name  string `json:"name"`
-	Value string `json:"value,omitempty"`
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+	Value     string `json:"value,omitempty"`
 }


### PR DESCRIPTION
This commit updates the secret commands to use `Secret` struct from the
faas-provider rather than using it's own struct.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

I would like to do this change as a pre-work for this issue #701 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this on my local with swarm and kubernetes.
swarm
```
./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(secret-update) ✗ ./faas-cli-darwin secret create test-swarm-secret --from-literal=test-swarm-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-swarm-secret
Created: 201 Created
➜  faas-cli git:(secret-update) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-swarm-secret

➜  faas-cli git:(secret-update) ✗ docker secret ls
ID                          NAME                  DRIVER              CREATED             UPDATED
z6vbmmuzs2p1zxkdrd33ucmv2   basic-auth-password                       3 months ago        3 months ago
tmgocr7w8hko1e5q0fr9sunh9   basic-auth-user                           3 months ago        3 months ago
gej14vmt673ou0qoia0s56za3   secret-api-test-key                       3 weeks ago         3 weeks ago
du8ngqydlix35cu0vssl7u85t   test-swarm-secret                         22 seconds ago      22 seconds ago

./faas-cli-darwin secret update test-swarm-secret --from-literal=test-swarm-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-swarm-secret
Updated: 200 OK                                                                                                                                                                                           
➜  faas-cli git:(secret-update) ✗ ./faas-cli-darwin secret remove test-swarm-secret
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
```

Kubernetes
```
./faas-cli-darwin secret list
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret create test-kube-secret --from-literal=test-kube-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-kube-secret
Created: 202 Accepted
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-kube-secret
test-secret

➜  faas-cli git:(master) ✗ kubectl get secret
NAME                  TYPE                                  DATA   AGE
default-token-jssdd   kubernetes.io/service-account-token   3      22m
➜  faas-cli git:(master) ✗ kubectl get secret  -n openfaas-fn
NAME                  TYPE                                  DATA   AGE
default-token-5h89w   kubernetes.io/service-account-token   3      20m
test-kube-secret      Opaque                                1      31s
test-secret           Opaque                                1      10m
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
