### PR TITLE
Add namespace flag to secrets commands

### DIFF
--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -43,6 +43,7 @@ func init() {
 	secretCreateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretCreateCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretCreateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	secretCreateCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 	secretCmd.AddCommand(secretCreateCmd)
 }
 
@@ -69,7 +70,8 @@ func preRunSecretCreate(cmd *cobra.Command, args []string) error {
 
 func runSecretCreate(cmd *cobra.Command, args []string) error {
 	secret := types.Secret{
-		Name: args[0],
+		Name:      args[0],
+		Namespace: functionNamespace,
 	}
 
 	switch {

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -30,6 +30,7 @@ func init() {
 	secretListCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretListCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretListCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	secretListCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 
 	secretCmd.AddCommand(secretListCmd)
 }
@@ -46,7 +47,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		fmt.Println(msg)
 	}
 
-	secrets, err := proxy.GetSecretListToken(gatewayAddress, tlsInsecure, token)
+	secrets, err := proxy.GetSecretListToken(gatewayAddress, tlsInsecure, token, functionNamespace)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -27,6 +27,7 @@ func init() {
 	secretRemoveCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretRemoveCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretRemoveCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	secretRemoveCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 	secretCmd.AddCommand(secretRemoveCmd)
 }
 
@@ -50,7 +51,8 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	secret := types.Secret{
-		Name: args[0],
+		Name:      args[0],
+		Namespace: functionNamespace,
 	}
 	err := proxy.RemoveSecretToken(gatewayAddress, secret, tlsInsecure, token)
 	if err != nil {

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -34,6 +34,7 @@ func init() {
 	secretUpdateCmd.Flags().StringVar(&literalSecret, "from-literal", "", "Value of the secret")
 	secretUpdateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
 	secretUpdateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	secretUpdateCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 	secretCmd.AddCommand(secretUpdateCmd)
 }
 
@@ -61,7 +62,8 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	secret := types.Secret{
-		Name: args[0],
+		Name:      args[0],
+		Namespace: functionNamespace,
 	}
 
 	switch {

--- a/proxy/secret_test.go
+++ b/proxy/secret_test.go
@@ -18,7 +18,7 @@ func Test_GetSecretList_200OK(t *testing.T) {
 	})
 	defer s.Close()
 
-	secrets, err := GetSecretList(s.URL, true)
+	secrets, err := GetSecretList(s.URL, true, "openfaas-fn")
 	if err != nil {
 		t.Errorf("Error returned: %s", err.Error())
 	}
@@ -39,7 +39,7 @@ func Test_GetSecretList_202Accepted(t *testing.T) {
 	})
 	defer s.Close()
 
-	secrets, err := GetSecretList(s.URL, true)
+	secrets, err := GetSecretList(s.URL, true, "")
 	if err != nil {
 		t.Errorf("Error returned: %s", err.Error())
 	}
@@ -54,7 +54,7 @@ func Test_GetSecretList_202Accepted(t *testing.T) {
 func Test_GetSecretList_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
 
-	_, err := GetSecretList(s.URL, true)
+	_, err := GetSecretList(s.URL, true, "openfaas-fn")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -69,7 +69,7 @@ func Test_GetSecretList_Not200(t *testing.T) {
 func Test_GetSecretList_Unauthorized401(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusUnauthorized)
 
-	_, err := GetSecretList(s.URL, true)
+	_, err := GetSecretList(s.URL, true, "fn")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -93,8 +93,9 @@ var expectedSecretList = []types.Secret{
 func Test_CreateSecret_200OK(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusOK)
 	secret := types.Secret{
-		Name:  "secret-name",
-		Value: "secret-value",
+		Name:      "secret-name",
+		Value:     "secret-value",
+		Namespace: "openfaas-fn",
 	}
 
 	status, _ := CreateSecret(s.URL, secret, true)
@@ -107,8 +108,9 @@ func Test_CreateSecret_200OK(t *testing.T) {
 func Test_CreateSecret_201Created(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusCreated)
 	secret := types.Secret{
-		Name:  "secret-name",
-		Value: "secret-value",
+		Name:      "secret-name",
+		Value:     "secret-value",
+		Namespace: "openfaas-fn",
 	}
 
 	status, _ := CreateSecret(s.URL, secret, true)
@@ -121,8 +123,9 @@ func Test_CreateSecret_201Created(t *testing.T) {
 func Test_CreateSecret_202Accepted(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusAccepted)
 	secret := types.Secret{
-		Name:  "secret-name",
-		Value: "secret-value",
+		Name:      "secret-name",
+		Value:     "secret-value",
+		Namespace: "openfaas-fn",
 	}
 
 	status, _ := CreateSecret(s.URL, secret, true)
@@ -136,8 +139,9 @@ func Test_CreateSecret_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
 
 	secret := types.Secret{
-		Name:  "secret-name",
-		Value: "secret-value",
+		Name:      "secret-name",
+		Value:     "secret-value",
+		Namespace: "openfaas-fn",
 	}
 	status, output := CreateSecret(s.URL, secret, true)
 
@@ -155,8 +159,9 @@ func Test_CreateSecret_Unauthorized401(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusUnauthorized)
 
 	secret := types.Secret{
-		Name:  "secret-name",
-		Value: "secret-value",
+		Name:      "secret-name",
+		Value:     "secret-value",
+		Namespace: "openfaas-fn",
 	}
 	status, output := CreateSecret(s.URL, secret, true)
 
@@ -174,8 +179,9 @@ func Test_CreateSecret_Conflict409(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusConflict)
 
 	secret := types.Secret{
-		Name:  "secret-name",
-		Value: "secret-value",
+		Name:      "secret-name",
+		Value:     "secret-value",
+		Namespace: "openfaas-fn",
 	}
 	status, output := CreateSecret(s.URL, secret, true)
 


### PR DESCRIPTION
This commit add `--namespace` flags to the secret subcommand in order to
support multiple namesapces feature.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: #701 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested on local kubernetes cluster. 

```
faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets
No secrets found.
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets?namespace=fn
No secrets found.
➜  faas-cli git:(add-namespace-to-secret) ✗ clear
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets
No secrets found.
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets?namespace=fn
No secrets found.
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret create test-secret --from-literal=value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
Created: 202 Accepted
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets

NAME
test-secret

➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret create test-secret-fn --from-literal=value -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret-fn
Created: 202 Accepted
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets?namespace=fn

NAME
test-secret-fn

➜  faas-cli git:(add-namespace-to-secret) ✗ kubectl get secrets -n openfaas-fn
NAME                  TYPE                                  DATA   AGE
default-token-slhvr   kubernetes.io/service-account-token   3      23d
test-secret           Opaque                                1      3m15s
➜  faas-cli git:(add-namespace-to-secret) ✗ kubectl get secrets -n fn
NAME                  TYPE                                  DATA   AGE
default-token-2sg2j   kubernetes.io/service-account-token   3      23d
test-secret-fn        Opaque                                1      2m14s
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret create test-secret --from-literal=updated-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
secret with the name "test-secret" already exists
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret update test-secret --from-literal=updated-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret
Updated: 202 Accepted
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret update test-secret-fn --from-literal=updated-value -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret-fn
Updated: 202 Accepted
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets

NAME
test-secret

➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets?namespace=fn

NAME
test-secret-fn

➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret rm test-secret
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret rm test-secret -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Unable to find secret: test-secret
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret rm test-secret-fn -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets
No secrets found.
➜  faas-cli git:(add-namespace-to-secret) ✗ ./faas-cli-darwin secret ls -n fn
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
http://127.0.0.1:31112/system/secrets?namespace=fn
No secrets found.
➜  faas-cli git:(add-namespace-to-secret) ✗ kubectl get secrets -n openfaas-fn
NAME                  TYPE                                  DATA   AGE
default-token-slhvr   kubernetes.io/service-account-token   3      23d
➜  faas-cli git:(add-namespace-to-secret) ✗ kubectl get secrets -n fn
NAME                  TYPE                                  DATA   AGE
default-token-2sg2j   kubernetes.io/service-account-token   3      23d
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
