### PR TITLE
Fix issue with cloud seal command

### DIFF
--- a/commands/list.go
+++ b/commands/list.go
@@ -20,7 +20,7 @@ var (
 func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
 	listCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
-	listCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Namespace of the function")
+	listCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 	listCmd.Flags().BoolVarP(&verboseList, "verbose", "v", false, "Verbose output for the function list")
 	listCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	listCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
@@ -56,7 +56,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	}
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
-	functions, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token, namespace)
+	functions, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token, functionNamespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This commit fixes the issue with `cloud seal` command `--namespace`
flag. Since default value for `--namespace` flag for cloud is different
than other commands `--namespace` flag. It was getting overriden by
`--namespace` flag value from list command. This commit changes the
variable used for `--namespace` flag in `list` command.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes: #709 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this in my local.

```
./faas-cli cloud seal --name alexellis-github --literal hmac-secret=c4488af0c158e8c
Sealing secret: alexellis-github in namespace: openfaas-fn

Unable to load public certificate pub-cert.pem
➜  faas-cli git:(issue-708) ./faas-cli cloud seal --name alexellis-github --literal hmac-secret=c4488af0c158e8c --namespace=fn
Sealing secret: alexellis-github in namespace: fn

Unable to load public certificate pub-cert.pem
➜  faas-cli git:(issue-708) ./faas-cli list
Function                      	Invocations    	Replicas
cows                          	0              	1
➜  faas-cli git:(issue-708) ./faas-cli list -n fn
Function                      	Invocations    	Replica
nodeinfo                      	0              	2
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
