### PR TITLE
Save oauth tokens to the openfaas config file

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openfaas/faas-cli/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
@@ -187,6 +188,10 @@ func authClientCredentials() error {
 			return errors.Wrapf(tokenErr, "unable to unmarshal token: %s", string(tokenData))
 		}
 
+		if err := config.UpdateAuthConfig(gateway, token.AccessToken, config.Oauth2AuthType); err != nil {
+			return err
+		}
+		fmt.Println("credentials saved for", gateway)
 		printExampleTokenUsage(gateway, token.AccessToken)
 	}
 
@@ -226,6 +231,11 @@ func makeCallbackHandler(cancel context.CancelFunc) func(w http.ResponseWriter, 
 			}
 
 			if token := q.Get("access_token"); len(token) > 0 {
+
+				if err := config.UpdateAuthConfig(gateway, token, config.Oauth2AuthType); err != nil {
+					fmt.Printf("error while saving authentication token: %s", err.Error())
+				}
+				fmt.Println("credentials saved for", gateway)
 				printExampleTokenUsage(gateway, token)
 			} else {
 				fmt.Printf("Unable to detect a valid access_token in URL fragment. Check your credentials or contact your administrator.\n")

--- a/commands/login.go
+++ b/commands/login.go
@@ -86,11 +86,17 @@ func runLogin(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := config.UpdateAuthConfig(gateway, username, password); err != nil {
+	token := config.EncodeAuth(username, password)
+	if err := config.UpdateAuthConfig(gateway, token, config.BasicAuthType); err != nil {
 		return err
 	}
 
-	user, _, err := config.LookupAuthConfig(gateway)
+	authConfig, err := config.LookupAuthConfig(gateway)
+	if err != nil {
+		return err
+	}
+
+	user, _, err := config.DecodeAuth(authConfig.Token)
 	if err != nil {
 		return err
 	}

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -23,6 +23,9 @@ var (
 	DefaultFile = "config.yml"
 )
 
+//AuthType auth type
+type AuthType string
+
 const (
 	//BasicAuthType basic authentication type
 	BasicAuthType = "basic"
@@ -37,9 +40,9 @@ type ConfigFile struct {
 }
 
 type AuthConfig struct {
-	Gateway string `yaml:"gateway,omitempty"`
-	Auth    string `yaml:"auth,omitempty"`
-	Token   string `yaml:"token,omitempty"`
+	Gateway string   `yaml:"gateway,omitempty"`
+	Auth    AuthType `yaml:"auth,omitempty"`
+	Token   string   `yaml:"token,omitempty"`
 }
 
 // New initializes a config file for the given file path
@@ -156,7 +159,7 @@ func DecodeAuth(input string) (string, string, error) {
 }
 
 // UpdateAuthConfig creates or updates the username and password for a given gateway
-func UpdateAuthConfig(gateway, token, authType string) error {
+func UpdateAuthConfig(gateway, token string, authType AuthType) error {
 	_, err := url.ParseRequestURI(gateway)
 	if err != nil || len(gateway) < 1 {
 		return fmt.Errorf("invalid gateway URL")

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -164,7 +164,7 @@ func Test_RemoveAuthConfig(t *testing.T) {
 	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
 
 	gatewayURL2 := strings.TrimRight("http://openfaas.test2/", "/")
-	UpdateAuthConfig(gatewayURL2, u, p)
+	UpdateAuthConfig(gatewayURL2, token, BasicAuthType)
 
 	err := RemoveAuthConfig(gatewayURL)
 	if err != nil {
@@ -213,5 +213,23 @@ func Test_RemoveAuthConfig_WithUnknownGateway(t *testing.T) {
 	r := regexp.MustCompile(`(?m:gateway)`)
 	if !r.MatchString(err.Error()) {
 		t.Errorf("Error not matched: %s", err.Error())
+	}
+}
+
+func Test_UpdateAuthConfig_Oauth2Insert(t *testing.T) {
+	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
+	DefaultFile = "test2.yml"
+	token := "somebase64encodedstring"
+	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
+	UpdateAuthConfig(gatewayURL, token, Oauth2AuthType)
+
+	authConfig, err := LookupAuthConfig(gatewayURL)
+	if err != nil {
+		t.Errorf("got error %s", err.Error())
+		t.Errorf(authConfig.Token)
+	}
+
+	if authConfig.Token != token {
+		t.Errorf("got token %s, expected %s", authConfig.Token, token)
 	}
 }

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -11,16 +11,50 @@ import (
 
 //SetAuth sets basic auth for the given gateway
 func SetAuth(req *http.Request, gateway string) {
-	username, password, err := config.LookupAuthConfig(gateway)
+	authConfig, err := config.LookupAuthConfig(gateway)
 	if err != nil {
 		// no auth info found
 		return
 	}
-
+	username, password, err := config.DecodeAuth(authConfig.Token)
+	if err != nil {
+		// no auth info found
+		return
+	}
 	req.SetBasicAuth(username, password)
 }
 
 //SetToken sets authentication token
 func SetToken(req *http.Request, token string) {
 	req.Header.Set("Authorization", "Bearer "+token)
+}
+
+//SetBasicAuth set basic authentication
+func SetBasicAuth(req *http.Request, authConfig config.AuthConfig) {
+	username, password, err := config.DecodeAuth(authConfig.Token)
+	if err != nil {
+		// no auth info found
+		return
+	}
+	req.SetBasicAuth(username, password)
+}
+
+//SetOauth2 set oauth2 token
+func SetOauth2(req *http.Request, authConfig config.AuthConfig) {
+	SetToken(req, authConfig.Token)
+}
+
+//AddAuth add authentication
+func AddAuth(req *http.Request, gateway string) {
+	authConfig, err := config.LookupAuthConfig(gateway)
+	if err != nil {
+		// no auth info found
+		return
+	}
+
+	if authConfig.Auth == config.BasicAuthType {
+		SetBasicAuth(req, authConfig)
+	} else if authConfig.Auth == config.Oauth2AuthType {
+		SetOauth2(req, authConfig)
+	}
 }

--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -52,9 +52,12 @@ func AddAuth(req *http.Request, gateway string) {
 		return
 	}
 
-	if authConfig.Auth == config.BasicAuthType {
+	switch authConfig.Auth {
+	case config.BasicAuthType:
 		SetBasicAuth(req, authConfig)
-	} else if authConfig.Auth == config.Oauth2AuthType {
+		return
+	case config.Oauth2AuthType:
 		SetOauth2(req, authConfig)
+		return
 	}
 }

--- a/proxy/auth_test.go
+++ b/proxy/auth_test.go
@@ -19,7 +19,8 @@ func Test_SetAuth_AuthorizationHeader(t *testing.T) {
 	config.DefaultFile = "authtest1.yml"
 	basicAuthURL := strings.TrimRight("http://openfaas.test/", "/")
 	openURL := "http://openfaas.test/"
-	config.UpdateAuthConfig(basicAuthURL, "Aladdin", "open sesame")
+	token := config.EncodeAuth("Aladdin", "open sesame")
+	config.UpdateAuthConfig(basicAuthURL, token, config.BasicAuthType)
 
 	req, _ := http.NewRequest("GET", openURL, nil)
 	SetAuth(req, basicAuthURL)
@@ -36,7 +37,8 @@ func Test_SetAuth_SkipAuthorization(t *testing.T) {
 	config.DefaultFile = "authtest2.yml"
 	basicAuthURL := strings.TrimRight("http://openfaas.test/", "/")
 	openURL := "http://openfaas.test2/"
-	config.UpdateAuthConfig(basicAuthURL, "Aladdin", "open sesame")
+	token := config.EncodeAuth("Aladdin", "open sesame")
+	config.UpdateAuthConfig(basicAuthURL, token, config.BasicAuthType)
 
 	req, _ := http.NewRequest("GET", openURL, nil)
 	SetAuth(req, "http://openfaas.test2")

--- a/proxy/auth_test.go
+++ b/proxy/auth_test.go
@@ -47,3 +47,54 @@ func Test_SetAuth_SkipAuthorization(t *testing.T) {
 		t.Errorf("got header %q, want none", header)
 	}
 }
+
+func Test_AddAuth_Oauth2(t *testing.T) {
+	//setup store
+	config.DefaultDir, _ = ioutil.TempDir("", "faas-cli-auth-test")
+	config.DefaultFile = "authtest2.yml"
+	basicAuthURL := strings.TrimRight("http://openfaas.ouath.test/", "/")
+	token := "somebase64string"
+	config.UpdateAuthConfig(basicAuthURL, token, config.Oauth2AuthType)
+
+	req, _ := http.NewRequest("GET", basicAuthURL, nil)
+	AddAuth(req, basicAuthURL)
+	header := req.Header.Get("Authorization")
+	expectedValue := "Bearer " + token
+	if header != expectedValue {
+		t.Errorf("got header %q, want %q", header, expectedValue)
+	}
+}
+
+func Test_AddAuth_BasicAuth(t *testing.T) {
+	//setup store
+	config.DefaultDir, _ = ioutil.TempDir("", "faas-cli-auth-test")
+	config.DefaultFile = "authtest2.yml"
+	basicAuthURL := strings.TrimRight("http://openfaas.basic-auth.test/", "/")
+	token := config.EncodeAuth("username", "password")
+	config.UpdateAuthConfig(basicAuthURL, token, config.BasicAuthType)
+
+	req, _ := http.NewRequest("GET", basicAuthURL, nil)
+	AddAuth(req, basicAuthURL)
+	header := req.Header.Get("Authorization")
+	expectedValue := "Basic " + token
+	if header != expectedValue {
+		t.Errorf("got header %q, want %q", header, expectedValue)
+	}
+}
+
+func Test_AddAuth_SkipAuthorization(t *testing.T) {
+	//setup store
+	config.DefaultDir, _ = ioutil.TempDir("", "faas-cli-auth-test")
+	config.DefaultFile = "authtest2.yml"
+	basicAuthURL := strings.TrimRight("http://openfaas.test/", "/")
+	openURL := "http://openfaas.test2/"
+	token := config.EncodeAuth("Aladdin", "open sesame")
+	config.UpdateAuthConfig(basicAuthURL, token, config.Oauth2AuthType)
+
+	req, _ := http.NewRequest("GET", openURL, nil)
+	SetAuth(req, openURL)
+	header := req.Header.Get("Authorization")
+	if header != "" {
+		t.Errorf("got header %q, want none", header)
+	}
+}

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -39,7 +39,7 @@ func ListFunctionsToken(gateway string, tlsInsecure bool, token string, namespac
 	if len(token) > 0 {
 		SetToken(getRequest, token)
 	} else {
-		SetAuth(getRequest, gateway)
+		AddAuth(getRequest, gateway)
 	}
 
 	if err != nil {


### PR DESCRIPTION
This commit saves oauth2 tokens to the openfaas config file with a
different auth type. The different auth type helps to determine whether
it is basic auth token or oauth2 token. It also refactors existing
config file function to cater the needs of auth command.

Fixes: #663

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In this PR I have implemented the saving oauth2 tokens to the config file as per discussed architecture and also added the support to the `faas-cli list` command. It this approach looks, I can go ahead and implement the same in other commands.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#663 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested it on my local with a gateway which has oauth2 enabled.

```
./faas-cli auth --auth-url https://dev-cqxdj5cl.auth0.com/authorize --audience https://dev-cqxdj5cl.auth0.com/api/v2/ --client-id "4cCLcJDzkvQ2aQ11aHt7iLpbVfuPDOEk" -g http://gw.viveksyngh.me
Starting local token server on port 31111
Launching browser: https://dev-cqxdj5cl.auth0.com/authorize?audience=https%3A%2F%2Fdev-cqxdj5cl.auth0.com%2Fapi%2Fv2%2F&client_id=4cCLcJDzkvQ2aQ11aHt7iLpbVfuPDOEk&nonce=1571748418287862000&redirect_uri=http%3A%2F%2F127.0.0.1%3A31111%2Foauth%2Fcallback&response_type=token&scope=&state=1571748418287860000
credentials saved for http://gw.viveksyngh.me
Example:
	./faas-cli list --gateway "http://gw.viveksyngh.me" --token "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UVTFOMFV3TVRVMVFURk..
➜  faas-cli git:(add-ouath-token-to-config) ✗ cat ~/.openfaas/config.yml
auths:
- gateway: http://gw.viveksyngh.me
  auth: oauth2
  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UVTFOMFV3TVR....
➜  faas-cli git:(add-ouath-token-to-config) ✗ ./faas-cli list -g http://gw.viveksyngh.me
Function                      	Invocations    	Replicas
cows                          	0              	1
➜  faas-cli git:(add-ouath-token-to-config) ✗ ./faas-cli login -u admin -p $PASSWORD -g http://gw.viveksyngh.me
WARNING! Using --password is insecure, consider using: cat ~/faas_pass.txt | faas-cli login -u user --password-stdin
Calling the OpenFaaS server to validate the credentials...
credentials saved for admin http://gw.viveksyngh.me
➜  faas-cli git:(add-ouath-token-to-config) ✗ cat ~/.openfaas/config.yml
auths:
- gateway: http://gw.viveksyngh.me
  auth: basic
  token: YWRtaW46ZWE4ZjM2NDFhMzYwMDliOGVmMTg4OWUzM2IyZDVmYWUzNjg2ZmY4Mg==
➜  faas-cli git:(add-ouath-token-to-config) ✗ ./faas-cli list -g http://gw.viveksyngh.me
Function                      	Invocations    	Replicas
cows                          	0              	1
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
