### PR TITLE
Add oauth2 token support to all commands

### DIFF
--- a/proxy/auth.go
+++ b/proxy/auth.go
@@ -16,12 +16,15 @@ func SetAuth(req *http.Request, gateway string) {
 		// no auth info found
 		return
 	}
-	username, password, err := config.DecodeAuth(authConfig.Token)
-	if err != nil {
-		// no auth info found
+
+	switch authConfig.Auth {
+	case config.BasicAuthType:
+		SetBasicAuth(req, authConfig)
+		return
+	case config.Oauth2AuthType:
+		SetOauth2(req, authConfig)
 		return
 	}
-	req.SetBasicAuth(username, password)
 }
 
 //SetToken sets authentication token
@@ -42,22 +45,4 @@ func SetBasicAuth(req *http.Request, authConfig config.AuthConfig) {
 //SetOauth2 set oauth2 token
 func SetOauth2(req *http.Request, authConfig config.AuthConfig) {
 	SetToken(req, authConfig.Token)
-}
-
-//AddAuth add authentication
-func AddAuth(req *http.Request, gateway string) {
-	authConfig, err := config.LookupAuthConfig(gateway)
-	if err != nil {
-		// no auth info found
-		return
-	}
-
-	switch authConfig.Auth {
-	case config.BasicAuthType:
-		SetBasicAuth(req, authConfig)
-		return
-	case config.Oauth2AuthType:
-		SetOauth2(req, authConfig)
-		return
-	}
 }

--- a/proxy/auth_test.go
+++ b/proxy/auth_test.go
@@ -48,7 +48,7 @@ func Test_SetAuth_SkipAuthorization(t *testing.T) {
 	}
 }
 
-func Test_AddAuth_Oauth2(t *testing.T) {
+func Test_SetAuth_Oauth2(t *testing.T) {
 	//setup store
 	config.DefaultDir, _ = ioutil.TempDir("", "faas-cli-auth-test")
 	config.DefaultFile = "authtest2.yml"
@@ -57,7 +57,7 @@ func Test_AddAuth_Oauth2(t *testing.T) {
 	config.UpdateAuthConfig(basicAuthURL, token, config.Oauth2AuthType)
 
 	req, _ := http.NewRequest("GET", basicAuthURL, nil)
-	AddAuth(req, basicAuthURL)
+	SetAuth(req, basicAuthURL)
 	header := req.Header.Get("Authorization")
 	expectedValue := "Bearer " + token
 	if header != expectedValue {
@@ -65,7 +65,7 @@ func Test_AddAuth_Oauth2(t *testing.T) {
 	}
 }
 
-func Test_AddAuth_BasicAuth(t *testing.T) {
+func Test_SetAuth_BasicAuth(t *testing.T) {
 	//setup store
 	config.DefaultDir, _ = ioutil.TempDir("", "faas-cli-auth-test")
 	config.DefaultFile = "authtest2.yml"
@@ -74,7 +74,7 @@ func Test_AddAuth_BasicAuth(t *testing.T) {
 	config.UpdateAuthConfig(basicAuthURL, token, config.BasicAuthType)
 
 	req, _ := http.NewRequest("GET", basicAuthURL, nil)
-	AddAuth(req, basicAuthURL)
+	SetAuth(req, basicAuthURL)
 	header := req.Header.Get("Authorization")
 	expectedValue := "Basic " + token
 	if header != expectedValue {
@@ -82,7 +82,7 @@ func Test_AddAuth_BasicAuth(t *testing.T) {
 	}
 }
 
-func Test_AddAuth_SkipAuthorization(t *testing.T) {
+func Test_SetAuth_SkipAuthorizationHeader(t *testing.T) {
 	//setup store
 	config.DefaultDir, _ = ioutil.TempDir("", "faas-cli-auth-test")
 	config.DefaultFile = "authtest2.yml"

--- a/proxy/list.go
+++ b/proxy/list.go
@@ -39,7 +39,7 @@ func ListFunctionsToken(gateway string, tlsInsecure bool, token string, namespac
 	if len(token) > 0 {
 		SetToken(getRequest, token)
 	} else {
-		AddAuth(getRequest, gateway)
+		SetAuth(getRequest, gateway)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Add oauth2 token support to all system commands which requires
authentication. This commit also removes AddAuth method and adds the
same logic to SetAuth method. I have tested this on my local local
kubernetes cluster with Oauth2 enabled using auth0.com.

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: #715 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
./faas-cli-darwin auth --auth-url https://dev-cqxdj5cl.auth0.com/authorize --audience https://dev-cqxdj5cl.auth0.com/api/v2/ --client-id "4cCLcJDzkvQ2aQ11aHt7iLpbVfuPDOEk" -g http://gw.viveksyngh.me
Launching browser: https://dev-cqxdj5cl.auth0.com/authorize?audience=https%3A%2F%2Fdev-cqxdj5cl.auth0.com%2Fapi%2Fv2%2F&client_id=4cCLcJDzkvQ2aQ11aHt7iLpbVfuPDOEk&nonce=1572763064187499000&redirect_uri=http%3A%2F%2F127.0.0.1%3A31111%2Foauth%2Fcallback&response_type=token&scope=&state=1572763064187498000
Starting local token server on port 31111
credentials saved for http://gw.viveksyngh.me
Example:
	./faas-cli list --gateway "http://gw.viveksyngh.me" --token "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UVTFOMFV3TVRVMVFURkNPVE0zUlRreU1UaEdSVEl3TURRNVJEYzVSVEZHTVVKQk56RTJNQSJ9.eyJpc3MiOiJodHRwczovL2Rldi1jcXhkajVjbC5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMTA5OTUzNzYyOTMyOTI4NzUxNzUiLCJhd"
➜  faas-cli git:(master) ✗ cat ~/.openfaas/config.yml
auths:
...
- gateway: http://gw.viveksyngh.me
  auth: oauth2
  token: eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9UVTFOMFV3TVRVMVFURkNPVE0zUlRreU1UaEdSVEl3TURRNVJEYzVSVEZHTVVKQk56RTJNQSJ9.eyJpc3MiOiJodHRwczovL2Rldi1jcXhkajVjbC5hdXRoMC5jb20vIiwic3ViIjoiZ29vZ2xlLW9hdXRoMnwxMTA5OTUzNzYyOTMyOTI4NzUxNzUiLCJhd
➜  faas-cli git:(master) ✗ export OPENFAAS_URL=http://gw.viveksyngh.me
➜  faas-cli git:(master) ✗ ./faas-cli-darwin version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  e83806606e949c64d4950f6d1edd3507cc6a8b33
 version: dev

Gateway
 uri:     http://gw.viveksyngh.me
 version: 0.18.0
 sha:     137b63e61fe55e0aea7df466931198c37817f743
 commit:  Add namespaces endpoint


Provider
 name:          faas-netes
 orchestration: kubernetes
 version:       0.9.6
 sha:           baa82ada2d81c5978c187ce3720dfcc4a4c26081
➜  faas-cli git:(master) ✗ ./faas-cli-darwin list
Function                      	Invocations    	Replicas
cows                          	0              	1
➜  faas-cli git:(master) ✗ ./faas-cli-darwin deploy -f https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Parsed: https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Deploying: markdown.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/markdown

Deploying: hubstats.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/hubstats

Deploying: nodeinfo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/nodeinfo

Deploying: echoit.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/echoit

Deploying: wordcount.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/wordcount

Deploying: base64.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/base64

➜  faas-cli git:(master) ✗ ./faas-cli-darwin list
Function                      	Invocations    	Replicas
base64                        	0              	1
cows                          	0              	1
echoit                        	0              	1
hubstats                      	0              	1
markdown                      	0              	1
nodeinfo                      	0              	1
wordcount                     	0              	1
➜  faas-cli git:(master) ✗ ./faas-cli-darwin describe cows
Name:                cows
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               alexellis2/ascii-cows-openfaas:0.1
Function process:
URL:                 http://gw.viveksyngh.me/function/cows
Async URL:           http://gw.viveksyngh.me/async-function/cows
Labels:              faas_function : cows
                     uid : 372284100
Annotations:         prometheus.io.scrape : false
                     topic : vm.powered.on
➜  faas-cli git:(master) ✗ ./faas-cli-darwin invoke cows
Reading from STDIN - hit (Control + D) to stop.
Hello
*        (__)
 \       (oo)
  \-------\/
   |     ||
   ||----||
  (oo)  (oo)
rollerskating cow
➜  faas-cli git:(master) ✗ ./faas-cli-darwin logs cows
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-11-03T06:42:47Z cows (cows-6db8bd4556-vpxqg) 2019/11/03 06:42:47 Forking fprocess.
2019-11-03T06:42:48Z cows (cows-6db8bd4556-vpxqg) 2019/11/03 06:42:48 Wrote 96 Bytes - Duration: 0.304968 seconds
2019-11-03T06:43:43Z cows (cows-6db8bd4556-vpxqg) 2019/11/03 06:43:43 Forking fprocess.
2019-11-03T06:43:43Z cows (cows-6db8bd4556-vpxqg) 2019/11/03 06:43:43 Wrote 195 Bytes - Duration: 0.099445 seconds
^C
➜  faas-cli git:(master) ✗ ./faas-cli-darwin delete echoit
Unknown command "delete" for "faas-cli"
➜  faas-cli git:(master) ✗ ./faas-cli-darwin rm echoit
Deleting: stronghash.
No existing function to remove
Deleting: nodejs-echo.
No existing function to remove
Deleting: shrink-image.
^C

➜  faas-cli git:(master) ✗ ./faas-cli-darwin remove echoit
Deleting: nodejs-echo.
No existing function to remove
Deleting: shrink-image.
No existing function to remove
Deleting: ruby-echo.
No existing function to remove
Deleting: url-ping.
No existing function to remove
Deleting: stronghash.
No existing function to remove
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret create test-secret --from-literal=test-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
Created: 202 Accepted
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret update test-secret --from-literal=udpated-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret
Updated: 202 Accepted
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret rm test-secret
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(master) ✗ kubectl edit -n openfaas deploy/gateway
deployment.extensions/gateway edited
➜  faas-cli git:(master) ✗
➜  faas-cli git:(master) ✗
➜  faas-cli git:(master) ✗ PASSWORD=$(kubectl get secret -n openfaas basic-auth -o jsonpath="{.data.basic-auth-password}" | base64 --decode; echo)
➜  faas-cli git:(master) ✗ ./faas-cli-darwin login -u admin -p $PASSWORD -g http://gw.viveksyngh.me
WARNING! Using --password is insecure, consider using: cat ~/faas_pass.txt | faas-cli login -u user --password-stdin
Calling the OpenFaaS server to validate the credentials...
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
credentials saved for admin http://gw.viveksyngh.me
➜  faas-cli git:(master) ✗ cat ~/.openfaas/config.yml
auths:
...
- gateway: http://gw.viveksyngh.me
  auth: basic
  token: YWRtaW46ZWE4ZjM2NDFhMzYwMDliOGVmMTg==
➜  faas-cli git:(master) ✗ ./faas-cli-darwin remove echoit -f https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Parsed: https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Deleting: base64.
Removing old function.
Deleting: markdown.
Removing old function.
Deleting: hubstats.
Removing old function.
Deleting: nodeinfo.
Removing old function.
Deleting: echoit.
Removing old function.
Deleting: wordcount.
Removing old function.
➜  faas-cli git:(master) ✗ ./faas-cli-darwin version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  e83806606e949c64d4950f6d1edd3507cc6a8b33
 version: dev

Gateway
 uri:     http://gw.viveksyngh.me
 version: 0.18.0
 sha:     137b63e61fe55e0aea7df466931198c37817f743
 commit:  Add namespaces endpoint


Provider
 name:          faas-netes
 orchestration: kubernetes
 version:       0.9.6
 sha:           baa82ada2d81c5978c187ce3720dfcc4a4c26081
➜  faas-cli git:(master) ✗ ./faas-cli-darwin deploy -f https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Parsed: https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Deploying: base64.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/base64

Deploying: markdown.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/markdown

Deploying: hubstats.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/hubstats

Deploying: nodeinfo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/nodeinfo

Deploying: echoit.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/echoit

Deploying: wordcount.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://gw.viveksyngh.me/function/wordcount

➜  faas-cli git:(master) ✗ ./faas-cli-darwin list
Function                      	Invocations    	Replicas
base64                        	0              	1
cows                          	0              	1
echoit                        	0              	1
hubstats                      	0              	1
markdown                      	0              	1
nodeinfo                      	0              	1
wordcount                     	0              	1
➜  faas-cli git:(master) ✗ ./faas-cli-darwin describe cows
Name:                cows
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               alexellis2/ascii-cows-openfaas:0.1
Function process:
URL:                 http://gw.viveksyngh.me/function/cows
Async URL:           http://gw.viveksyngh.me/async-function/cows
Labels:              faas_function : cows
                     uid : 372284100
Annotations:         prometheus.io.scrape : false
                     topic : vm.powered.on
➜  faas-cli git:(master) ✗ ./faas-cli-darwin invoke cows
Reading from STDIN - hit (Control + D) to stop.
Hello
         (__)
         (00)
  /-------\/
 / |     ||
*  ||----||
   ^^    ^^
Norwegian cow
➜  faas-cli git:(master) ✗ ./faas-cli-darwin logs cows
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
2019-11-03T06:55:10Z cows (cows-6db8bd4556-vpxqg) 2019/11/03 06:55:10 Forking fprocess.
2019-11-03T06:55:11Z cows (cows-6db8bd4556-vpxqg) 2019/11/03 06:55:11 Wrote 91 Bytes - Duration: 0.092995 seconds
^C

➜  faas-cli git:(master) ✗ ./faas-cli-darwin remove -f https://raw.githubusercontent.com/openfaas/faas/master/stack.yml --filter=echoit
Parsed: https://raw.githubusercontent.com/openfaas/faas/master/stack.yml
Deleting: echoit.
Removing old function.
➜  faas-cli git:(master) ✗ ./faas-cli-darwin list
Function                      	Invocations    	Replicas
base64                        	0              	1
cows                          	1              	1
echoit                        	0              	1
hubstats                      	0              	1
markdown                      	0              	1
nodeinfo                      	0              	1
wordcount                     	0              	1
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret create test-secret --from-literal=test-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
Created: 202 Accepted
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret update test-secret --from-literal=udpated-value
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret
Updated: 202 Accepted
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(master) ✗
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret rm test-secret
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(master) ✗ ./faas-cli-darwin secret ls
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
