### PR TITLE
Add namespace to outputted deployed URL

### DIFF
--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -50,6 +50,14 @@ type DeployFunctionSpec struct {
 	Namespace               string
 }
 
+func generateFuncStr(spec *DeployFunctionSpec) string {
+
+	if len(spec.Namespace) > 0 {
+		return fmt.Sprintf("%s.%s", spec.FunctionName, spec.Namespace)
+	}
+	return spec.FunctionName
+}
+
 // DeployFunction first tries to deploy a function and if it exists will then attempt
 // a rolling update. Warnings are suppressed for the second API call (if required.)
 func DeployFunction(spec *DeployFunctionSpec) int {
@@ -171,7 +179,7 @@ func Deploy(spec *DeployFunctionSpec, update bool, warnInsecureGateway bool) (in
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
 		deployOutput += fmt.Sprintf("Deployed. %s.\n", res.Status)
 
-		deployedURL := fmt.Sprintf("URL: %s/function/%s", gateway, spec.FunctionName)
+		deployedURL := fmt.Sprintf("URL: %s/function/%s", gateway, generateFuncStr(spec))
 		deployOutput += fmt.Sprintln(deployedURL)
 	case http.StatusUnauthorized:
 		deployOutput += fmt.Sprintln("unauthorized access, run \"faas-cli login\" to setup authentication for this server")

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -187,7 +187,7 @@ func Test_DeployFunction_generateFuncStr(t *testing.T) {
 
 	for _, testCase := range testCases {
 		funcStr := generateFuncStr(testCase.spec)
-		fmt.Println(funcStr)
+
 		if funcStr != testCase.expectedStr {
 			t.Fatalf("generateFuncStr %s\nwant: %s, got: %s", testCase.name, testCase.expectedStr, funcStr)
 		}

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -125,3 +125,72 @@ func Test_DeployFunction_MissingURLPrefix(t *testing.T) {
 		t.Fatalf("Want: %s\nGot: %s", expectedErrMsg, stdout)
 	}
 }
+
+func Test_DeployFunction_generateFuncStr(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		spec        *DeployFunctionSpec
+		expectedStr string
+		shouldErr   bool
+	}{
+		{
+			name: "No Namespace",
+			spec: &DeployFunctionSpec{
+				"fprocess",
+				"",
+				"funcName",
+				"image",
+				"dXNlcjpwYXNzd29yZA==",
+				"language",
+				false,
+				nil,
+				"network",
+				[]string{},
+				false,
+				[]string{},
+				map[string]string{},
+				map[string]string{},
+				FunctionResourceRequest{},
+				false,
+				tlsNoVerify,
+				"",
+				"",
+			},
+			expectedStr: "funcName",
+		},
+		{name: "With Namespace",
+			spec: &DeployFunctionSpec{
+				"fprocess",
+				"",
+				"funcName",
+				"image",
+				"dXNlcjpwYXNzd29yZA==",
+				"language",
+				false,
+				nil,
+				"network",
+				[]string{},
+				false,
+				[]string{},
+				map[string]string{},
+				map[string]string{},
+				FunctionResourceRequest{},
+				false,
+				tlsNoVerify,
+				"",
+				"nameSpace",
+			},
+			expectedStr: "funcName.nameSpace",
+		},
+	}
+
+	for _, testCase := range testCases {
+		funcStr := generateFuncStr(testCase.spec)
+		fmt.Println(funcStr)
+		if funcStr != testCase.expectedStr {
+			t.Fatalf("generateFuncStr %s\nwant: %s, got: %s", testCase.name, testCase.expectedStr, funcStr)
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When deploying a function the namespace will be displayed as it should in the gateway endpoint. The change is done by @rgee0 as per his commit. I tested and opened the PR from his name.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] Alex have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Closes #717 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built the cli and deployed nodeinfo
```
mdekov@mdekov-Lenovo-Y520-15IKBN:~/go/src/github.com/martindekov/newFunction$ ../../openfaas/faas-cli/faas-cli store deploy nodeinfo  -g http://192.168.99.100:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://192.168.99.100:31112/function/nodeinfo

mdekov@mdekov-Lenovo-Y520-15IKBN:~/go/src/github.com/martindekov/newFunction$ ../../openfaas/faas-cli/faas-cli store deploy nodeinfo  -g http://192.168.99.100:31112 -n prod
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://192.168.99.100:31112/function/nodeinfo.prod

```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] @rgee0's code follows the code style of this project.
- [ ] @rgee0's change requires a change to the documentation.
- [ ] @rgee0's have updated the documentation accordingly.
- [x] @rgee0've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide (almost 100% sure he did :smile: )
- [x] @rgee0 have signed-off his commits with `git commit -s`
- [x] @rgee0 have added tests to cover his changes.
- [x] All new and existing tests passed.
