### PR TITLE
Updated outdated kubeseal arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
 Now grab your pub-cert.pem file from your cluster, or use the official [OpenFaaS Cloud certificate](https://github.com/openfaas/cloud-functions/blob/master/pub-cert.pem).
 
 ```
-$ kubeseal --fetch-cert > pub-cert.pem
+$ kubeseal --fetch-cert --controller-name ofc-sealedsecrets-sealed-secrets > pub-cert.pem
 ```
 
 Then seal a secret using the OpenFaaS CLI:

--- a/README.md
+++ b/README.md
@@ -354,6 +354,11 @@ $ faas-cli cloud seal --name alexellis-github --literal hmac-secret=1234 --cert=
 
 You can then place the `secrets.yml` file in any public Git repo without others being able to read the contents.
 
+When SealedSecrets is installed by ofc-bootstrap
+
+The [scripts/export-sealed-secret-pubcert.sh](https://github.com/openfaas-incubator/ofc-bootstrap/blob/master/scripts/export-sealed-secret-pubcert.sh) does everything automatically.
+
+
 ### Environment variable overrides
 
 * `OPENFAAS_TEMPLATE_URL` - to set the default URL to pull templates from


### PR DESCRIPTION
In the ofc-bootstrap repo we have scripts thats overrides the default controller name to ofc-sealedsecrets-sealed-secrets