### PR TITLE
Restore getTemplateURL() in template pull

### DIFF
--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -4,6 +4,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -42,7 +43,7 @@ func runTemplatePull(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		repository = args[0]
 	}
-
+	repository = getTemplateURL(repository, os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
 	return pullTemplate(repository)
 }
 


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
This commit re-introduces the line which determines what value should be used for the repository before the code heads off into pullTemplate()

## Motivation and Context
Rework in #668 removed the call to getTemplateURL() which set `repository` to a value based on a precedence order.  This meant that an argument needed to be passed to `faas template pull` in order for it to complete without error, which had implications for pulling of the standard templates using the bare command.
- [x] I have raised an issue to propose this change (Fixes #720 )

## How Has This Been Tested?
Built from master:
```
$ ./faas-cli-darwin version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  270e4361ff935eb85c8ab51d48e338d9a5d1bd8b
 version: dev

Gateway
 uri:     http://127.0.0.1:8080
 version: 0.12.0
 sha:     ebc41933b7115e100b0a63137de43bd6abe34293
 commit:  Remove prometheus changes


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.6.1 
 sha:           3cac0ccc2e8bb7f567739a33f7d414cdb58440aa
$ ./faas-cli-darwin template pull
The repository URL must be a valid git repo uri
```

Added the missing line & rebuilt:
```
$ ./faas-cli-darwin version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  270e4361ff935eb85c8ab51d48e338d9a5d1bd8b
 version: dev

Gateway
 uri:     http://127.0.0.1:8080
 version: 0.12.0
 sha:     ebc41933b7115e100b0a63137de43bd6abe34293
 commit:  Remove prometheus changes


Provider
 name:          faas-swarm
 orchestration: swarm
 version:       0.6.1 
 sha:           3cac0ccc2e8bb7f567739a33f7d414cdb58440aa
$ ./faas-cli-darwin template pull
Fetch templates from repository: https://github.com/openfaas/templates.git at master
2019/11/07 19:15:34 Attempting to expand templates from https://github.com/openfaas/templates.git
2019/11/07 19:15:37 Fetched 18 template(s) : [csharp csharp-armhf dockerfile dockerfile-armhf go go-armhf java12 java8 node node-arm64 node-armhf node12 php7 python python-armhf python3 python3-armhf ruby] from https://github.com/openfaas/templates.git
```
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
