### PR TITLE
Add stack file template configuration to build

### DIFF
--- a/commands/template_pull_stack.go
+++ b/commands/template_pull_stack.go
@@ -18,7 +18,6 @@ var (
 func init() {
 	templatePullStackCmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite existing templates?")
 	templatePullStackCmd.Flags().BoolVar(&pullDebug, "debug", false, "Enable debug output")
-	templatePullStackCmd.PersistentFlags().StringVarP(&customRepoName, "repo", "r", "", "The custom name of the template repo")
 
 	templatePullCmd.AddCommand(templatePullStackCmd)
 }
@@ -41,10 +40,7 @@ func runTemplatePullStack(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(customRepoName) > 0 {
-		return pullSpecificTemplate(templatesConfig, customRepoName, cmd)
-	}
-	return pullAllTemplates(templatesConfig, cmd)
+	return pullStackTemplates(templatesConfig, cmd)
 }
 
 func loadTemplateConfig() ([]stack.TemplateSource, error) {
@@ -72,7 +68,7 @@ func readStackConfig() (stack.Configuration, error) {
 	return configField, nil
 }
 
-func pullAllTemplates(templateInfo []stack.TemplateSource, cmd *cobra.Command) error {
+func pullStackTemplates(templateInfo []stack.TemplateSource, cmd *cobra.Command) error {
 	for _, val := range templateInfo {
 		fmt.Printf("Pulling template: %s from configuration file: %s\n", val.Name, yamlFile)
 		if len(val.Source) == 0 {
@@ -97,15 +93,4 @@ func findTemplate(templateInfo []stack.TemplateSource, customName string) (speci
 		}
 	}
 	return nil
-}
-
-func pullSpecificTemplate(templateInfo []stack.TemplateSource, customName string, cmd *cobra.Command) error {
-	desiredTemplate := findTemplate(templateInfo, customName)
-	if desiredTemplate == nil {
-		return fmt.Errorf("Unable to find template repo with name: `%s`", customName)
-	}
-	if len(desiredTemplate.Source) == 0 {
-		return runTemplateStorePull(cmd, []string{desiredTemplate.Name})
-	}
-	return pullTemplate(desiredTemplate.Source)
 }

--- a/commands/template_pull_stack_test.go
+++ b/commands/template_pull_stack_test.go
@@ -98,68 +98,7 @@ func Test_pullAllTemplates(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {
-			actualError := pullAllTemplates(test.existingTemplates, templatePullStackCmd)
-			if actualError != nil && test.expectedError == false {
-				t.Errorf("Unexpected error: %s", actualError.Error())
-			}
-		})
-	}
-}
-
-func Test_pullSpecificTemplate(t *testing.T) {
-	tests := []struct {
-		title             string
-		desiredTemplate   string
-		existingTemplates []stack.TemplateSource
-		expectedError     bool
-	}{
-		{
-			title:           "Pull custom named template",
-			desiredTemplate: "my_powershell",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "my_powershell", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
-				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
-			},
-			expectedError: false,
-		},
-		{
-			title:           "Pull missing template",
-			desiredTemplate: "my_perl",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "my_powershell", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
-				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
-			},
-			expectedError: true,
-		},
-		{
-			title:           "Pull custom template from store",
-			desiredTemplate: "perl-alpine",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "perl-alpine"},
-				{Name: "my_rust", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
-			},
-			expectedError: false,
-		},
-		{
-			title:           "Pull specific template with invalid URL",
-			desiredTemplate: "my_powershell",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "my_powershell", Source: "invalidURL"},
-			},
-			expectedError: true,
-		},
-		{
-			title:           "Pull template missing from store",
-			desiredTemplate: "my_powershell",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "my_powershell"},
-			},
-			expectedError: true,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.title, func(t *testing.T) {
-			actualError := pullSpecificTemplate(test.existingTemplates, test.desiredTemplate, templatePullStackCmd)
+			actualError := pullStackTemplates(test.existingTemplates, templatePullStackCmd)
 			if actualError != nil && test.expectedError == false {
 				t.Errorf("Unexpected error: %s", actualError.Error())
 			}

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -87,9 +87,10 @@ type EnvironmentFile struct {
 
 // Services root level YAML file to define FaaS function-set
 type Services struct {
-	Version   string              `yaml:"version,omitempty"`
-	Functions map[string]Function `yaml:"functions,omitempty"`
-	Provider  Provider            `yaml:"provider,omitempty"`
+	Version            string              `yaml:"version,omitempty"`
+	Functions          map[string]Function `yaml:"functions,omitempty"`
+	Provider           Provider            `yaml:"provider,omitempty"`
+	StackConfiguration StackConfiguration  `yaml:"configuration,omitempty"`
 }
 
 // LanguageTemplate read from template.yml within root of a language template folder


### PR DESCRIPTION
Adding functionality which will pull templates defined in the
function YAML file. Additionaly added overwrite flag to the
build command in order to enable the command to overwrite
templates. Also removed the filtering funcitonality from template
pull stack command and renamed the method which will be used to
pull the configuration

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

Configuration in stack.yml file was used only by `template pull stack` command. Now the configuration is additionally red in the building phase of the function.

## Description
<!--- Describe your changes in detail -->

Adding `--overwrite` flag to the `faas-cli build` command as it reads and pull templates
defined in the function YAML file. Removing the filtering logic of the `template pull stack`
along with its testing as requested and renaming the method responsible for the pulling. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #725 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Appended to a new function's `stack.yml` the following:

```
configuration:
  templates:
    - name: perl-alpine
    - name: rusta
      source: https://github.com/openfaas-incubator/openfaas-rust-template
```
and tested
* `faas-cli build` - pulled templates if not there, if there used them cached
* `faas-cli build --overwrite` - pulled templates no matter present or not
* `faas-cli template pull stack` - same as above
* `faas-cli template pull stack --overwrite` - same as above

Additional case when there are already existing templates(`perl-alpine`,`rust`,`valum-http`) and we decide to add additional template(`crystal-http`) to the configuration the following happens.

```
$ faas-cli build 
Pulling template: perl-alpine from configuration file: stack.yml
Fetch templates from repository: https://github.com/tmiklas/openfaas-perl-templates at master
2019/11/16 13:21:32 Attempting to expand templates from https://github.com/tmiklas/openfaas-perl-templates
2019/11/16 13:21:34 Cannot overwrite the following 1 template(s): [perl-alpine]
2019/11/16 13:21:34 Fetched 0 template(s) : [] from https://github.com/tmiklas/openfaas-perl-templates
Pulling template: rusta from configuration file: stack.yml
Fetch templates from repository: https://github.com/openfaas-incubator/openfaas-rust-template at master
2019/11/16 13:21:34 Attempting to expand templates from https://github.com/openfaas-incubator/openfaas-rust-template
2019/11/16 13:21:36 Cannot overwrite the following 1 template(s): [rust]
2019/11/16 13:21:36 Fetched 0 template(s) : [] from https://github.com/openfaas-incubator/openfaas-rust-template
Pulling template: vala-http from configuration file: stack.yml
Fetch templates from repository: https://github.com/affix/openfaas-templates-affix/ at master
2019/11/16 13:21:36 Attempting to expand templates from https://github.com/affix/openfaas-templates-affix/
2019/11/16 13:21:37 Cannot overwrite the following 4 template(s): [lua53 swift vala-valum vala-valum-http]
2019/11/16 13:21:37 Fetched 0 template(s) : [] from https://github.com/affix/openfaas-templates-affix/
Pulling template: crystal-http from configuration file: stack.yml
Fetch templates from repository: https://github.com/koffeinfrei/crystal-http-template at master
2019/11/16 13:21:37 Attempting to expand templates from https://github.com/koffeinfrei/crystal-http-template
2019/11/16 13:21:39 Fetched 1 template(s) : [crystal-http] from https://github.com/koffeinfrei/crystal-http-template
```
Removed the appended template configuration and re-ran the tests mentioned above and the building process was as it were without the change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
