### PR TITLE
Download kubeseal via faas-cli cloud seal command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,26 +330,29 @@ Commands:
 
 You can use the CLI to seal a secret for usage on public Git repo. The pre-requisite is that you have installed [SealedSecrets](https://github.com/bitnami-labs/sealed-secrets) and exported your public key from your cluster as `pub-cert.pem`.
 
-Install `kubeseal`:
+Install `kubeseal` using `faas-cli` or the [SealedSecrets docs](https://github.com/bitnami-labs/sealed-secrets):
 
+```sh
+$ faas-cli cloud seal --download
 ```
-release=$(curl --silent "https://api.github.com/repos/bitnami-labs/sealed-secrets/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
-GOOS=$(go env GOOS)
-GOARCH=$(go env GOARCH)
-wget https://github.com/bitnami/sealed-secrets/releases/download/$release/kubeseal-$GOOS-$GOARCH
-sudo install -m 755 kubeseal-$GOOS-$GOARCH /usr/local/bin/kubeseal
+
+You can also download a specific version:
+
+```sh
+$ faas-cli cloud seal --download --download-version v0.8.0
 ```
 
 Now grab your pub-cert.pem file from your cluster, or use the official [OpenFaaS Cloud certificate](https://github.com/openfaas/cloud-functions/blob/master/pub-cert.pem).
 
-```
+```sh
 $ kubeseal --fetch-cert --controller-name ofc-sealedsecrets-sealed-secrets > pub-cert.pem
 ```
 
 Then seal a secret using the OpenFaaS CLI:
 
 ```
-$ faas-cli cloud seal --name alexellis-github --literal hmac-secret=1234 --cert=pub-cert.pem
+$ faas-cli cloud seal --name alexellis-github \
+  --literal hmac-secret=1234 --cert=pub-cert.pem
 ```
 
 You can then place the `secrets.yml` file in any public Git repo without others being able to read the contents.

--- a/commands/cloud.go
+++ b/commands/cloud.go
@@ -8,21 +8,29 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
 
+	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/schema"
 	"github.com/spf13/cobra"
 )
 
 var (
-	namespace  string
-	name       string
-	literal    *[]string
-	outputFile string
-	fromFile   *[]string
-	certFile   string
+	namespace       string
+	name            string
+	literal         *[]string
+	outputFile      string
+	fromFile        *[]string
+	certFile        string
+	download        bool
+	downloadVersion string
 )
 
 func init() {
@@ -34,6 +42,9 @@ func init() {
 	cloudSealCmd.Flags().StringVarP(&certFile, "cert", "c", "pub-cert.pem", "Filename of public certificate")
 
 	cloudSealCmd.Flags().StringVarP(&outputFile, "output-file", "o", "secrets.yml", "Output file for secrets")
+
+	cloudSealCmd.Flags().BoolVar(&download, "download", false, "Download the kubeseal binary required for this command, see also --download-version")
+	cloudSealCmd.Flags().StringVar(&downloadVersion, "download-version", "", "Specifiy a kubeseal version to download")
 
 	literal = cloudSealCmd.Flags().StringArrayP("literal", "l", []string{}, "Secret literal key-value data")
 
@@ -49,15 +60,22 @@ var cloudCmd = &cobra.Command{
 }
 
 var cloudSealCmd = &cobra.Command{
-	Use:   `seal [--name secret-name] [--literal k=v] [--from-file] [--namespace openfaas-fn]`,
+	Use:   `seal [--name secret-name] [--literal k=v] [--from-file] [--namespace openfaas-fn] [--download]`,
 	Short: "Seal a secret for usage with OpenFaaS Cloud",
 	Example: `  faas-cli cloud seal --name alexellis-github --literal hmac-secret=c4488af0c158e8c
   faas-cli cloud seal --name alexellis-token --from-file api-key.txt
-  faas-cli cloud seal --name alexellis-token --literal a=b --literal c=d --cert pub-cert.pem`,
+  faas-cli cloud seal --name alexellis-token --literal a=b --literal c=d --cert pub-cert.pem
+  faas-cli cloud seal --download
+  faas-cli cloud seal --download --download-version v0.9.5`,
 	RunE: runCloudSeal,
 }
 
 func runCloudSeal(cmd *cobra.Command, args []string) error {
+
+	if download {
+		return downloadKubeSeal()
+	}
+
 	if len(name) == 0 {
 		return fmt.Errorf("--name is required")
 	}
@@ -132,4 +150,99 @@ func runCloudSeal(cmd *cobra.Command, args []string) error {
 
 	return nil
 
+}
+
+func downloadKubeSeal() error {
+	releases := "https://github.com/bitnami-labs/sealed-secrets/releases/latest"
+
+	releaseVersion := downloadVersion
+	if len(downloadVersion) == 0 {
+		version, err := findRelease(releases)
+		if err != nil {
+			return err
+		}
+		releaseVersion = version
+	}
+
+	osVal := runtime.GOOS
+	arch := runtime.GOARCH
+
+	if arch == "x86_64" {
+		arch = "amd64"
+	}
+
+	downloadURL := "https://github.com/bitnami/sealed-secrets/releases/download/" + releaseVersion + "/kubeseal-" + osVal + "-" + arch
+
+	fmt.Printf("Starting download of kubeseal %s, this could take a few moments.\n", releaseVersion)
+	output, err := downloadBinary(http.DefaultClient, downloadURL, "kubeseal")
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf(`Download completed, please run:
+
+  chmod +x %s
+  sudo install %s /usr/local/bin/
+  /usr/local/bin/kubeseal --version
+
+  `, output, output)
+
+	return nil
+}
+
+func findRelease(url string) (string, error) {
+	timeout := time.Second * 5
+	client := proxy.MakeHTTPClient(&timeout, false)
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	req, err := http.NewRequest(http.MethodHead, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+	if res.StatusCode != 302 {
+		return "", fmt.Errorf("incorrect status code: %d", res.StatusCode)
+	}
+
+	loc := res.Header.Get("Location")
+	if len(loc) == 0 {
+		return "", fmt.Errorf("unable to determine release of kubeseal")
+	}
+	version := loc[strings.LastIndex(loc, "/")+1:]
+	return version, nil
+}
+
+func downloadBinary(client *http.Client, url, name string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	tempDir := os.TempDir()
+	outputPath := path.Join(tempDir, name)
+	if res.Body != nil {
+		defer res.Body.Close()
+		res, _ := ioutil.ReadAll(res.Body)
+
+		err := ioutil.WriteFile(outputPath, res, 0600)
+		if err != nil {
+			return "", err
+		}
+		return outputPath, nil
+	}
+	return "", fmt.Errorf("error downloading %s", url)
 }

--- a/commands/cloud.go
+++ b/commands/cloud.go
@@ -44,7 +44,7 @@ func init() {
 	cloudSealCmd.Flags().StringVarP(&outputFile, "output-file", "o", "secrets.yml", "Output file for secrets")
 
 	cloudSealCmd.Flags().BoolVar(&download, "download", false, "Download the kubeseal binary required for this command, see also --download-version")
-	cloudSealCmd.Flags().StringVar(&downloadVersion, "download-version", "", "Specifiy a kubeseal version to download")
+	cloudSealCmd.Flags().StringVar(&downloadVersion, "download-version", "", "Specify a kubeseal version to download")
 
 	literal = cloudSealCmd.Flags().StringArrayP("literal", "l", []string{}, "Secret literal key-value data")
 
@@ -149,7 +149,6 @@ func runCloudSeal(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s written.\n", outputFile)
 
 	return nil
-
 }
 
 func downloadKubeSeal() error {
@@ -183,10 +182,10 @@ func downloadKubeSeal() error {
 	fmt.Printf(`Download completed, please run:
 
   chmod +x %s
+  %s --version
   sudo install %s /usr/local/bin/
-  /usr/local/bin/kubeseal --version
 
-  `, output, output)
+  `, output, output, output)
 
 	return nil
 }

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -18,7 +18,10 @@ func Test_addVersionDev(t *testing.T) {
 	version.GitCommit = "sha-test"
 
 	stdOut := test.CaptureStdout(func() {
-		faasCmd.SetArgs([]string{"version"})
+		faasCmd.SetArgs([]string{
+			"version",
+			"--warn-update=false",
+		})
 		faasCmd.Execute()
 	})
 
@@ -38,7 +41,10 @@ func Test_addVersion(t *testing.T) {
 	version.Version = "version.tag"
 
 	stdOut := test.CaptureStdout(func() {
-		faasCmd.SetArgs([]string{"version"})
+		faasCmd.SetArgs([]string{
+			"version",
+			"--warn-update=false",
+		})
 		faasCmd.Execute()
 	})
 
@@ -57,7 +63,11 @@ func Test_addVersion_short_version(t *testing.T) {
 	version.Version = "version.tag"
 
 	stdOut := test.CaptureStdout(func() {
-		faasCmd.SetArgs([]string{"version", "--short-version"})
+		faasCmd.SetArgs([]string{
+			"version",
+			"--warn-update=false",
+			"--short-version",
+		})
 		faasCmd.Execute()
 	})
 
@@ -165,6 +175,7 @@ func executeVersionCmd(t *testing.T, responseBody string) (versionInfo string, g
 		faasCmd.SetArgs([]string{
 			"version",
 			"--gateway=" + s.URL,
+			"--warn-update=false",
 		})
 		faasCmd.Execute()
 	})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Download kubeseal via faas-cli cloud seal command 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes: #722 and closes: #724 by @utsavanand2 💪 🙏 

This is the combination of the approach taken by @utsavanand2 and
the guidance offered by @rgee0 and @LucasRoesler combined into
a single PR. It also uses the GitHub HTTP website instead of the
GitHub API - the GitHub API has a rate-limit of 50 requests per
hour and is likely to get exhausted quickly, so this approach
removes the issue in #724.

Given that there is only one executable needed at this stage, the
download command idea was removed in favour of a simple flag. The
flag will be updated in the README.md and documentation after
the merge and release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with --download and --download-version with an override
on MacOS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
