### PR TITLE
Depreciate generic "faas" provider for "openfaas"

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,8 +1,6 @@
 provider:
   name: openfaas
   gateway: http://127.0.0.1:8080  # can be a remote server
-  network: "func_functions"       # this is optional and defaults to func_functions
-
 
 ## Note for Kubernetes memory specifications:
 ## Run: `sed -ie s/40m/40Mi/g stack.yml`

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -18,8 +18,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-const providerName = "faas"
-const providerNameLong = "openfaas"
+const legacyProviderName = "faas"
+const providerName = "openfaas"
 const defaultSchemaVersion = "1.0"
 
 // ValidSchemaVersions available schema versions
@@ -94,8 +94,8 @@ func ParseYAMLData(fileData []byte, regex string, filter string, envsubst bool) 
 		}
 	}
 
-	if services.Provider.Name != providerName && services.Provider.Name != providerNameLong {
-		return nil, fmt.Errorf("['%s', '%s'] is the only valid provider for this tool - found: %s", providerName, providerNameLong, services.Provider.Name)
+	if services.Provider.Name != providerName {
+		return nil, fmt.Errorf(`['%s'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: %s`, providerName, services.Provider.Name)
 	}
 
 	if len(services.Version) > 0 && !IsValidSchemaVersion(services.Version) {

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -335,8 +335,8 @@ func Test_ParseYAMLData_ProviderValues(t *testing.T) {
 		file          string
 	}{
 		{
-			title:         "Provider is faas and gives no error",
-			provider:      "faas",
+			title:         "Provider is openfaas and gives no error",
+			provider:      "openfaas",
 			expectedError: "",
 			file: `version: 1.0
 provider:
@@ -347,7 +347,7 @@ provider:
 		},
 		{
 			title:         "Provider is openfaas and gives no error",
-			provider:      "faas",
+			provider:      "openfaas",
 			expectedError: "",
 			file: `version: 1.0
 provider:
@@ -357,12 +357,23 @@ provider:
 `,
 		},
 		{
-			title:         "Provider is serverless-openfaas and gives error",
+			title:         "Provider is faas and gives error",
 			provider:      "faas",
-			expectedError: "['faas', 'openfaas'] is the only valid provider for this tool - found: serverless-openfaas",
+			expectedError: `['openfaas'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: faas`,
 			file: `version: 1.0
 provider:
-  name: serverless-openfaas
+  name: faas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"
+`,
+		},
+		{
+			title:         "Provider is serverless and gives error",
+			provider:      "faas",
+			expectedError: `['openfaas'] is the only valid "provider.name" for the OpenFaaS CLI, but you gave: serverless`,
+			file: `version: 1.0
+provider:
+  name: serverless
   gateway: http://127.0.0.1:8080
   network: "func_functions"
 `,


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Depreciate generic "faas" provider for "openfaas"

## Motivation and Context

The openfaas provider was introduced as a default over 8 months
ago, so anyone still using the generic and legacy term "faas"
should update their stack.yml file. Simply replacing "faas" with
"openfaas" is sufficient, all files created over the past
8 months+ should already have this text.

This is the final step of the depreciation of the legacy
provider "faas" and has no bearing on functionality.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With the stack.yml file and through the unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
