### PR TITLE
Make any template beginning with 'dockerfile' not a language template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ obj
 *.swp
 
 .idea
+*.iml
 .DS_Store
 
 

--- a/builder/build.go
+++ b/builder/build.go
@@ -372,5 +372,5 @@ func deDuplicate(buildOptPackages []string) []string {
 }
 
 func isLanguageTemplate(language string) bool {
-	return strings.ToLower(language) != "dockerfile"
+	return !strings.HasPrefix(strings.ToLower(language), "dockerfile")
 }

--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -19,6 +19,17 @@ func Test_isLanguageTemplate_Dockerfile(t *testing.T) {
 	}
 }
 
+func Test_isLanguageTemplate_Dockerfile_armhf(t *testing.T) {
+
+	language := "Dockerfile-armhf"
+
+	want := false
+	got := isLanguageTemplate(language)
+	if got != want {
+		t.Errorf("language: %s got %v, want %v", language, got, want)
+	}
+}
+
 func Test_isLanguageTemplate_Node(t *testing.T) {
 
 	language := "node"


### PR DESCRIPTION
Required to correctly process dockerfile-armhf template when building

## Description
Change isLanguageTemplate function to check that the lower cased language doesn't start with 'dockerfile' as opposed to just equals 'dockerfile'.

## Motivation and Context
Stops faas-cli build from appending /function to lang=Dockerfile-armhf build.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Issue:  https://github.com/openfaas/faas-cli/issues/734

## How Has This Been Tested?
Tested by running version of faas-cli built with this change on armhf arch with lang=Dockerfile-armhf template.  Checked that this builds correctly, and that the function can be deployed to an openfaas cluster successfully.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
