### PR TITLE
Add --namespace to invoke command

### DIFF
--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -16,18 +16,21 @@ import (
 )
 
 var (
-	contentType string
-	query       []string
-	headers     []string
-	invokeAsync bool
-	httpMethod  string
-	sigHeader   string
-	key         string
+	contentType             string
+	query                   []string
+	headers                 []string
+	invokeAsync             bool
+	httpMethod              string
+	sigHeader               string
+	key                     string
+	functionInvokeNamespace string
 )
 
 func init() {
 	// Setup flags that are used by multiple commands (variables defined in faas.go)
 	invokeCmd.Flags().StringVar(&functionName, "name", "", "Name of the deployed function")
+	invokeCmd.Flags().StringVarP(&functionInvokeNamespace, "namespace", "n", "", "Namespace of the deployed function")
+
 	invokeCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 
 	invokeCmd.Flags().StringVar(&contentType, "content-type", "text/plain", "The content-type HTTP header such as application/json")
@@ -54,7 +57,7 @@ var invokeCmd = &cobra.Command{
   faas-cli invoke env --header X-Ping-Url=http://request.bin/etc
   faas-cli invoke resize-img --async -H "X-Callback-Url=http://gateway:8080/function/send2slack" < image.png
   faas-cli invoke env -H X-Ping-Url=http://request.bin/etc
-  faas-cli invoke flask --method GET
+  faas-cli invoke flask --method GET --namespace dev
   faas-cli invoke env --sign X-GitHub-Event --key yoursecret`,
 	RunE: runInvoke,
 }
@@ -105,7 +108,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 		headers = append(headers, signedHeader)
 	}
 
-	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType, query, headers, invokeAsync, httpMethod, tlsInsecure)
+	response, err := proxy.InvokeFunction(gatewayAddress, functionName, &functionInput, contentType, query, headers, invokeAsync, httpMethod, tlsInsecure, functionInvokeNamespace)
 	if err != nil {
 		return err
 	}

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -15,7 +15,7 @@ import (
 )
 
 // InvokeFunction a function
-func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType string, query []string, headers []string, async bool, httpMethod string, tlsInsecure bool) (*[]byte, error) {
+func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType string, query []string, headers []string, async bool, httpMethod string, tlsInsecure bool, namespace string) (*[]byte, error) {
 	var resBytes []byte
 
 	gateway = strings.TrimRight(gateway, "/")
@@ -45,7 +45,11 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 		return nil, httpMethodErr
 	}
 
-	gatewayURL := gateway + functionEndpoint + name + qs
+	gatewayURL := gateway + functionEndpoint + name
+	if len(namespace) > 0 {
+		gatewayURL += "." + namespace
+	}
+	gatewayURL += qs
 
 	req, err := http.NewRequest(httpMethod, gatewayURL, reader)
 	if err != nil {

--- a/proxy/invoke_test.go
+++ b/proxy/invoke_test.go
@@ -29,6 +29,7 @@ func Test_InvokeFunction(t *testing.T) {
 		false,
 		http.MethodPost,
 		tlsNoVerify,
+		"",
 	)
 
 	if err != nil {
@@ -51,6 +52,7 @@ func Test_InvokeFunction_Async(t *testing.T) {
 		true,
 		http.MethodPost,
 		tlsNoVerify,
+		"",
 	)
 
 	if err != nil {
@@ -73,6 +75,7 @@ func Test_InvokeFunction_Not2xx(t *testing.T) {
 		false,
 		http.MethodPost,
 		tlsNoVerify,
+		"",
 	)
 
 	if err == nil {
@@ -98,6 +101,7 @@ func Test_InvokeFunction_MissingURLPrefix(t *testing.T) {
 		false,
 		http.MethodPost,
 		tlsNoVerify,
+		"",
 	)
 
 	if err == nil {


### PR DESCRIPTION
This appears to be a miss in the PR that added namespace support.

Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add --namespace to invoke command

## Motivation and Context

Missing from #693 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```sh
go build && uname|./faas-cli invoke --namespace=dev stronghash -g 192.168.0.26:31112

# An existing command with --namespace also worked

go build && uname|./faas-cli list -g 192.168.0.26:31112 -n dev
Function                        Invocations     Replicas
stronghash                      0               1    
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] All new and existing tests passed.
