### PR TITLE
Describe function command should include namespace in urls

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -88,7 +88,7 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 		status = "Ready"
 	}
 
-	url, asyncURL := getFunctionURLs(gatewayAddress, functionName)
+	url, asyncURL := getFunctionURLs(gatewayAddress, functionName, functionNamespace)
 
 	funcDesc := schema.FunctionDescription{
 		Name:              function.Name,
@@ -109,9 +109,18 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getFunctionURLs(gateway string, functionName string) (string, string) {
+func getFunctionURLs(gateway string, functionName string, functionNamespace string) (string, string) {
 	gateway = strings.TrimRight(gateway, "/")
-	return gateway + "/function/" + functionName, gateway + "/async-function/" + functionName
+
+	url := gateway + "/function/" + functionName
+	asyncURL := gateway + "/async-function/" + functionName
+
+	if functionNamespace != "" {
+		url += "." + functionNamespace
+		asyncURL += "." + functionNamespace
+	}
+
+	return url, asyncURL
 }
 
 func printFunctionDescription(funcDesc schema.FunctionDescription) {

--- a/commands/describe_test.go
+++ b/commands/describe_test.go
@@ -1,0 +1,28 @@
+package commands
+
+import "testing"
+
+func Test_getFunctionURLs(t *testing.T) {
+	cases := []struct {
+		name              string
+		gateway           string
+		functionName      string
+		functionNamespace string
+		expectedURL       string
+		expectedAsyncURL  string
+	}{
+		{"localhost", "http://127.0.0.1:8080", "figlet", "alpha", "http://127.0.0.1:8080/function/figlet.alpha", "http://127.0.0.1:8080/async-function/figlet.alpha"},
+		{"secure site", "https://example.com", "nodeinfo", "beta", "https://example.com/function/nodeinfo.beta", "https://example.com/async-function/nodeinfo.beta"},
+		{"no namespace", "https://example.com:31112", "nodeinfo", "", "https://example.com:31112/function/nodeinfo", "https://example.com:31112/async-function/nodeinfo"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			url, asyncURL := getFunctionURLs(tc.gateway, tc.functionName, tc.functionNamespace)
+
+			if url != tc.expectedURL || asyncURL != tc.expectedAsyncURL {
+				t.Fatalf("incorrect URL(s), want: %q and %q, got: %q and %q", tc.expectedURL, tc.expectedAsyncURL, url, asyncURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Name spaces have been appended to both the url and async url in the command package function getFunctionURLs.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #739 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have created a table test that ensures the expected URLs are generated for DNSs with and without ports, as well as for functions with and without namespaces.

I also built the faas-cli app on my MacOS using MiniKube and OpenFaaS installed with k3sup. I then enabled namespaces, a new feature as of this comment. I followed the instructions in the following pages to set up my system:
* https://docs.openfaas.com/deployment/kubernetes
* https://docs.openfaas.com/reference/namespaces/

I ran the describe command with `./faas-client describe <function> -n <namespace>` and `./faas-client describe <function>` and saw the expected URLs. See screenshot:
<img width="551" alt="Screen Shot 2019-12-19 at 5 02 25 PM" src="https://user-images.githubusercontent.com/17328443/71221426-75297c00-2281-11ea-9d63-0b074bd34ebf.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
