### PR TITLE
Return an error if kubeseal release is not found

### DIFF
--- a/commands/cloud.go
+++ b/commands/cloud.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -228,8 +229,12 @@ func downloadBinary(client *http.Client, url, name string) (string, error) {
 	}
 
 	res, err := client.Do(req)
+
 	if err != nil {
 		return "", err
+	}
+	if res.StatusCode != http.StatusOK {
+		return "", errors.New(fmt.Sprintf("could not find release, http status code was %d, release may not exist for this architecture", res.StatusCode))
 	}
 	tempDir := os.TempDir()
 	outputPath := path.Join(tempDir, name)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Based on suggestion in  #749 to return error on non-200 status code rather than download the 404 HTML page.

We now show the user we got a non 200 status code, and return.

Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```
GOARCH=arm GOARM=6 go build

#On ARM 
pi@raspberrypi:~ $ ./faas-cli cloud seal --download
Starting download of kubeseal v0.9.6, this could take a few moments.
Could not find release, http status code was 404, release may not exist for this archetecture

# On AMD64
heyal@heyal-xps:~/go/src/github.com/openfaas/faas-cli$ ./faas-cli cloud seal --download
Starting download of kubeseal v0.9.6, this could take a few moments.
Download completed, please run:

  chmod +x /tmp/kubeseal
  /tmp/kubeseal --version
  sudo install /tmp/kubeseal /usr/local/bin/

```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
