### PR TITLE
[Ready for Review] Client SDK for proxy API calls

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,3 +53,4 @@
 [[constraint]]
   name = "github.com/alexellis/go-execute"
   version = "0.3.0"
+

--- a/commands/general.go
+++ b/commands/general.go
@@ -1,0 +1,101 @@
+package commands
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/openfaas/faas-cli/config"
+	"github.com/openfaas/faas-cli/proxy"
+)
+
+var (
+	commandTimeout = 60 * time.Second
+)
+
+//CLIAuth auth struct for the CLI
+type CLIAuth struct {
+	Username string
+	Password string
+	Token    string
+}
+
+//BasicAuth basic authentication type
+type BasicAuth struct {
+	username string
+	password string
+}
+
+func (auth *BasicAuth) Set(req *http.Request) error {
+	req.SetBasicAuth(auth.username, auth.password)
+	return nil
+}
+
+//BearerToken bearer token
+type BearerToken struct {
+	token string
+}
+
+func (c *BearerToken) Set(req *http.Request) error {
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	return nil
+}
+
+//NewCLIAuth returns a new CLI Auth
+func NewCLIAuth(token string, gateway string) proxy.ClientAuth {
+	authConfig, _ := config.LookupAuthConfig(gateway)
+
+	var (
+		username    string
+		password    string
+		bearerToken string
+	)
+
+	if authConfig.Auth == config.BasicAuthType {
+		username, password, _ = config.DecodeAuth(authConfig.Token)
+
+		return &BasicAuth{
+			username: username,
+			password: password,
+		}
+
+	}
+
+	// User specified token gets priority
+	if len(token) > 0 {
+		bearerToken = token
+	} else {
+		bearerToken = authConfig.Token
+	}
+
+	return &BearerToken{
+		token: bearerToken,
+	}
+}
+
+func GetDefaultCLITransport(tlsInsecure bool, timeout *time.Duration) *http.Transport {
+	if timeout != nil || tlsInsecure {
+		tr := &http.Transport{
+			Proxy:             http.ProxyFromEnvironment,
+			DisableKeepAlives: false,
+		}
+
+		if timeout != nil {
+			tr.DialContext = (&net.Dialer{
+				Timeout: *timeout,
+			}).DialContext
+
+			tr.IdleConnTimeout = 120 * time.Millisecond
+			tr.ExpectContinueTimeout = 1500 * time.Millisecond
+		}
+
+		if tlsInsecure {
+			tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: tlsInsecure}
+		}
+		tr.DisableKeepAlives = false
+
+		return tr
+	}
+	return nil
+}

--- a/commands/list.go
+++ b/commands/list.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -54,9 +55,12 @@ func runList(cmd *cobra.Command, args []string) error {
 			yamlGateway = services.Provider.GatewayURL
 		}
 	}
-
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
-	functions, err := proxy.ListFunctionsToken(gatewayAddress, tlsInsecure, token, functionNamespace)
+
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	proxyClient := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
+	functions, err := proxyClient.ListFunctions(context.Background(), functionNamespace)
 	if err != nil {
 		return err
 	}

--- a/commands/namespaces.go
+++ b/commands/namespaces.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -29,14 +30,14 @@ var namespacesCmd = &cobra.Command{
 
 func runNamespaces(cmd *cobra.Command, args []string) error {
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
-
-	namespaces, err := proxy.ListNamespacesToken(gatewayAddress, tlsInsecure, token)
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	client := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
+	namespaces, err := client.ListNamespaces(context.Background())
 	if err != nil {
 		return err
 	}
-
 	printNamespaces(namespaces)
-
 	return nil
 }
 

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -59,6 +60,11 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	proxyclient := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
+	ctx := context.Background()
+
 	if len(services.Functions) > 0 {
 		if len(services.Provider.Network) == 0 {
 			services.Provider.Network = defaultNetwork
@@ -68,7 +74,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 			function.Name = k
 			fmt.Printf("Deleting: %s.\n", function.Name)
 
-			proxy.DeleteFunctionToken(gatewayAddress, function.Name, tlsInsecure, token, functionNamespace)
+			proxyclient.DeleteFunction(ctx, function.Name, functionNamespace)
 		}
 	} else {
 		if len(args) < 1 {
@@ -77,7 +83,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
-		proxy.DeleteFunctionToken(gatewayAddress, functionName, tlsInsecure, token, functionNamespace)
+		proxyclient.DeleteFunction(ctx, functionName, functionNamespace)
 	}
 
 	return nil

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -109,9 +110,11 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
 		fmt.Println(msg)
 	}
-
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	client := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
 	fmt.Println("Creating secret: " + secret.Name)
-	_, output := proxy.CreateSecretToken(gatewayAddress, secret, tlsInsecure, token)
+	_, output := client.CreateSecret(context.Background(), secret)
 	fmt.Printf(output)
 
 	return nil

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -47,7 +48,10 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		fmt.Println(msg)
 	}
 
-	secrets, err := proxy.GetSecretListToken(gatewayAddress, tlsInsecure, token, functionNamespace)
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	client := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
+	secrets, err := client.GetSecretList(context.Background(), functionNamespace)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -54,7 +55,11 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 		Name:      args[0],
 		Namespace: functionNamespace,
 	}
-	err := proxy.RemoveSecretToken(gatewayAddress, secret, tlsInsecure, token)
+
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	client := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
+	err := client.RemoveSecret(context.Background(), secret)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -96,8 +97,11 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("must provide a non empty secret via --from-literal, --from-file or STDIN")
 	}
 
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	client := proxy.NewClient(cliAuth, gatewayAddress, transport, &commandTimeout)
 	fmt.Println("Updating secret: " + secret.Name)
-	_, output := proxy.UpdateSecretToken(gatewayAddress, secret, tlsInsecure, token)
+	_, output := client.UpdateSecret(context.Background(), secret)
 	fmt.Printf(output)
 
 	return nil

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -4,10 +4,12 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 
+	"github.com/openfaas/faas-cli/proxy"
 	"github.com/spf13/cobra"
 )
 
@@ -127,8 +129,11 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	gateway = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
+	cliAuth := NewCLIAuth(token, gateway)
+	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
+	proxyClient := proxy.NewClient(cliAuth, gateway, transport, &commandTimeout)
 
-	statusCode, err := deployImage(imageName, item.Fprocess, itemName, registryAuth, storeDeployFlags,
+	statusCode, err := deployImage(context.Background(), proxyClient, imageName, item.Fprocess, itemName, registryAuth, storeDeployFlags,
 		tlsInsecure, item.ReadOnlyRootFilesystem, token, functionNamespace)
 
 	if badStatusCode(statusCode) {

--- a/commands/version.go
+++ b/commands/version.go
@@ -4,8 +4,10 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"runtime"
+	"time"
 
 	"os"
 
@@ -92,7 +94,11 @@ func printServerVersions() {
 
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, yamlGateway, os.Getenv(openFaaSURLEnvironment))
 
-	info, err := proxy.GetSystemInfo(gatewayAddress, tlsInsecure, token)
+	versionTimeout := 5 * time.Second
+	cliAuth := NewCLIAuth(token, gatewayAddress)
+	transport := GetDefaultCLITransport(tlsInsecure, &versionTimeout)
+	cliClient := proxy.NewClient(cliAuth, gatewayAddress, transport, &versionTimeout)
+	info, err := cliClient.GetSystemInfo(context.Background())
 	if err != nil {
 		return
 	}

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -26,6 +26,26 @@ func Test_LookupAuthConfig_WithNoConfigFile(t *testing.T) {
 	}
 }
 
+func Test_LookupAuthConfig_GatewayWithNoConfig(t *testing.T) {
+	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
+	DefaultFile = "test2.yml"
+	u := "admin"
+	p := "some pass"
+	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
+	token := EncodeAuth(u, p)
+	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+
+	_, err := LookupAuthConfig("http://openfaas.com")
+	if err == nil {
+		t.Errorf("Error was not returned")
+	}
+
+	r := regexp.MustCompile(`(?m:no auth config found for)`)
+	if !r.MatchString(err.Error()) {
+		t.Errorf("Error not matched: %s", err.Error())
+	}
+}
+
 func Test_UpdateAuthConfig_Insert(t *testing.T) {
 	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
 	DefaultFile = "test2.yml"

--- a/proxy/client.go
+++ b/proxy/client.go
@@ -1,0 +1,114 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+//Client an API client to perform all operations
+type Client struct {
+	httpClient *http.Client
+	//ClientAuth a type implementing ClientAuth interface for client authentication
+	ClientAuth ClientAuth
+	//GatewayURL base URL of OpenFaaS gateway
+	GatewayURL *url.URL
+	//UserAgent user agent for the client
+	UserAgent string
+}
+
+//ClientAuth an interface for client authentication.
+// to add authentication to the client implement this interface
+type ClientAuth interface {
+	Set(req *http.Request) error
+}
+
+//NewClient initializes a new API client
+func NewClient(auth ClientAuth, gatewayURL string, transport http.RoundTripper, timeout *time.Duration) *Client {
+	gatewayURL = strings.TrimRight(gatewayURL, "/")
+	baseURL, err := url.Parse(gatewayURL)
+	if err != nil {
+		log.Fatalf("invalid gateway URL: %s", gatewayURL)
+	}
+
+	client := &http.Client{}
+	if timeout != nil {
+		client.Timeout = *timeout
+	}
+
+	if transport != nil {
+		client.Transport = transport
+	}
+
+	return &Client{
+		ClientAuth: auth,
+		httpClient: client,
+		GatewayURL: baseURL,
+	}
+}
+
+//newRequest create a new HTTP request with authentication
+func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, err
+	}
+	rel := &url.URL{Path: u.Path, RawQuery: u.RawQuery}
+	url := c.GatewayURL.ResolveReference(rel)
+
+	req, err := http.NewRequest(method, url.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+
+	c.ClientAuth.Set(req)
+
+	return req, err
+}
+
+//doRequest perform an HTTP request with context
+func (c *Client) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
+	req = req.WithContext(ctx)
+	resp, err := c.httpClient.Do(req)
+
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+	}
+
+	return resp, err
+}
+
+func addQueryParams(u string, params map[string]string) (string, error) {
+	parsedURL, err := url.Parse(u)
+	if err != nil {
+		return u, err
+	}
+
+	qs := parsedURL.Query()
+	for key, value := range params {
+		qs.Add(key, value)
+	}
+	parsedURL.RawQuery = qs.Encode()
+	return parsedURL.String(), nil
+}
+
+//AddCheckRedirect add CheckRedirect to the client
+func (c *Client) AddCheckRedirect(checkRedirect func(*http.Request, []*http.Request) error) {
+	c.httpClient.CheckRedirect = checkRedirect
+}

--- a/proxy/client_test.go
+++ b/proxy/client_test.go
@@ -1,0 +1,119 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func Test_NewClient(t *testing.T) {
+	auth := NewTestAuth(nil)
+	testcases := []struct {
+		Name   string
+		Input  string
+		Output string
+	}{
+		{
+			Name:   "Without trailing slash",
+			Input:  "http://127.0.0.1:8080",
+			Output: "http://127.0.0.1:8080",
+		},
+		{
+			Name:   "With trailing slash",
+			Input:  "http://127.0.0.1:8080/",
+			Output: "http://127.0.0.1:8080",
+		},
+	}
+
+	for _, test := range testcases {
+		newClient := NewClient(auth, test.Input, nil, &defaultCommandTimeout)
+		clientURL := newClient.GatewayURL.String()
+		if clientURL != test.Output {
+			t.Fatalf("Testcase %s failed. Expected: %s, Got: %s", test.Name, test.Output, clientURL)
+		}
+	}
+}
+
+func Test_newRequest_URL(t *testing.T) {
+	auth := NewTestAuth(nil)
+	gatewayURL := "http://127.0.0.1:8080"
+	client := NewClient(auth, gatewayURL, nil, &defaultCommandTimeout)
+
+	testcases := []struct {
+		Name        string
+		Path        string
+		ExpectedURL string
+	}{
+		{
+			Name:        "A valid path",
+			Path:        "/system/functions",
+			ExpectedURL: "http://127.0.0.1:8080/system/functions",
+		},
+		{
+			Name:        "Root Path",
+			Path:        "/",
+			ExpectedURL: "http://127.0.0.1:8080/",
+		},
+		{
+			Name:        "Path without starting slash",
+			Path:        "system/functions",
+			ExpectedURL: "http://127.0.0.1:8080/system/functions",
+		},
+		{
+			Name:        "Path with querystring",
+			Path:        "system/functions?namespace=fn",
+			ExpectedURL: "http://127.0.0.1:8080/system/functions?namespace=fn",
+		},
+	}
+
+	for _, test := range testcases {
+		request, err := client.newRequest("POST", test.Path, nil)
+		if err != nil {
+			t.Fatalf("Got Error! %s", err.Error())
+		}
+
+		url := request.URL.String()
+		if url != test.ExpectedURL {
+			t.Fatalf("Testcase %s failed. Expected: %s, Got: %s", test.Name, test.ExpectedURL, url)
+		}
+	}
+
+}
+
+func Test_addQueryParams(t *testing.T) {
+
+	testcases := []struct {
+		Name        string
+		QueryParams map[string]string
+		URL         string
+		ExpectedURL string
+	}{
+		{
+			Name:        "URL without hostname",
+			QueryParams: map[string]string{"namespace": "openfaas-fn"},
+			URL:         "/system/functions",
+			ExpectedURL: "/system/functions?namespace=openfaas-fn",
+		},
+		{
+			Name:        "URL hostname",
+			QueryParams: map[string]string{"namespace": "openfaas-fn"},
+			URL:         "http://127.0.0.1/system/functions",
+			ExpectedURL: "http://127.0.0.1/system/functions?namespace=openfaas-fn",
+		},
+		{
+			Name:        "A URL with simple hostname",
+			QueryParams: map[string]string{"namespace": "openfaas-fn"},
+			URL:         "example",
+			ExpectedURL: "example?namespace=openfaas-fn",
+		},
+	}
+
+	for _, test := range testcases {
+		url, err := addQueryParams(test.URL, test.QueryParams)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+
+		if url != test.ExpectedURL {
+			t.Fatalf("Testcase %s failed, Expected: %s, Got: %s", test.Name, test.ExpectedURL, url)
+		}
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -10,6 +10,11 @@ import (
 	"time"
 )
 
+// MakeHTTPClient makes a HTTP client with good defaults for timeouts.
+func MakeHTTPClient(timeout *time.Duration, tlsInsecure bool) http.Client {
+	return makeHTTPClientWithDisableKeepAlives(timeout, tlsInsecure, false)
+}
+
 // makeHTTPClientWithDisableKeepAlives makes a HTTP client with good defaults for timeouts.
 func makeHTTPClientWithDisableKeepAlives(timeout *time.Duration, tlsInsecure bool, disableKeepAlives bool) http.Client {
 	client := http.Client{}
@@ -40,9 +45,4 @@ func makeHTTPClientWithDisableKeepAlives(timeout *time.Duration, tlsInsecure boo
 	}
 
 	return client
-}
-
-// MakeHTTPClient makes a HTTP client with good defaults for timeouts.
-func MakeHTTPClient(timeout *time.Duration, tlsInsecure bool) http.Client {
-	return makeHTTPClientWithDisableKeepAlives(timeout, tlsInsecure, false)
 }

--- a/proxy/secret_test.go
+++ b/proxy/secret_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"net/http"
 	"regexp"
 	"testing"
@@ -17,8 +18,8 @@ func Test_GetSecretList_200OK(t *testing.T) {
 		},
 	})
 	defer s.Close()
-
-	secrets, err := GetSecretList(s.URL, true, "openfaas-fn")
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	secrets, err := client.GetSecretList(context.Background(), "openfaas-fn")
 	if err != nil {
 		t.Errorf("Error returned: %s", err.Error())
 	}
@@ -38,8 +39,8 @@ func Test_GetSecretList_202Accepted(t *testing.T) {
 		},
 	})
 	defer s.Close()
-
-	secrets, err := GetSecretList(s.URL, true, "")
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	secrets, err := client.GetSecretList(context.Background(), "")
 	if err != nil {
 		t.Errorf("Error returned: %s", err.Error())
 	}
@@ -53,8 +54,8 @@ func Test_GetSecretList_202Accepted(t *testing.T) {
 
 func Test_GetSecretList_Not200(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusBadRequest)
-
-	_, err := GetSecretList(s.URL, true, "openfaas-fn")
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	_, err := client.GetSecretList(context.Background(), "openfaas-fn")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -68,8 +69,8 @@ func Test_GetSecretList_Not200(t *testing.T) {
 
 func Test_GetSecretList_Unauthorized401(t *testing.T) {
 	s := test.MockHttpServerStatus(t, http.StatusUnauthorized)
-
-	_, err := GetSecretList(s.URL, true, "fn")
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	_, err := client.GetSecretList(context.Background(), "fn")
 
 	if err == nil {
 		t.Fatalf("Error was not returned")
@@ -97,8 +98,8 @@ func Test_CreateSecret_200OK(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "openfaas-fn",
 	}
-
-	status, _ := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, _ := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusOK {
 		t.Errorf("expected: %d, got: %d", http.StatusOK, status)
@@ -112,8 +113,8 @@ func Test_CreateSecret_201Created(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "openfaas-fn",
 	}
-
-	status, _ := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, _ := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusCreated {
 		t.Errorf("expected: %d, got: %d", http.StatusCreated, status)
@@ -127,8 +128,8 @@ func Test_CreateSecret_202Accepted(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "openfaas-fn",
 	}
-
-	status, _ := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, _ := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusAccepted {
 		t.Errorf("expected: %d, got: %d", http.StatusAccepted, status)
@@ -143,7 +144,8 @@ func Test_CreateSecret_Not200(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "openfaas-fn",
 	}
-	status, output := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, output := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusBadRequest {
 		t.Errorf("expected: %d, got: %d", http.StatusBadRequest, status)
@@ -163,7 +165,8 @@ func Test_CreateSecret_Unauthorized401(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "openfaas-fn",
 	}
-	status, output := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, output := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusUnauthorized {
 		t.Errorf("expected: %d, got: %d", http.StatusUnauthorized, status)
@@ -183,7 +186,8 @@ func Test_CreateSecret_Conflict409(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "openfaas-fn",
 	}
-	status, output := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, output := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusConflict {
 		t.Errorf("want: %d, got: %d", http.StatusConflict, status)
@@ -203,7 +207,8 @@ func Test_CreateSecret_ForbiddenNamespace(t *testing.T) {
 		Value:     "secret-value",
 		Namespace: "kube-system",
 	}
-	status, output := CreateSecret(s.URL, secret, true)
+	client := NewClient(NewTestAuth(nil), s.URL, nil, nil)
+	status, output := client.CreateSecret(context.Background(), secret)
 
 	if status != http.StatusBadRequest {
 		t.Errorf("want: %d, got: %d", http.StatusBadRequest, status)

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -10,6 +10,7 @@ const (
 	systemPath     = "/system/functions"
 	functionPath   = "/system/function"
 	namespacesPath = "/system/namespaces"
+	namespaceKey   = "namespace"
 )
 
 func createSystemEndpoint(gateway, namespace string) (string, error) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Provide Client SDK for doing things like deploy, remove, list functions etc.

Commands which are affected with this change.

```
version 
describe
deploy
store deploy
remove
list
namespaces
secret list
secret create
secret update
secret delete
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested on Local Kubernetes cluster on docker for mac.

```
./faas-cli version -g http://127.0.0.1:31112
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:
 version: dev

Gateway
 uri:     http://127.0.0.1:31112
 version: 0.18.7
 sha:     59b7839236098820e73ed25301258b722c3d33e4
 commit:  Change how and when we fetch and parse namespace info


Provider
 name:          faas-netes
 orchestration: kubernetes
 version:       0.9.15
 sha:           41c33f9f7c29e8276bd01387f78d6f0cff847890
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli namespaces -g http://127.0.0.1:31112
Namespaces:
 - fn
 - openfaas-fn
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
env                           	0              	1
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli remove env  -g http://127.0.0.1:31112
Deleting: env.
Removing old function.
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112 -n openfaas-fn
Function                      	Invocations    	Replicas
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112 -n fn
Function                      	Invocations    	Replicas
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli deploy  -g http://127.0.0.1:31112
Deploying: nodejs-echo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/nodejs-echo

Deploying: shrink-image.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/shrink-image

Deploying: ruby-echo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/ruby-echo

Deploying: url-ping.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/url-ping

Deploying: stronghash.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/stronghash

➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112 -n openfaas-fn
Function                      	Invocations    	Replicas
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112 -n fn
Function                      	Invocations    	Replicas
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli/faas-cli-darwin deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions -g http://127.0.0.1:31112
➜  openfaas ./faas-cli remove env  -g http://127.0.0.1:31112
➜  openfaas ./faas-cli/faas-cli-darwin deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/env

➜  openfaas cd faas-cli
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli desribe env -g http://127.0.0.1:31112
Unknown command "desribe" for "faas-cli"

Did you mean this?
	describe

➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli describe env -g http://127.0.0.1:31112
Name:                env
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               functions/alpine:latest
Function process:    env
URL:                 http://127.0.0.1:31112/function/env
Async URL:           http://127.0.0.1:31112/async-function/env
Labels:              faas_function : env
Annotations:         prometheus.io.scrape : false
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli describe env -g http://127.0.0.1:31112 -n openfaas-fn
Name:                env
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               functions/alpine:latest
Function process:    env
URL:                 http://127.0.0.1:31112/function/env.openfaas-fn
Async URL:           http://127.0.0.1:31112/async-function/env.openfaas-fn
Labels:              faas_function : env
Annotations:         prometheus.io.scrape : false
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli describe env -g http://127.0.0.1:31112 -n fn
No such function: env
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret list -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret create test-secret --from-literal=test-value -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
Created: 202 Accepted
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret list -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret update test-secret --from-literal=test-value-updated -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret
Updated: 202 Accepted
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret create  test-secret --from-literal=test-value-updated -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
secret with the name "test-secret" already exists
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret remove test-secret  -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli secret list -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli remove env -n openfaa-fn -g http://127.0.0.1:31112
Deleting: env.
No existing function to remove
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli remove env -n openfaas-fn -g http://127.0.0.1:31112
Deleting: env.
Removing old function.
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
env                           	0              	1
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
env                           	0              	1
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ✗ ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
```

```
./faas-cli version -g http://127.0.0.1:31112
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:
 version: dev

Gateway
 uri:     http://127.0.0.1:31112
 version: 0.18.7
 sha:     59b7839236098820e73ed25301258b722c3d33e4
 commit:  Change how and when we fetch and parse namespace info


Provider
 name:          faas-netes
 orchestration: kubernetes
 version:       0.9.15
 sha:           41c33f9f7c29e8276bd01387f78d6f0cff847890
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli namespaces -g http://127.0.0.1:31112
Namespaces:
 - fn
 - openfaas-fn
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli remove env  -g http://127.0.0.1:31112
Deleting: env.
No existing function to remove
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112 -n openfaas-fn
Function                      	Invocations    	Replicas
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112 -n fn
Function                      	Invocations    	Replicas
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli deploy  -g http://127.0.0.1:31112
Deploying: stronghash.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/stronghash

Deploying: nodejs-echo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/nodejs-echo

Deploying: shrink-image.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/shrink-image

Deploying: ruby-echo.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/ruby-echo

Deploying: url-ping.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/url-ping

➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112 -n openfaas-fn
Function                      	Invocations    	Replicas
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112 -n fn
Function                      	Invocations    	Replicas
➜  faas-cli git:(proxy-deploy-poc) cd ..
➜  openfaas ./faas-cli/faas-cli-darwin deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/env

➜  openfaas cd faas-cli
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli remove env  -g http://127.0.0.1:31112
Deleting: env.
Removing old function.
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli remove env  -g http://127.0.0.1:31112
Deleting: env.
No existing function to remove
➜  faas-cli git:(proxy-deploy-poc) cd ..
➜  openfaas ./faas-cli/faas-cli-darwin deploy --name env --fprocess="env" --image="functions/alpine:latest" --network=func_functions -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/env

➜  openfaas cd faas-cli
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli desribe env -g http://127.0.0.1:31112
Unknown command "desribe" for "faas-cli"

Did you mean this?
	describe

➜  faas-cli git:(proxy-deploy-poc) ./faas-cli describe env -g http://127.0.0.1:31112
Name:                env
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               functions/alpine:latest
Function process:    env
URL:                 http://127.0.0.1:31112/function/env
Async URL:           http://127.0.0.1:31112/async-function/env
Labels:              faas_function : env
Annotations:         prometheus.io.scrape : false
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli describe env -g http://127.0.0.1:31112 -n openfaas-fn
Name:                env
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               functions/alpine:latest
Function process:    env
URL:                 http://127.0.0.1:31112/function/env.openfaas-fn
Async URL:           http://127.0.0.1:31112/async-function/env.openfaas-fn
Labels:              faas_function : env
Annotations:         prometheus.io.scrape : false
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli describe env -g http://127.0.0.1:31112 -n fn
No such function: env
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret list -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(proxy-deploy-poc) /faas-cli secret create test-secret --from-literal=test-value -n openfaas-fn -g http://127.0.0.1:31112
zsh: no such file or directory: /faas-cli
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret create test-secret --from-literal=test-value -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
Created: 202 Accepted
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret list -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

NAME
test-secret

➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret update test-secret --from-literal=test-value-updated -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Updating secret: test-secret
Updated: 202 Accepted
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret create  test-secret --from-literal=test-value-updated -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: test-secret
secret with the name "test-secret" already exists
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret remove test-secret  -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Removed.. OK.
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli secret list -n openfaas-fn -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
No secrets found.
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli remove env -n openfaa-fn -g http://127.0.0.1:31112
Deleting: env.
No existing function to remove
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli remove env -n openfaas-fn -g http://127.0.0.1:31112
Deleting: env.
Removing old function.
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
env                           	0              	1
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
env                           	0              	1
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list  -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
figlet                        	0              	0
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli store list

FUNCTION                                 DESCRIPTION
NodeInfo                                 Get info about the machine that you'r...
Figlet                                   Generate ASCII logos with the figlet CLI
SSL/TLS cert info                        Returns SSL/TLS certificate informati...
Colorization                             Turn black and white photos to color ...
Inception                                This is a forked version of the work ...
Have I Been Pwned                        The Have I Been Pwned function lets y...
Face Detection with Pigo                 Detect faces in images using the Pigo...
curl                                     Use curl for network diagnostics, pas...
SentimentAnalysis                        Python function provides a rating on ...
Tesseract OCR                            This function brings OCR - Optical Ch...
Dockerhub Stats                          Golang function gives the count of re...
QR Code Generator - Go                   QR Code generator using Go
Nmap Security Scanner                    Tool for network discovery and securi...
ASCII Cows                               Generate cartoons of ASCII cows
YouTube Video Downloader                 Download YouTube videos as a function
OpenFaaS Text-to-Speech                  Generate an MP3 of text using Google'...
nslookup                                 Uses nslookup to return any IP addres...
Docker Image Manifest Query              Query an image on the Docker Hub for ...
face-detect with OpenCV                  Detect faces in images. Send a URL as...
Face blur by Endre Simo                  Blur out faces detected in JPEGs. Inv...
Left-Pad                                 left-pad on OpenFaaS
normalisecolor                           Automatically fix white-balance in ph...
mememachine                              Turn any image into a meme.
Business Strategy Generator              Generates a Business Strategy (using ...
Line Drawing Generator from a photograph Automatically generates a sketch like...
Image EXIF Reader                        Reads EXIF information from an URL or...
Open NSFW Model                          Score images for NSFW (nudity) content.
Identicon Generator                      Create an identicon from a provided s...

➜  faas-cli git:(proxy-deploy-poc) ./faas-cli store deploy NodeInfo
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Is OpenFaaS deployed? Do you need to specify the --gateway flag?
Put http://127.0.0.1:8080/system/functions: dial tcp 127.0.0.1:8080: connect: connection refused

Function 'nodeinfo' failed to deploy with status code: 500
➜  faas-cli git:(proxy-deploy-poc) ./faas-cli store deploy NodeInfo -g http://127.0.0.1:31112
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:31112/function/nodeinfo

➜  faas-cli git:(proxy-deploy-poc) ./faas-cli list -g http://127.0.0.1:31112
Function                      	Invocations    	Replicas
figlet                        	0              	0
nodeinfo                      	0              	1
nodejs-echo                   	0              	1
ruby-echo                     	0              	1
shrink-image                  	0              	1
stronghash                    	0              	1
url-ping                      	0              	1
➜  faas-cli git:(proxy-deploy-poc)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
