### PR TITLE
Add ability to specify handler folder for templates

### DIFF
--- a/builder/copy.go
+++ b/builder/copy.go
@@ -15,6 +15,7 @@ func CopyFiles(src, dest string) error {
 	if err != nil {
 		return err
 	}
+
 	if info.IsDir() {
 		debugPrint(fmt.Sprintf("Creating directory: %s at %s", info.Name(), dest))
 		return copyDir(src, dest)

--- a/commands/build.go
+++ b/commands/build.go
@@ -52,11 +52,8 @@ func init() {
 	buildCmd.Flags().StringArrayVarP(&buildOptions, "build-option", "o", []string{}, "Set a build option, e.g. dev")
 	buildCmd.Flags().Var(&tagFormat, "tag", "Override latest tag on function Docker image, accepts 'latest', 'sha', 'branch', or 'describe'")
 	buildCmd.Flags().StringArrayVar(&buildLabels, "build-label", []string{}, "Add a label for Docker image (LABEL=VALUE)")
-
 	buildCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
-
 	buildCmd.Flags().BoolVar(&quietBuild, "quiet", false, "Perform a quiet build, without showing output from Docker")
-
 	buildCmd.Flags().BoolVar(&disableStackPull, "disable-stack-pull", false, "Disables the template configuration in the stack.yml")
 
 	// Set bash-completion.
@@ -177,7 +174,19 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		if len(functionName) == 0 {
 			return fmt.Errorf("please provide the deployed --name of your function")
 		}
-		err := builder.BuildImage(image, handler, functionName, language, nocache, squash, shrinkwrap, buildArgMap, buildOptions, tagFormat, buildLabelMap, quietBuild)
+		err := builder.BuildImage(image,
+			handler,
+			functionName,
+			language,
+			nocache,
+			squash,
+			shrinkwrap,
+			buildArgMap,
+			buildOptions,
+			tagFormat,
+			buildLabelMap,
+			quietBuild)
+
 		if err != nil {
 			return err
 		}
@@ -223,7 +232,19 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 				} else {
 
 					combinedBuildOptions := combineBuildOpts(function.BuildOptions, buildOptions)
-					err := builder.BuildImage(function.Image, function.Handler, function.Name, function.Language, nocache, squash, shrinkwrap, buildArgMap, combinedBuildOptions, tagFormat, buildLabelMap, quietBuild)
+					err := builder.BuildImage(function.Image,
+						function.Handler,
+						function.Name,
+						function.Language,
+						nocache,
+						squash,
+						shrinkwrap,
+						buildArgMap,
+						combinedBuildOptions,
+						tagFormat,
+						buildLabelMap,
+						quietBuild)
+
 					if err != nil {
 						errors = append(errors, err)
 					}

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -101,6 +101,6 @@ Manage your OpenFaaS functions from the command line`,
 
 // runFaas TODO
 func runFaas(cmd *cobra.Command, args []string) {
-	printFiglet()
+	printLogo()
 	cmd.Help()
 }

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -201,7 +201,7 @@ Download templates:
 
 	// Create function directory from template.
 	builder.CopyFiles(fromTemplateHandler, handlerDir)
-	printFiglet()
+	printLogo()
 	fmt.Printf("\nFunction created in folder: %s\n", handlerDir)
 
 	imageName := fmt.Sprintf("%s:latest", functionName)

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -182,8 +182,25 @@ Download templates:
 		return fmt.Errorf("got unexpected error while updating .gitignore file: %s", err)
 	}
 
+	pathToTemplateYAML := fmt.Sprintf("./template/%s/template.yml", language)
+	if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
+		return err
+	}
+
+	langTemplate, err := stack.ParseYAMLForLanguageTemplate(pathToTemplateYAML)
+	if err != nil {
+		return fmt.Errorf("error reading language template: %s", err.Error())
+	}
+
+	templateHandlerFolder := "function"
+	if len(langTemplate.HandlerFolder) > 0 {
+		templateHandlerFolder = langTemplate.HandlerFolder
+	}
+
+	fromTemplateHandler := filepath.Join("template", language, templateHandlerFolder)
+
 	// Create function directory from template.
-	builder.CopyFiles(filepath.Join("template", language, "function"), handlerDir)
+	builder.CopyFiles(fromTemplateHandler, handlerDir)
 	printFiglet()
 	fmt.Printf("\nFunction created in folder: %s\n", handlerDir)
 

--- a/commands/version.go
+++ b/commands/version.go
@@ -54,7 +54,7 @@ func runVersionE(cmd *cobra.Command, args []string) error {
 		fmt.Println(version.BuildVersion())
 
 	} else {
-		printFiglet()
+		printLogo()
 		fmt.Printf(`CLI:
  commit:  %s
  version: %s
@@ -127,7 +127,8 @@ Gateway
 	fmt.Println()
 }
 
-func printFiglet() {
+// printLogo prints an ASCII logo, which was generated with figlet
+func printLogo() {
 	figletColoured := aec.BlueF.Apply(figletStr)
 	if runtime.GOOS == "windows" {
 		figletColoured = aec.GreenF.Apply(figletStr)

--- a/guide/TEMPLATE.md
+++ b/guide/TEMPLATE.md
@@ -38,6 +38,25 @@ template
     └── template.yml
 ```
 
+## template.yml schema
+
+* `language` - template name i.e. `node`
+* `fprocess` - optional, fprocess for watchdog
+* `build_options` - array, optional to define a slice of `string, []string` to provide a number of build options and package installed for the named package
+
+    Example:
+
+    ```yaml
+    build_options:
+      - name: curl-tls
+        packages:
+        - curl
+        - ca-certificates
+    ```
+* `welcome_message` - printed after `faas-cli new`, populate with a link to the user guide or how to add a module for package manager
+* `handler_folder` - where to copy the function's build context into the Docker image, usually just `function`
+
+
 ## Download external repository
 
 In order to build functions using 3rd party templates, you need to add 3rd templates before the build step, with the following command:

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -99,11 +99,13 @@ type Services struct {
 
 // LanguageTemplate read from template.yml within root of a language template folder
 type LanguageTemplate struct {
-	Language     string        `yaml:"language"`
-	FProcess     string        `yaml:"fprocess"`
-	BuildOptions []BuildOption `yaml:"build_options"`
+	Language     string        `yaml:"language,omitempty"`
+	FProcess     string        `yaml:"fprocess,omitempty"`
+	BuildOptions []BuildOption `yaml:"build_options,omitempty"`
 	// WelcomeMessage is printed to the user after generating a function
-	WelcomeMessage string `yaml:"welcome_message"`
+	WelcomeMessage string `yaml:"welcome_message,omitempty"`
+	// HandlerFolder to copy the function code into
+	HandlerFolder string `yaml:"handler_folder,omitempty"`
 }
 
 // BuildOption a named build option for one or more packages


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add ability to specify handler folder for a template as defined in 
issue #754

## Motivation and Context

Fixes: #754

* The destination folder for the user's function / handler was
hard-coded to ./function/ or ./ for the Dockerfile template, this
patch allows users to override the value in template.yml
* Set handler_folder to a custom value such as "src"
* Updated new command for new handler path - the new command
needs to decide whether to find its templated handler code in the 
function folder or a custom folder.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by updating the node template to use a handler_folder of
src, the build failed, then the Dockerfile was updated to match
the src folder instead of function, this resolved the error
and once deployed, it worked as expected.

Tested "faas-cli new" with the old cli and a template modified to use "src".
The result was an empty directory, I then updated faas-cli with
this patch and got the files populated as expected: i.e.
handler.js and package.json

To try this out:

1) Download the templates
2) Edit a template where you see "function" and replace it with something else like "lib" or "src"
3) Edit template.yml for that template and add the `handler_folder` entry
4) Build a new CLI, run `faas-cli build --shrinkwrap` and look inside build/name/
5) See that your function code was put into lib or src
6) Run a build, test the function
