### PR TITLE
Remove returns non zero exit code for HTTP error

### DIFF
--- a/commands/remove.go
+++ b/commands/remove.go
@@ -83,7 +83,10 @@ func runDelete(cmd *cobra.Command, args []string) error {
 
 		functionName = args[0]
 		fmt.Printf("Deleting: %s.\n", functionName)
-		proxyclient.DeleteFunction(ctx, functionName, functionNamespace)
+		err := proxyclient.DeleteFunction(ctx, functionName, functionNamespace)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -48,17 +48,16 @@ func (c *Client) DeleteFunction(ctx context.Context, functionName string, namesp
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
 		fmt.Println("Removing old function.")
 	case http.StatusNotFound:
-		fmt.Println("No existing function to remove")
+		err = fmt.Errorf("No existing function to remove")
 	case http.StatusUnauthorized:
-		fmt.Println("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		err = fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
 	default:
 		var bodyReadErr error
 		bytesOut, bodyReadErr := ioutil.ReadAll(delRes.Body)
 		if bodyReadErr != nil {
 			err = bodyReadErr
 		} else {
-			err = fmt.Errorf("server returned unexpected status code %d %s", delRes.StatusCode, string(bytesOut))
-			fmt.Println("Server returned unexpected status code", delRes.StatusCode, string(bytesOut))
+			err = fmt.Errorf("Server returned unexpected status code %d %s", delRes.StatusCode, string(bytesOut))
 		}
 	}
 

--- a/proxy/delete_test.go
+++ b/proxy/delete_test.go
@@ -38,13 +38,11 @@ func Test_DeleteFunction_404(t *testing.T) {
 	cliAuth := NewTestAuth(nil)
 	proxyClient := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
 
-	stdout := test.CaptureStdout(func() {
-		proxyClient.DeleteFunction(context.Background(), "function-to-delete", "")
-	})
+	err := proxyClient.DeleteFunction(context.Background(), "function-to-delete", "")
 
 	r := regexp.MustCompile(`(?m:No existing function to remove)`)
-	if !r.MatchString(stdout) {
-		t.Fatalf("Want: %s, got: %s", "No existing function to remove", stdout)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Want: %s, got: %s", "No existing function to remove", err.Error())
 	}
 }
 
@@ -55,12 +53,10 @@ func Test_DeleteFunction_Not2xxAnd404(t *testing.T) {
 	cliAuth := NewTestAuth(nil)
 	proxyClient := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
 
-	stdout := test.CaptureStdout(func() {
-		proxyClient.DeleteFunction(context.Background(), "function-to-delete", "")
-	})
+	err := proxyClient.DeleteFunction(context.Background(), "function-to-delete", "")
 
 	r := regexp.MustCompile(`(?m:Server returned unexpected status code)`)
-	if !r.MatchString(stdout) {
-		t.Fatalf("Output not matched: %s", stdout)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Output not matched: %s", err.Error())
 	}
 }


### PR DESCRIPTION
## Description

This commit Fixes #748. It creates and returns an error when there is a 
HTTP error with the cli remove command and so a non zero exit code (1) is 
returned.

## Motivation and Context
Currently an exit code of 0 is returned for all cases even when there
is a HTTP error with the `faas-cli remove` command in cases where 
there the function does not exist or where a bad gateway is used.
This Fixes #748 and is required to prevent false positives during 
integration testing.
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
`faas-cli remove invalid-function`
`echo $?`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
