### PR TITLE
Provide --build-args for functions in stack.yml

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -235,7 +235,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 					fmt.Println("Please provide a valid language for your function.")
 				} else {
 					combinedBuildOptions := combineBuildOpts(function.BuildOptions, buildOptions)
-					combinedBuildArgMap := combineBuildArgMap(function.BuildConfig.BuildArgMap, buildArgMap)
+					combinedBuildArgMap := mergeMap(function.BuildConfig.BuildArgs, buildArgMap)
 					combinedExtraPaths := mergeSlice(services.StackConfiguration.CopyExtraPaths, copyExtra)
 					err := builder.BuildImage(function.Image,
 						function.Handler,
@@ -306,14 +306,4 @@ func combineBuildOpts(YAMLBuildOpts []string, buildFlagBuildOpts []string) []str
 
 	return mergeSlice(YAMLBuildOpts, buildFlagBuildOpts)
 
-}
-
-func combineBuildArgMap(YAMLBuildArgMap *map[string]string, buildFlagBuildArgMap map[string]string) map[string]string {
-
-	var buildArgMap map[string]string
-	if YAMLBuildArgMap != nil {
-		buildArgMap = *YAMLBuildArgMap
-	}
-
-	return mergeMap(buildArgMap, buildFlagBuildArgMap)
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -235,6 +235,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 					fmt.Println("Please provide a valid language for your function.")
 				} else {
 					combinedBuildOptions := combineBuildOpts(function.BuildOptions, buildOptions)
+					combinedBuildArgMap := combineBuildArgMap(function.BuildConfig.BuildArgMap, buildArgMap)
 					combinedExtraPaths := mergeSlice(services.StackConfiguration.CopyExtraPaths, copyExtra)
 					err := builder.BuildImage(function.Image,
 						function.Handler,
@@ -243,7 +244,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 						nocache,
 						squash,
 						shrinkwrap,
-						buildArgMap,
+						combinedBuildArgMap,
 						combinedBuildOptions,
 						tagFormat,
 						buildLabelMap,
@@ -305,4 +306,14 @@ func combineBuildOpts(YAMLBuildOpts []string, buildFlagBuildOpts []string) []str
 
 	return mergeSlice(YAMLBuildOpts, buildFlagBuildOpts)
 
+}
+
+func combineBuildArgMap(YAMLBuildArgMap *map[string]string, buildFlagBuildArgMap map[string]string) map[string]string {
+
+	var buildArgMap map[string]string
+	if YAMLBuildArgMap != nil {
+		buildArgMap = *YAMLBuildArgMap
+	}
+
+	return mergeMap(buildArgMap, buildFlagBuildArgMap)
 }

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -125,5 +125,5 @@ type BuildOption struct {
 
 // BuildConfig for providing build-args
 type BuildConfig struct {
-	BuildArgMap *map[string]string `yaml:"build_args"`
+	BuildArgs map[string]string `yaml:"build_args"`
 }

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -55,6 +55,8 @@ type Function struct {
 	// BuildOptions to determine native packages
 	BuildOptions []string `yaml:"build_options"`
 
+	BuildConfig BuildConfig `yaml:"build_config,omitempty"`
+
 	// Annotations
 	Annotations *map[string]string `yaml:"annotations"`
 
@@ -119,4 +121,9 @@ type LanguageTemplate struct {
 type BuildOption struct {
 	Name     string   `yaml:"name"`
 	Packages []string `yaml:"packages"`
+}
+
+// BuildConfig for providing build-args
+type BuildConfig struct {
+	BuildArgMap *map[string]string `yaml:"build_args"`
 }


### PR DESCRIPTION
We need to support supplying build args via the .
# Description
This PR allows passing the Docker build arguments to build process using YAML stack file. The new yaml structure will look like:

```
version: 1

provider:
  name: openfaas
  gateway: http://127.0.0.1:8080

functions:
  url-ping:
    lang: python
    handler: ./sample/url-ping
    image: alexellis2/faas-urlping
    build_config:
      build_args: # would be translated to the docker --build-args flags during the docker build
        GO_MOD: 1
```

## Motivation and Context
To ensure reproducible and portable builds, we should support supplying build args via the YAML stack file.

Resolves: #687

- [X] An issue has been raised to propose this change

## How Has This Been Tested?
- I have run the included unit tests
- Build `faas-cli` locally on Ubuntu 18.04.4 machine and then done build and deploy for a function with stack.yml structure similar to the one mentioned above in description

## Types of changes
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly. Here's the [PR](https://github.com/openfaas/docs/pull/215).
- [X] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [X] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
