### PR TITLE
Fixes #772: Push latest image to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,16 @@ after_success:
         fi;
 
         docker tag $DOCKER_NS/faas-cli:latest-dev $DOCKER_NS/faas-cli:$TRAVIS_TAG;
+        docker tag $DOCKER_NS/faas-cli:latest-dev $DOCKER_NS/faas-cli:latest;
         echo $DOCKER_PASSWORD | docker login -u=$DOCKER_USERNAME --password-stdin;
         docker push $DOCKER_NS/faas-cli:$TRAVIS_TAG;
+        docker push $DOCKER_NS/faas-cli:latest;
 
         docker tag $DOCKER_NS/faas-cli:latest-dev quay.io/$DOCKER_NS/faas-cli:$TRAVIS_TAG;
+        docker tag $DOCKER_NS/faas-cli:latest-dev quay.io/$DOCKER_NS/faas-cli:latest;
         echo $QUAY_PASSWORD | docker login -u=$QUAY_USERNAME --password-stdin quay.io;
         docker push quay.io/$DOCKER_NS/faas-cli:$TRAVIS_TAG;
+        docker push quay.io/$DOCKER_NS/faas-cli:latest;
 
       fi;
 


### PR DESCRIPTION
- Always push image with latest tag to docker hub
- Always push image with latest tag to quay.io

## Description
<!--- Describe your changes in detail -->
Tag and push the image for docker hub and quay.io in travis

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#772 
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I don't know how to test it. Please show me how.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
