### PR TITLE
Use an id_token for implicit flow

### DIFF
--- a/commands/auth.go
+++ b/commands/auth.go
@@ -139,7 +139,13 @@ func authImplicit(grant string) error {
 	q.Add("&response_mode", "fragment")
 	q.Add("audience", audience)
 
-	q.Add("redirect_uri", fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("%s:%d", redirectHost, listenPort)))
+	uri, err := makeRedirectURI(redirectHost, listenPort)
+	if err != nil {
+		return err
+	}
+
+	q.Add("redirect_uri", uri.String())
+
 	authURLVal, _ := url.Parse(authURL)
 	authURLVal.RawQuery = q.Encode()
 
@@ -156,6 +162,11 @@ func authImplicit(grant string) error {
 	<-context.Done()
 
 	return nil
+}
+
+func makeRedirectURI(host string, port int) (*url.URL, error) {
+	val := fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("%s:%d", redirectHost, listenPort))
+	return url.Parse(val)
 }
 
 func authClientCredentials() error {

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -31,6 +31,7 @@ var (
 	launchBrowser bool
 	grant         string
 	clientSecret  string
+	redirectHost  string
 )
 
 func init() {
@@ -40,6 +41,7 @@ func init() {
 	authCmd.Flags().IntVar(&listenPort, "listen-port", 31111, "OAuth2 local port for receiving cookie")
 	authCmd.Flags().StringVar(&audience, "audience", "", "OAuth2 audience")
 	authCmd.Flags().BoolVar(&launchBrowser, "launch-browser", true, "Launch browser for OAuth2 redirect")
+	authCmd.Flags().StringVar(&redirectHost, "redirect-host", "http://127.0.0.1", "Host for OAuth2 redirection in the implicit flow including URL scheme")
 
 	authCmd.Flags().StringVar(&scope, "scope", "openid profile", "scope for OAuth2 flow - i.e. \"openid profile\"")
 	authCmd.Flags().StringVar(&grant, "grant", "implicit", "grant for OAuth2 flow - either implicit, implicit-id or client_credentials")
@@ -137,7 +139,7 @@ func authImplicit(grant string) error {
 	q.Add("&response_mode", "fragment")
 	q.Add("audience", audience)
 
-	q.Add("redirect_uri", fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("http://localhost:%d", listenPort)))
+	q.Add("redirect_uri", fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("%s:%d", redirectHost, listenPort)))
 	authURLVal, _ := url.Parse(authURL)
 	authURLVal.RawQuery = q.Encode()
 

--- a/commands/auth.go
+++ b/commands/auth.go
@@ -165,8 +165,17 @@ func authImplicit(grant string) error {
 }
 
 func makeRedirectURI(host string, port int) (*url.URL, error) {
-	val := fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("%s:%d", redirectHost, listenPort))
-	return url.Parse(val)
+	val := fmt.Sprintf("%s/oauth/callback", fmt.Sprintf("%s:%d", host, port))
+	res, err := url.Parse(val)
+
+	if err != nil {
+		return res, err
+	}
+
+	if st := res.String(); !(strings.HasPrefix(st, "http://") || strings.HasPrefix(st, "https://")) {
+		return res, fmt.Errorf("a scheme is required for the URL, i.e. http://")
+	}
+	return res, err
 }
 
 func authClientCredentials() error {

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) OpenFaaS Author(s) 2019. All rights reserved.
+// Copyright (c) OpenFaaS Author(s) 2020. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 package commands
@@ -56,5 +56,37 @@ func Test_auth(t *testing.T) {
 			}
 
 		})
+	}
+}
+
+func Test_makeRedirectURI_Valid(t *testing.T) {
+	uri, err := makeRedirectURI("http://localhost", 31112)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := uri.String()
+	want := "http://localhost:31112/oauth/callback"
+
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
+		t.Fail()
+	}
+}
+
+func Test_makeRedirectURI_NoSchemeIsInvalid(t *testing.T) {
+	_, err := makeRedirectURI("localhost", 31112)
+
+	if err == nil {
+		t.Fatal("test should fail without a URL scheme")
+	}
+
+	got := err.Error()
+	want := "a scheme is required for the URL, i.e. http://"
+
+	if got != want {
+		t.Errorf("want %q, got %q", want, got)
+		t.Fail()
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Allows an id_token to be used and the id_token flow instead
of the access_token which may have been incorrect.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Fixes an issue reported when used with Azure which was not
reproducible with Auth0/GitLab.
