### PR TITLE
Add support for --secret option for buildkit support.

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -28,6 +28,7 @@ var (
 	buildArgs        []string
 	buildArgMap      map[string]string
 	buildOptions     []string
+	buildkitSecret   []string
 	copyExtra        []string
 	tagFormat        schema.BuildFormat
 	buildLabels      []string
@@ -51,6 +52,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&shrinkwrap, "shrinkwrap", false, "Just write files to ./build/ folder for shrink-wrapping")
 	buildCmd.Flags().StringArrayVarP(&buildArgs, "build-arg", "b", []string{}, "Add a build-arg for Docker (KEY=VALUE)")
 	buildCmd.Flags().StringArrayVarP(&buildOptions, "build-option", "o", []string{}, "Set a build option, e.g. dev")
+	buildCmd.Flags().StringArrayVar(&buildkitSecret, "buildkit-secret", []string{}, "Set a secret option for buildkit, --buildkit-secret id=mysecret,src=mysecret.txt")
 	buildCmd.Flags().Var(&tagFormat, "tag", "Override latest tag on function Docker image, accepts 'latest', 'sha', 'branch', or 'describe'")
 	buildCmd.Flags().StringArrayVar(&buildLabels, "build-label", []string{}, "Add a label for Docker image (LABEL=VALUE)")
 	buildCmd.Flags().StringArrayVar(&copyExtra, "copy-extra", []string{}, "Extra paths that will be copied into the function build context")
@@ -186,6 +188,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			shrinkwrap,
 			buildArgMap,
 			buildOptions,
+			buildkitSecret,
 			tagFormat,
 			buildLabelMap,
 			quietBuild,
@@ -245,6 +248,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 						shrinkwrap,
 						buildArgMap,
 						combinedBuildOptions,
+						buildkitSecret,
 						tagFormat,
 						buildLabelMap,
 						quietBuild,


### PR DESCRIPTION
Signed-off-by: Heng GAO <heng.gao.us@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I add a flag in the build command called --buildkit-secret to support one of the docker buildkit 
option described in here:
https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information

The reason for this change is because i have this function depends on a private pypi repository which require senstive access information. To avoid put my credentials into the images, i decided to make this change to take the benifit of using docker buildkit to protect my secrets.

The flag added to the --buildkit-secret is same as the docker build --secret, i have successfully built this change and applied it locally to create a image using following command:

```
DOCKER_BUILDKIT=1 faas-cli build --no-cache --buildkit-secret id=netrc,src=${HOME}/.netrc -f hello.yml
```
And in my dockerfile, i need to specify following changes to make this work:
```Dockerfile
# syntax = docker/dockerfile:1.0-experimental
FROM openfaas/of-watchdog:0.7.2 as watchdog
FROM python:3.8-slim

...

RUN --mount=type=secret,id=netrc,dst=/root/.netrc pip install -r requirements.txt --extra-index-url ${EXTRA_INDEX_URL}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because user's function might have dependencies that hosted on private pypi or gitlab, this change will help user to built their functions more securely.
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves: https://github.com/openfaas/faas-cli/issues/785
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

New testing option added in the Test_buildFlagSlice to verify that the buildFlagSlice function can create the docker command flag correctly, and add a new testing function to make sure the docker command can be generated correctly. 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
