### PR TITLE
Support base paths in the gateway url

### DIFF
--- a/proxy/client_test.go
+++ b/proxy/client_test.go
@@ -34,7 +34,7 @@ func Test_NewClient(t *testing.T) {
 
 func Test_newRequest_URL(t *testing.T) {
 	auth := NewTestAuth(nil)
-	gatewayURL := "http://127.0.0.1:8080"
+	gatewayURL := "http://127.0.0.1:8080/base/path"
 	client := NewClient(auth, gatewayURL, nil, &defaultCommandTimeout)
 
 	testcases := []struct {
@@ -45,22 +45,22 @@ func Test_newRequest_URL(t *testing.T) {
 		{
 			Name:        "A valid path",
 			Path:        "/system/functions",
-			ExpectedURL: "http://127.0.0.1:8080/system/functions",
+			ExpectedURL: "http://127.0.0.1:8080/base/path/system/functions",
 		},
 		{
 			Name:        "Root Path",
 			Path:        "/",
-			ExpectedURL: "http://127.0.0.1:8080/",
+			ExpectedURL: "http://127.0.0.1:8080/base/path",
 		},
 		{
 			Name:        "Path without starting slash",
 			Path:        "system/functions",
-			ExpectedURL: "http://127.0.0.1:8080/system/functions",
+			ExpectedURL: "http://127.0.0.1:8080/base/path/system/functions",
 		},
 		{
 			Name:        "Path with querystring",
 			Path:        "system/functions?namespace=fn",
-			ExpectedURL: "http://127.0.0.1:8080/system/functions?namespace=fn",
+			ExpectedURL: "http://127.0.0.1:8080/base/path/system/functions?namespace=fn",
 		},
 	}
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Refactor the proxy request construction so that it preserves the
  gateway base path.  The update to use the proxy client everywhere
  in openfaas/faas-cli#753 changed the gateway address behavior.
  Specifically the usage ResolveReference strips the base path from
  the Gateway address when the path starts with a `/`, breaking
  the previous behavior that respected the base path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #787

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have updated the existing unit test that verifies this exact behavior. 

I have also tested this manually with our existing openfaas installation that was not accessible previously with the latest release (0.12.2)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
