### PR TITLE
Update struct for OpenFaaS Function store

### DIFF
--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -3,6 +3,7 @@
 package commands
 
 import (
+	v2 "github.com/openfaas/faas-cli/schema/store/v2"
 	"testing"
 
 	"github.com/openfaas/faas-cli/schema"
@@ -208,8 +209,8 @@ func stringInSlice(a string, list []string) bool {
 
 func Test_filterStoreItem_Found(t *testing.T) {
 
-	items := []schema.StoreItem{
-		schema.StoreItem{
+	items := []v2.StoreFunction{
+		v2.StoreFunction{
 			Name: "figlet",
 		},
 	}
@@ -230,8 +231,8 @@ func Test_filterStoreItem_Found(t *testing.T) {
 
 func Test_filterStoreItem_NotFound(t *testing.T) {
 
-	items := []schema.StoreItem{
-		schema.StoreItem{
+	items := []v2.StoreFunction{
+		v2.StoreFunction{
 			Name: "figlets",
 		},
 	}

--- a/proxy/function_store.go
+++ b/proxy/function_store.go
@@ -3,21 +3,20 @@ package proxy
 import (
 	"encoding/json"
 	"fmt"
+	v2 "github.com/openfaas/faas-cli/schema/store/v2"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
-
-	"github.com/openfaas/faas-cli/schema"
 )
 
 type StoreResult struct {
 	Version   string             `json:"version"`
-	Functions []schema.StoreItem `json:"functions"`
+	Functions []v2.StoreFunction `json:"functions"`
 }
 
 // FunctionStoreList returns functions from a store URL
-func FunctionStoreList(store string) ([]schema.StoreItem, error) {
+func FunctionStoreList(store string) ([]v2.StoreFunction, error) {
 
 	var storeResults StoreResult
 

--- a/proxy/function_store.go
+++ b/proxy/function_store.go
@@ -11,9 +11,15 @@ import (
 	"github.com/openfaas/faas-cli/schema"
 )
 
+type StoreResult struct {
+	Version   string             `json:"version"`
+	Functions []schema.StoreItem `json:"functions"`
+}
+
 // FunctionStoreList returns functions from a store URL
 func FunctionStoreList(store string) ([]schema.StoreItem, error) {
-	var results []schema.StoreItem
+
+	var storeResults StoreResult
 
 	store = strings.TrimRight(store, "/")
 
@@ -38,7 +44,7 @@ func FunctionStoreList(store string) ([]schema.StoreItem, error) {
 			return nil, fmt.Errorf("cannot read result from OpenFaaS store at URL: %s", store)
 		}
 
-		jsonErr := json.Unmarshal(bytesOut, &results)
+		jsonErr := json.Unmarshal(bytesOut, &storeResults)
 		if jsonErr != nil {
 			return nil, fmt.Errorf("cannot parse result from OpenFaaS store at URL: %s\n%s", store, jsonErr.Error())
 		}
@@ -48,5 +54,5 @@ func FunctionStoreList(store string) ([]schema.StoreItem, error) {
 			return nil, fmt.Errorf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
 		}
 	}
-	return results, nil
+	return storeResults.Functions, nil
 }

--- a/proxy/function_store_test.go
+++ b/proxy/function_store_test.go
@@ -1,0 +1,64 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package proxy
+
+import (
+	"fmt"
+	v2 "github.com/openfaas/faas-cli/schema/store/v2"
+	"github.com/openfaas/faas-cli/test"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+const testStack = `
+{
+    "version": "0.2.0",
+    "functions": [
+    {
+        "title": "NodeInfo",
+        "name": "nodeinfo",
+        "description": "Get info about the machine that you're deployed on. Tells CPU count, hostname, OS, and Uptime",
+        "images": {
+            "arm64": "functions/nodeinfo:arm64",
+            "armhf": "functions/nodeinfo-http:latest-armhf",
+            "x86_64": "functions/nodeinfo-http:latest"
+        },
+        "repo_url": "https://github.com/openfaas/faas/tree/master/sample-functions/NodeInfo"
+    }]
+}
+`
+
+func Test_Generate(t *testing.T) {
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			Method:             http.MethodGet,
+			Uri:                "/functions",
+			ResponseBody:       testStack,
+			ResponseStatusCode: http.StatusOK,
+		},
+	})
+	defer s.Close()
+	u := fmt.Sprintf("%s%s", s.URL, "/functions")
+
+	got, err := FunctionStoreList(u)
+	if err != nil {
+		t.Fatalf("err was not nill, %s", err.Error())
+	}
+
+	want := []v2.StoreFunction{{
+		Title:                  "NodeInfo",
+		Name:                   "nodeinfo",
+		Description:            "Get info about the machine that you're deployed on. Tells CPU count, hostname, OS, and Uptime",
+		Images:                 map[string]string{"arm64": "functions/nodeinfo:arm64", "armhf": "functions/nodeinfo-http:latest-armhf", "x86_64": "functions/nodeinfo-http:latest"},
+		RepoURL:                "https://github.com/openfaas/faas/tree/master/sample-functions/NodeInfo",
+		ReadOnlyRootFilesystem: false,
+		Environment:            nil,
+		Labels:                 nil,
+		Annotations:            nil,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got: %v, \nwant %v", got, want)
+	}
+}


### PR DESCRIPTION
## Description

Looks like the store json is different to the expected structure in the
cli for generating the yaml spec from the function store definitions.
There was a missing wrapper sruct that took the version and the list of
functions.

This has been tested with go build && ./faas-cli generate --from-store
nodeinfo

This generated yaml when there was an error before


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #792 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has been tested with go build && ./faas-cli generate --from-store
nodeinfo

This generated yaml when there was an error before

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
