### PR TITLE
Use path instead of filepath for url building

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -9,7 +9,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
-	"path/filepath"
+	gopath "path"
 	"strings"
 	"time"
 )
@@ -67,7 +67,7 @@ func (c *Client) newRequest(method, path string, body io.Reader) (*http.Request,
 	if err != nil {
 		return nil, err
 	}
-	endpoint.Path = filepath.Join(endpoint.Path, u.Path)
+	endpoint.Path = gopath.Join(endpoint.Path, u.Path)
 	endpoint.RawQuery = u.RawQuery
 
 	req, err := http.NewRequest(method, endpoint.String(), body)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Swtich from `filepath` to the plain `path.Join` when constructing
  request URLs because `filepath` is OS aware and uses a different
  separator on Windows, which means it constructs invalid URLS

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #805

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change is covered by existing unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
