### PR TITLE
Ensure delete respects namespace value in stack file

### DIFF
--- a/commands/remove.go
+++ b/commands/remove.go
@@ -77,10 +77,11 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 
 		for k, function := range services.Functions {
+			function.Namespace = getNamespace(functionNamespace, function.Namespace)
 			function.Name = k
-			fmt.Printf("Deleting: %s.\n", function.Name)
+			fmt.Printf("Deleting: %s.%s\n", function.Name, function.Namespace)
 
-			proxyclient.DeleteFunction(ctx, function.Name, functionNamespace)
+			proxyclient.DeleteFunction(ctx, function.Name, function.Namespace)
 		}
 	} else {
 		if len(args) < 1 {
@@ -88,7 +89,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 
 		functionName = args[0]
-		fmt.Printf("Deleting: %s.\n", functionName)
+		fmt.Printf("Deleting: %s.%s\n", functionName, functionNamespace)
 		err := proxyclient.DeleteFunction(ctx, functionName, functionNamespace)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Use `getNamespace` utility during the `remove` command to ensure
  that the namespace is set correctly and respects the stack file

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

#811 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested with KinD and arkade

```yaml
# namespace-stack.yaml
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080

functions:
  stronghash:
    skip_build: true
    image: functions/alpine:latest
    fprocess: "sha512sum"
    namespace: foo
```

```sh

$ kind create cluster 
$ arkade install openfaas --clusterrole --basic-auth=false
$ kubectl create namespace foo

$ faas-cli deploy -f namespace-stack.yaml
Deploying: stronghash.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/stronghash.foo

$ kubectl get po -n foo
NAME                          READY   STATUS    RESTARTS   AGE
stronghash-6f9df77d59-7dd7g   1/1     Running   0          14s

$ faas-cli remove -f namespace-stack.yaml
Deleting: stronghash.foo
Removing old function.

$ kubectl get po -n foo
NAME                          READY   STATUS        RESTARTS   AGE
stronghash-6f9df77d59-7dd7g   1/1     Terminating   0          25s
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
