### PR TITLE
Change api version in generate command

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/schema"
 	knativev1alpha1 "github.com/openfaas/faas-cli/schema/knative/v1alpha1"
-	openfaasv1alpha2 "github.com/openfaas/faas-cli/schema/openfaas/v1alpha2"
+	openfaasv1 "github.com/openfaas/faas-cli/schema/openfaas/v1"
 	"github.com/openfaas/faas-cli/stack"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -22,7 +22,7 @@ import (
 const (
 	defaultFunctionNamespace = "openfaas-fn"
 	resourceKind             = "Function"
-	defaultAPIVersion        = "openfaas.com/v1alpha2"
+	defaultAPIVersion        = "openfaas.com/v1"
 )
 
 var (
@@ -48,14 +48,14 @@ func init() {
 }
 
 var generateCmd = &cobra.Command{
-	Use:   "generate --api=openfaas.com/v1alpha2 --yaml stack.yml --tag sha --namespace=openfaas-fn",
+	Use:   "generate --api=openfaas.com/v1 --yaml stack.yml --tag sha --namespace=openfaas-fn",
 	Short: "Generate Kubernetes CRD YAML file",
 	Long:  `The generate command creates kubernetes CRD YAML file for functions`,
-	Example: `faas-cli generate --api=openfaas.com/v1alpha2 --yaml stack.yml | kubectl apply  -f -
-faas-cli generate --api=openfaas.com/v1alpha2 -f stack.yml
+	Example: `faas-cli generate --api=openfaas.com/v1 --yaml stack.yml | kubectl apply  -f -
+faas-cli generate --api=openfaas.com/v1 -f stack.yml
 faas-cli generate --api=serving.knative.dev/v1alpha1 -f stack.yml
-faas-cli generate --api=openfaas.com/v1alpha2 --namespace openfaas-fn -f stack.yml
-faas-cli generate --api=openfaas.com/v1alpha2 -f stack.yml --tag branch -n openfaas-fn`,
+faas-cli generate --api=openfaas.com/v1 --namespace openfaas-fn -f stack.yml
+faas-cli generate --api=openfaas.com/v1 -f stack.yml --tag branch -n openfaas-fn`,
 	PreRunE: preRunGenerate,
 	RunE:    runGenerate,
 }
@@ -94,6 +94,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	annotations, annotationErr := parseMap(annotationArgs, "annotation")
 	if annotationErr != nil {
 		return fmt.Errorf("error parsing annotations: %v", annotationErr)
+	}
+
+	if len(functionNamespace) == 0 {
+		functionNamespace = defaultFunctionNamespace
 	}
 
 	if len(fromStore) > 0 {
@@ -190,7 +194,7 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 			metadata := schema.Metadata{Name: name, Namespace: namespace}
 			imageName := schema.BuildImageName(format, function.Image, version, branch)
 
-			spec := openfaasv1alpha2.Spec{
+			spec := openfaasv1.Spec{
 				Name:        name,
 				Image:       imageName,
 				Environment: allEnvironment,
@@ -201,7 +205,7 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 				Secrets:     function.Secrets,
 			}
 
-			crd := openfaasv1alpha2.CRD{
+			crd := openfaasv1.CRD{
 				APIVersion: apiVersion,
 				Kind:       resourceKind,
 				Metadata:   metadata,

--- a/schema/openfaas/v1/crd.go
+++ b/schema/openfaas/v1/crd.go
@@ -1,0 +1,45 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package v1
+
+import (
+	"github.com/openfaas/faas-cli/schema"
+	"github.com/openfaas/faas-cli/stack"
+)
+
+//APIVersionLatest latest API version of CRD
+const APIVersionLatest = "openfaas.com/v1"
+
+//Spec describe characteristics of the object
+type Spec struct {
+	//Name name of the function
+	Name string `yaml:"name"`
+	//Image docker image name of the function
+	Image string `yaml:"image"`
+
+	Environment map[string]string `yaml:"environment,omitempty"`
+
+	Labels *map[string]string `yaml:"labels,omitempty"`
+
+	//Limits for the function
+	Limits *stack.FunctionResources `yaml:"limits,omitempty"`
+
+	//Requests of resources requested by function
+	Requests *stack.FunctionResources `yaml:"requests,omitempty"`
+
+	Constraints *[]string `yaml:"constraints,omitempty"`
+
+	//Secrets list of secrets to be made available to function
+	Secrets []string `yaml:"secrets,omitempty"`
+}
+
+//CRD root level YAML definition for the object
+type CRD struct {
+	//APIVersion CRD API version
+	APIVersion string `yaml:"apiVersion"`
+	//Kind kind of the object
+	Kind     string          `yaml:"kind"`
+	Metadata schema.Metadata `yaml:"metadata"`
+	Spec     Spec            `yaml:"spec"`
+}


### PR DESCRIPTION
Changing api version in generate command since it was
outdated v1alpha2. The following changes took place:
* duplicated v1alpha2 package to v1 to avoid confusion
* updated examples to point to the right version
* updated default value to be v1 instead of v1alpha2
* fixed a bug where default namespace is unset

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [x] requested since I found the generate to be outdated

The generate command could not properly transform `stack.yml` into crd. Also the default values were missing `openfaas-fn` as default namespace so the functions were deployed in the kubernetes' default namespace.
```
kubectl apply -f something.yaml 
error: unable to recognize "something.yaml": no matches for kind "Function" in version "openfaas.com/v1alpha2"
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

ran `faas-cli generate` to see variables have now default namespace set to `openfaas-fn` and api version to `openfaas/v1` also applied the crd to verify it works as it should
```
$ ./faas-cli generate
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: stronghash
  namespace: openfaas-fn
spec:
  name: stronghash
  image: functions/alpine:latest
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: nodejs-echo
  namespace: openfaas-fn
spec:
  name: nodejs-echo
  image: alexellis/faas-nodejs-echo:0.1
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: shrink-image
  namespace: openfaas-fn
spec:
  name: shrink-image
  image: functions/resizer:0.1
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: ruby-echo
  namespace: openfaas-fn
spec:
  name: ruby-echo
  image: alexellis/ruby-echo:0.2
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: url-ping
  namespace: openfaas-fn
spec:
  name: url-ping
  image: alexellis/faas-url-ping:0.2
mdekov@mdekov-Lenovo-Y520-15IKBN:~/go/src/github.com/openfaas/faas-cli$ ./faas-cli generate>mycrd.yaml
mdekov@mdekov-Lenovo-Y520-15IKBN:~/go/src/github.com/openfaas/faas-cli$ kubectl apply -f mycrd.yaml 
function.openfaas.com/ruby-echo created
function.openfaas.com/url-ping created
function.openfaas.com/stronghash created
function.openfaas.com/nodejs-echo created
function.openfaas.com/shrink-image created
mdekov@mdekov-Lenovo-Y520-15IKBN:~/go/src/github.com/openfaas/faas-cli$ kubectl get functions -n openfaas-fn
NAME           AGE
nodejs-echo    11s
ruby-echo      11s
shrink-image   10s
stronghash     11s
url-ping       11s
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
