### PR TITLE
Add scale function API to SDK

### DIFF
--- a/proxy/scale.go
+++ b/proxy/scale.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+
+	types "github.com/openfaas/faas-provider/types"
+)
+
+//ScaleFunction scale a function
+func (c *Client) ScaleFunction(ctx context.Context, functionName, namespace string, replicas uint64) error {
+
+	scaleReq := types.ScaleServiceRequest{
+		ServiceName: functionName,
+		Replicas:    replicas,
+	}
+
+	var err error
+
+	bodyBytes, _ := json.Marshal(scaleReq)
+	bodyReader := bytes.NewReader(bodyBytes)
+
+	functionPath := filepath.Join(scalePath, functionName)
+	if len(namespace) > 0 {
+		functionPath, err = addQueryParams(functionPath, map[string]string{namespaceKey: namespace})
+		if err != nil {
+			return err
+		}
+	}
+
+	req, err := c.newRequest(http.MethodPost, functionPath, bodyReader)
+	if err != nil {
+		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+	}
+
+	res, err := c.doRequest(ctx, req)
+	if err != nil {
+		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	switch res.StatusCode {
+	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
+		break
+
+	case http.StatusNotFound:
+		return fmt.Errorf("function %s not found", functionName)
+
+	case http.StatusUnauthorized:
+		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+
+	default:
+		var bodyReadErr error
+		bytesOut, bodyReadErr := ioutil.ReadAll(res.Body)
+		if bodyReadErr != nil {
+			return bodyReadErr
+		}
+
+		return fmt.Errorf("server returned unexpected status code %d %s", res.StatusCode, string(bytesOut))
+	}
+	return nil
+}

--- a/proxy/scale_test.go
+++ b/proxy/scale_test.go
@@ -1,0 +1,72 @@
+package proxy
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"testing"
+
+	"regexp"
+
+	"github.com/openfaas/faas-cli/test"
+)
+
+func Test_ScaleFunction(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusAccepted)
+	defer s.Close()
+
+	cliAuth := NewTestAuth(nil)
+	proxyClient, _ := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
+
+	err := proxyClient.ScaleFunction(context.Background(), "function-to-scale", "", 0)
+
+	if err != nil {
+		t.Fatalf("Got Error: %s,", err.Error())
+	}
+}
+
+func Test_ScaleFunction_404(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusNotFound)
+	defer s.Close()
+
+	cliAuth := NewTestAuth(nil)
+	proxyClient, _ := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
+
+	err := proxyClient.ScaleFunction(context.Background(), "function-to-scale", "", 0)
+
+	expectedErr := fmt.Errorf("function %s not found", "function-to-scale")
+	if err.Error() != expectedErr.Error() {
+		t.Fatalf("Want: %s, got: %s", expectedErr.Error(), err.Error())
+	}
+}
+
+func Test_ScaleFunction_Unauthorized(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusUnauthorized)
+	defer s.Close()
+
+	cliAuth := NewTestAuth(nil)
+	proxyClient, _ := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
+
+	err := proxyClient.ScaleFunction(context.Background(), "function-to-scale", "", 0)
+
+	expectedErr := fmt.Errorf("unauthorized action, please setup authentication for this server")
+	if err.Error() != expectedErr.Error() {
+		t.Fatalf("Want: %s, got: %s", expectedErr.Error(), err.Error())
+	}
+}
+
+func Test_ScaleFunction_Not2xxAnd404(t *testing.T) {
+	s := test.MockHttpServerStatus(t, http.StatusInternalServerError)
+	defer s.Close()
+
+	cliAuth := NewTestAuth(nil)
+	proxyClient, _ := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
+
+	err := proxyClient.DeleteFunction(context.Background(), "function-to-scale", "")
+
+	r := regexp.MustCompile(`(?m:Server returned unexpected status code)`)
+	if !r.MatchString(err.Error()) {
+		t.Fatalf("Output not matched: %s", err.Error())
+	}
+}

--- a/proxy/utils.go
+++ b/proxy/utils.go
@@ -11,6 +11,7 @@ const (
 	functionPath   = "/system/function"
 	namespacesPath = "/system/namespaces"
 	namespaceKey   = "namespace"
+	scalePath      = "/system/scale-function"
 )
 
 func createSystemEndpoint(gateway, namespace string) (string, error) {


### PR DESCRIPTION
Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->
Add scale function API call to SDK. 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

I am using SDK in faas-idler except scale function all other API used by idler is present in SDK. It will be good to add scale function API call to SDK as well. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I have tested this on my local by calling the scale function from go application. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
