### PR TITLE
Support copying specific extra files

### DIFF
--- a/builder/copy.go
+++ b/builder/copy.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 )
 
@@ -60,6 +61,11 @@ func copyFile(src, dest string) error {
 		return fmt.Errorf("error reading src file stats: %s", err.Error())
 	}
 
+	err = ensureBaseDir(dest)
+	if err != nil {
+		return fmt.Errorf("error creating dest base directory: %s", err.Error())
+	}
+
 	f, err := os.Create(dest)
 	if err != nil {
 		return fmt.Errorf("error creating dest file: %s", err.Error())
@@ -82,6 +88,18 @@ func copyFile(src, dest string) error {
 	}
 
 	return nil
+}
+
+// ensureBaseDir creates the base directory of the given file path, if needed.
+// For example, if fpath is 'build/extras/dictionary.txt`, ensureBaseDir will
+// make sure that the directory `buid/extras/` is created.
+func ensureBaseDir(fpath string) error {
+	baseDir := path.Dir(fpath)
+	info, err := os.Stat(baseDir)
+	if err == nil && info.IsDir() {
+		return nil
+	}
+	return os.MkdirAll(baseDir, 0755)
 }
 
 func debugPrint(message string) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Ensure that the CopyFiles will create required missing intermediate
  folders. This allows the copy extra feature to specify a folder
  nested inside several folders, instead of needing to always
  specify the parent folder. When copying folders, the CopyFiles
  already handles the creation of intermediate folders, this patch makes
  behavior consistent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves #827 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. A new unit test was added. 
2. I manually tested the copy behavior using `faas-cli build --shrinkwrap`

```yaml
#stack.yaml
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080

configuration:
  copy:
    - ./common
    - ./extras/special.txt

functions:
  echo-common:
    lang: Dockerfile
    handler: ./echo-common
    fprocess: python index.py
    image: theaxer/echo-common
    environment:
      write_debug: true
```

```sh
➜  faas-cli build --shrinkwrap
[0] > Building echo-common.
Clearing temporary build folder: ./build/echo-common/
Preparing: ./echo-common/ ./build/echo-common/
Building: theaxer/echo-common:latest with Dockerfile template. Please wait..
echo-common shrink-wrapped to ./build/echo-common/
[0] < Building echo-common done in 0.01s.
[0] Worker done.

Total build time: 0.01s

➜  tree -L 3 build
build
└── echo-common
    ├── Dockerfile
    ├── common
    │   └── lookup_dict.json
    ├── extras
    │   └── special.txt
    ├── function
    │   ├── handler.py
    │   └── requirements.txt
    ├── index.py
    ├── requirements.txt
    └── template.yml

4 directories, 8 files
```

In the stack file, i have both a folder _and_ a specific file specified in the `copy` configuration.

After running shrinkwrap you can see both the `common` folder and the `extras/special.txt` folder are created in the build context.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
