### PR TITLE
Add CI env check to change dir and file permissions of artifcats

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,16 @@ Alternatively you can assign a secret to the node to allow it to pull from your 
 
 For Docker Swarm use the `--send-registry-auth` flag or its shorthand `-a` which will look up your registry credentials in your local credentials store and then transmit them over the wire to the deploy command on the API Gateway. Make sure HTTPS/TLS is enabled before attempting this.
 
+### Use faas-cli in CI environments
+
+If you're running faas-cli in a CI environment like [Github Actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables#default-environment-variables), [CircleCI](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables), or [Travis](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables), chances are you get the env var `CI` set to true.
+
+If the `CI` env var is set to `true` or `1`, faas-cli change the location of the OpenFaaS config from the default `~/.openfaas/config.yml` to `.openfaas/config.yml` with elevated permissions for the `config.yml` and the shrinkwrapped `build` dir (if there is one).
+
+This is really useful when running faas-cli as a container image. The recommended image type to use in a CI environment is the root variant, tagged with `-root` suffix.
+CI environments like Github Actions require you to use Docker images having a root user. Learn more about it [here](https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/dockerfile-support-for-github-actions#user).
+
+
 ### Use a YAML stack file
 
 Read the [YAML reference guide in the OpenFaaS docs](https://docs.openfaas.com/reference/yaml/).


### PR DESCRIPTION
Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR will enable users of faas-cli, especially the containerised version to have more permissive rules for artefacts created by the CLI to be shared across multiple users, which is typically the case in a CI/CD environment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting the env var CI to true or 1 will make the artefacts created by `faas-cli login` and `faas-cli build` to have 0777 permissions, with the files being created in the current directory, this will make sure the build and login artefacts can be shared across the host OS and user and the container in environments like GitHub Actions where only some host directories like the working dir are mounted to the container. But other environments like Google Cloud Build will benefit from the same.

- [x] I have raised an [issue](#830) to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A running sample of the containerised binary is running and building OpenFaaS function here:
https://github.com/utsavanand2/faasd-hello/runs/1177059289?check_suite_focus=true
while maintaining the simplicity of the workflow action yaml
```yaml
name: CI/CD

on:
  push:
    branches: 
      - master
      - readable-workflow
jobs:
  func-build:
    runs-on: ubuntu-latest
    steps:
      - 
        name: Checkout
        uses: actions/checkout@v2
      -
        name: Pull template
        uses: docker://utsavanand2/faas-cli:latest-root
        with:
          args: template store pull golang-http
      - 
        name: Run shrinkwrap build
        uses: docker://utsavanand2/faas-cli:latest-root
        with:
          args: build -f faasd-hello.yml --shrinkwrap
      -
        name: Login to OpenFaaS Gateway
        uses: docker://utsavanand2/faas-cli:latest-root
        with:
          args: login -p ${{ secrets.OPENFAAS_GATEWAY_PASSWD }} -g ${{ secrets.OPENFAAS_GATEWAY }}
      -
        name: Set up QEMU
        uses: docker/setup-qemu-action@v1
      -
        name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v1
      -
        name: Login to DockerHub
        if: success()
        uses: docker/login-action@v1
        with:
          username: ${{ secrets.DOCKER_USERNAME }}
          password: ${{ secrets.DOCKER_PASSWORD }}
      -
        name: List dir contents
        run: |
          ls -lah
      - 
        name: Build and Push the OpenFaaS function
        uses: docker/build-push-action@v2
        with:
          context: ./build/faasd-hello/
          file: ./build/faasd-hello/Dockerfile
          push: true
          platforms: linux/amd64,linux/arm64,linux/arm/v7
          tags: utsavanand2/faasd-hello:latest
      - 
        name: Deploy the function
        uses: docker://utsavanand2/faas-cli:latest-root
        with:
          args: deploy -f faasd-hello.yml
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
