### PR TITLE
Allow configuration of CLI config via env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ The [scripts/export-sealed-secret-pubcert.sh](https://github.com/openfaas-incuba
 * `OPENFAAS_TEMPLATE_URL` - to set the default URL to pull templates from
 * `OPENFAAS_PREFIX` - for use with `faas-cli new` - this can act in place of `--prefix`
 * `OPENFAAS_URL` - to override the default gateway URL
+* `OPENFAAS_CONFIG` - to override the location of the configuration folder, which contains auth configuration.
+* `CI` - to override the location of the configuration folder, when true, the configuration folder is `.openfaas` in the current working directory. This value is ignored if `OPENFAAS_CONFIG` is set.
 
 ### FaaS-CLI Developers / Contributors
 

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -13,9 +13,16 @@ import (
 )
 
 func Test_LookupAuthConfig_WithNoConfigFile(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test1.yml"
-	_, err := LookupAuthConfig("http://openfaas.test1")
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
+	_, err = LookupAuthConfig("http://openfaas.test1")
 	if err == nil {
 		t.Errorf("Error was not returned")
 	}
@@ -27,15 +34,25 @@ func Test_LookupAuthConfig_WithNoConfigFile(t *testing.T) {
 }
 
 func Test_LookupAuthConfig_GatewayWithNoConfig(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test2.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
 	u := "admin"
 	p := "some pass"
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
 	token := EncodeAuth(u, p)
-	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
-	_, err := LookupAuthConfig("http://openfaas.com")
+	_, err = LookupAuthConfig("http://openfaas.com")
 	if err == nil {
 		t.Errorf("Error was not returned")
 	}
@@ -47,13 +64,23 @@ func Test_LookupAuthConfig_GatewayWithNoConfig(t *testing.T) {
 }
 
 func Test_UpdateAuthConfig_Insert(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test2.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
 	u := "admin"
 	p := "some pass"
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
 	token := EncodeAuth(u, p)
-	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
 	authConfig, err := LookupAuthConfig(gatewayURL)
 	if err != nil {
@@ -73,13 +100,23 @@ func Test_UpdateAuthConfig_Insert(t *testing.T) {
 }
 
 func Test_UpdateAuthConfig_Update(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test3.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
 	u := "admin"
 	p := "pass"
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
 	token := EncodeAuth(u, p)
-	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
 	authConfig, err := LookupAuthConfig(gatewayURL)
 	if err != nil {
@@ -97,7 +134,10 @@ func Test_UpdateAuthConfig_Update(t *testing.T) {
 	u = "admin2"
 	p = "pass2"
 	token = EncodeAuth(u, p)
-	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
 	authConfig, err = LookupAuthConfig(gatewayURL)
 	if err != nil {
@@ -148,13 +188,21 @@ func Test_New_NoFile(t *testing.T) {
 }
 
 func Test_EnsureFile(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test6.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
 	cfg, err := EnsureFile()
 	if err != nil {
 		t.Error(err.Error())
 	}
-	if _, err := os.Stat(cfg); os.IsNotExist(err) {
+	_, err = os.Stat(cfg)
+	if os.IsNotExist(err) {
 		t.Errorf("expected config at %s", cfg)
 	}
 }
@@ -174,19 +222,31 @@ func Test_DecodeAuth(t *testing.T) {
 }
 
 func Test_RemoveAuthConfig(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test7.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
 
 	u := "admin"
 	p := "pass"
 	token := EncodeAuth(u, p)
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
-	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
 	gatewayURL2 := strings.TrimRight("http://openfaas.test2/", "/")
-	UpdateAuthConfig(gatewayURL2, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL2, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
-	err := RemoveAuthConfig(gatewayURL)
+	err = RemoveAuthConfig(gatewayURL)
 	if err != nil {
 		t.Errorf("got error %s", err.Error())
 	}
@@ -202,9 +262,16 @@ func Test_RemoveAuthConfig(t *testing.T) {
 }
 
 func Test_RemoveAuthConfig_WithNoConfigFile(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test8.yml"
-	err := RemoveAuthConfig("http://openfaas.test1")
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
+	err = RemoveAuthConfig("http://openfaas.test1")
 	if err == nil {
 		t.Errorf("Error was not returned")
 	}
@@ -216,16 +283,25 @@ func Test_RemoveAuthConfig_WithNoConfigFile(t *testing.T) {
 }
 
 func Test_RemoveAuthConfig_WithUnknownGateway(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test9.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
 
 	u := "admin"
 	p := "pass"
 	token := EncodeAuth(u, p)
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
-	UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	err = UpdateAuthConfig(gatewayURL, token, BasicAuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
-	err := RemoveAuthConfig("http://openfaas.test1")
+	err = RemoveAuthConfig("http://openfaas.test1")
 	if err == nil {
 		t.Errorf("Error was not returned")
 	}
@@ -237,11 +313,21 @@ func Test_RemoveAuthConfig_WithUnknownGateway(t *testing.T) {
 }
 
 func Test_UpdateAuthConfig_Oauth2Insert(t *testing.T) {
-	DefaultDir, _ = ioutil.TempDir("", "faas-cli-file-test")
-	DefaultFile = "test2.yml"
+	configDir, err := ioutil.TempDir("", "faas-cli-file-test")
+	if err != nil {
+		t.Fatalf("can not create test config directory: %s", err)
+	}
+	defer os.RemoveAll(configDir)
+
+	os.Setenv(ConfigLocationEnv, configDir)
+	defer os.Unsetenv(ConfigLocationEnv)
+
 	token := "somebase64encodedstring"
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
-	UpdateAuthConfig(gatewayURL, token, Oauth2AuthType)
+	err = UpdateAuthConfig(gatewayURL, token, Oauth2AuthType)
+	if err != nil {
+		t.Fatalf("unexpected error when updating auth config: %s", err)
+	}
 
 	authConfig, err := LookupAuthConfig(gatewayURL)
 	if err != nil {
@@ -252,4 +338,71 @@ func Test_UpdateAuthConfig_Oauth2Insert(t *testing.T) {
 	if authConfig.Token != token {
 		t.Errorf("got token %s, expected %s", authConfig.Token, token)
 	}
+}
+
+func Test_ConfigDir(t *testing.T) {
+
+	cases := []struct {
+		name         string
+		env          map[string]string
+		expectedPath string
+	}{
+		{
+			name: "override value is returned",
+			env: map[string]string{
+				"OPENFAAS_CONFIG": "/tmp/foo",
+			},
+			expectedPath: "/tmp/foo",
+		},
+		{
+			name: "override value is returned, when CI is set but false",
+			env: map[string]string{
+				"OPENFAAS_CONFIG": "/tmp/foo",
+				"CI":              "false",
+			},
+			expectedPath: "/tmp/foo",
+		},
+		{
+			name: "override value is returned even when CI is set",
+			env: map[string]string{
+				"OPENFAAS_CONFIG": "/tmp/foo",
+				"CI":              "true",
+			},
+			expectedPath: "/tmp/foo",
+		},
+		{
+			name: "when CI is true, return the default CI directory",
+			env: map[string]string{
+				"CI": "true",
+			},
+			expectedPath: DefaultCIDir,
+		},
+		{
+			name: "when CI is false, return the default directory",
+			env: map[string]string{
+				"CI": "false",
+			},
+			expectedPath: DefaultDir,
+		},
+		{
+			name:         "when no other env variables are set, the default path is returned",
+			expectedPath: DefaultDir,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			for name, value := range tc.env {
+				os.Setenv(name, value)
+				defer os.Unsetenv(name)
+			}
+
+			path := ConfigDir()
+			if path != tc.expectedPath {
+				t.Fatalf("expected config path '%s', got '%s'", tc.expectedPath, path)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Support configuration the faas-cli configuration directory path via
  the `OPENFAAS_CONFIG` env variable. When this value is set, the path
  will be overridden. When empty, we will also check the CI flag, which
  defaults the location to the current working directory. When neither
  `OPENFAAS_CONFIG` or `CI` are set, then the default location is in
  the current HOME folder.
- Various tests have been updated to use this new env variable instead
  of modifying the global variables. Also, the variables are now
  constants to prevent this kind of modification in general.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #832 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit tests verify the behavior. This is also verified by the modifications to the previous unit tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
