### PR TITLE
Leverage buildx to generate binaries in parallel

### DIFF
--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -24,30 +24,38 @@ RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 # ldflags -X injects commit version into binary
 
 RUN /usr/bin/license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Author(s)" \
-       && go test $(go list ./... | grep -v /vendor/ | grep -v /template/|grep -v /build/) -cover \
-       && VERSION=$(git describe --all --exact-match `git rev-parse HEAD` | grep tags | sed 's/tags\///') \
-       && GIT_COMMIT=$(git rev-list -1 HEAD) \
-       && CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
+       && go test $(go list ./... | grep -v /vendor/ | grep -v /template/|grep -v /build/) -cover
+
+FROM builder as linux
+RUN CGO_ENABLED=0 GOOS=linux go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
        -X github.com/openfaas/faas-cli/version.Version=${VERSION} \
        -X github.com/openfaas/faas-cli/commands.Platform=x86_64" \
-       -a -installsuffix cgo -o faas-cli \
-       && CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w \
+       -a -installsuffix cgo -o faas-cli
+
+FROM builder as darwin
+RUN CGO_ENABLED=0 GOOS=darwin go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
        -X github.com/openfaas/faas-cli/version.Version=${VERSION} \
        -X github.com/openfaas/faas-cli/commands.Platform=x86_64" \
-       -a -installsuffix cgo -o faas-cli-darwin \
-       && CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w \
+       -a -installsuffix cgo -o faas-cli-darwin
+
+FROM builder as windows
+RUN CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
        -X github.com/openfaas/faas-cli/version.Version=${VERSION} \
        -X github.com/openfaas/faas-cli/commands.Platform=x86_64" \
-       -a -installsuffix cgo -o faas-cli.exe \
-       && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build --ldflags "-s -w \
+       -a -installsuffix cgo -o faas-cli.exe
+
+FROM builder as arm
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
        -X github.com/openfaas/faas-cli/version.Version=${VERSION} \
        -X github.com/openfaas/faas-cli/commands.Platform=armhf" \
-       -a -installsuffix cgo -o faas-cli-armhf \
-       && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w \
+       -a -installsuffix cgo -o faas-cli-armhf
+
+FROM builder as arm64
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
        -X github.com/openfaas/faas-cli/version.Version=${VERSION} \
        -X github.com/openfaas/faas-cli/commands.Platform=arm64" \
@@ -64,11 +72,11 @@ RUN addgroup -S app \
 
 WORKDIR /home/app
 
-COPY --from=builder /go/src/github.com/openfaas/faas-cli/faas-cli                .
-COPY --from=builder /go/src/github.com/openfaas/faas-cli/faas-cli-darwin         .
-COPY --from=builder /go/src/github.com/openfaas/faas-cli/faas-cli-armhf          .
-COPY --from=builder /go/src/github.com/openfaas/faas-cli/faas-cli.exe            .
-COPY --from=builder /go/src/github.com/openfaas/faas-cli/faas-cli-arm64          .
+COPY --from=linux    /go/src/github.com/openfaas/faas-cli/faas-cli                .
+COPY --from=darwin   /go/src/github.com/openfaas/faas-cli/faas-cli-darwin         .
+COPY --from=arm      /go/src/github.com/openfaas/faas-cli/faas-cli-armhf          .
+COPY --from=windows  /go/src/github.com/openfaas/faas-cli/faas-cli.exe            .
+COPY --from=arm64    /go/src/github.com/openfaas/faas-cli/faas-cli-arm64          .
 
 RUN chown -R app:app ./
 


### PR DESCRIPTION
Signed-off-by: Utsav Anand <utsavanand2@gmail.com>

Leverage buildx to generate binaries in parallel
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use buildx to compile the faas-cli binaries for multiple environments in parallel.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See the build logs [here](https://github.com/utsavanand2/faas-cli/runs/1438473548?check_suite_focus=true)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
