### PR TITLE
Allow using any default branch name for template repos

### DIFF
--- a/commands/fetch_templates_test.go
+++ b/commands/fetch_templates_test.go
@@ -33,6 +33,16 @@ func Test_PullTemplates(t *testing.T) {
 		}
 
 	})
+
+	t.Run("fetchTemplates with default ref", func(t *testing.T) {
+		defer tearDownFetchTemplates(t)
+
+		err := fetchTemplates(localTemplateRepository, "", false)
+		if err != nil {
+			t.Error(err)
+		}
+
+	})
 }
 
 // setupLocalTemplateRepo will create a local copy of the core OpenFaaS templates, this

--- a/versioncontrol/git.go
+++ b/versioncontrol/git.go
@@ -14,7 +14,15 @@ var GitClone = &vcsCmd{
 	scheme: []string{"git", "https", "http", "git+ssh", "ssh"},
 }
 
-// GitCheckout defines the command to clone a repo into a directory
+// GitClone defines the command to clone the default branch of a repo into a directory
+var GitCloneDefault = &vcsCmd{
+	name:   "Git",
+	cmd:    "git",
+	cmds:   []string{"clone {repo} {dir} --depth=1 --config core.autocrlf=false"},
+	scheme: []string{"git", "https", "http", "git+ssh", "ssh"},
+}
+
+// GitCheckout defines the command to clone a specific REF of repo into a directory
 var GitCheckout = &vcsCmd{
 	name:   "Git",
 	cmd:    "git",

--- a/versioncontrol/parse.go
+++ b/versioncontrol/parse.go
@@ -35,7 +35,10 @@ func IsPinnedGitRemote(repoURL string) bool {
 
 // ParsePinnedRemote returns the remote url and contraint value from repository url
 func ParsePinnedRemote(repoURL string) (remoteURL, refName string) {
-	refName = "master"
+	// default refName is empty
+	// the template fetcher can detect this and will pull the default when
+	// the ref is empty
+	refName = ""
 	remoteURL = repoURL
 
 	// If using a Regexp in multiple goroutines,
@@ -54,7 +57,7 @@ func ParsePinnedRemote(repoURL string) (remoteURL, refName string) {
 	}
 
 	if !IsGitRemote(remoteURL) {
-		return repoURL, "master"
+		return remoteURL, refName
 	}
 
 	return remoteURL, refName

--- a/versioncontrol/parse_test.go
+++ b/versioncontrol/parse_test.go
@@ -144,14 +144,14 @@ func Test_ParsePinnedRemote(t *testing.T) {
 
 		})
 
-		t.Run(fmt.Sprintf("can parse default refname from url with %s", scenario.name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("can parse default empty refname from url with %s", scenario.name), func(t *testing.T) {
 			remote, refName := ParsePinnedRemote(scenario.url)
 			if remote != scenario.url {
 				t.Errorf("expected remote url: %s, got: %s", scenario.url, remote)
 			}
 
-			if refName != "master" {
-				t.Errorf("expected refName: master, got: %s", refName)
+			if refName != "" {
+				t.Errorf("expected emtpy refName, got: %s", refName)
 			}
 
 		})


### PR DESCRIPTION
**What**
- Use the git server's default remote branch when the template repo
  refName is empty. This allows us to support _any_ default branch
  instead of the previously hard coded `master`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Discussed on the Wedensday call

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I created a new copy of the original templates, but using the default branch `main`: https://github.com/LucasRoesler/templates-main

I then tested the CLI locally using 

```sh
➜ faas-cli template pull https://github.com/LucasRoesler/templates-main
Fetch templates from repository: https://github.com/LucasRoesler/templates-main at 
2020/11/28 18:24:49 Attempting to expand templates from https://github.com/LucasRoesler/templates-main
2020/11/28 18:24:50 Fetched 12 template(s) : [csharp dockerfile go java11 java11-vert-x node node12 php7 python python3 python3-debian ruby] from https://github.com/LucasRoesler/templates-main
➜  ls -al
total 12K
drwxrwxr-x  3 lucas lucas 4,0K Nov 28 18:24 .
drwxrwxr-x  4 lucas lucas 4,0K Nov 28 18:24 ..
drwxrwxr-x 14 lucas lucas 4,0K Nov 28 18:24 template
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
