### PR TITLE
Bump Go version to 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM teamserverless/license-check:0.3.9 as license-check
 
 # Build stage
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.13-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.15 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -17,7 +17,6 @@ ENV CGO_ENABLED=0
 
 WORKDIR /usr/bin/
 
-RUN apk --no-cache add git
 COPY --from=license-check /license-check /usr/bin/
 
 WORKDIR /go/src/github.com/openfaas/faas-cli

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -1,7 +1,7 @@
 FROM teamserverless/license-check:0.3.6 as license-check
 
 # Build stage
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 ARG GIT_COMMIT
 ARG VERSION


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bump Go version to 1.15

## Motivation and Context

Regular updates to sync with stable Go version.

Testing via CI