### PR TITLE
Add flag to control trimming of secrets

### DIFF
--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -19,11 +19,13 @@ import (
 var (
 	literalSecret string
 	secretFile    string
+	trimSecret    bool
 )
 
 // secretCreateCmd represents the secretCreate command
 var secretCreateCmd = &cobra.Command{
-	Use: `create SECRET_NAME 
+	Use: `create SECRET_NAME
+			[--trim=false]
 			[--from-literal=SECRET_VALUE]
 			[--from-file=/path/to/secret/file]
 			[STDIN]
@@ -41,6 +43,7 @@ cat /path/to/secret/file | faas-cli secret create secret-name`,
 func init() {
 	secretCreateCmd.Flags().StringVar(&literalSecret, "from-literal", "", "Value of the secret")
 	secretCreateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
+	secretCreateCmd.Flags().BoolVar(&trimSecret, "trim", true, "trim whitespace from the start and end of the secret value")
 	secretCreateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretCreateCmd.Flags().StringVarP(&gateway, "gateway", "g", defaultGateway, "Gateway URL starting with http(s)://")
 	secretCreateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
@@ -99,7 +102,9 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 		secret.Value = string(secretStdin)
 	}
 
-	secret.Value = strings.TrimSpace(secret.Value)
+	if trimSecret {
+		secret.Value = strings.TrimSpace(secret.Value)
+	}
 
 	if len(secret.Value) == 0 {
 		return fmt.Errorf("must provide a non empty secret via --from-literal, --from-file or STDIN")

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -23,6 +23,7 @@ var secretUpdateCmd = &cobra.Command{
 	Example: `faas-cli secret update NAME
 faas-cli secret update NAME --from-literal=secret-value
 faas-cli secret update NAME --from-file=/path/to/secret/file
+faas-cli secret update NAME --from-file=/path/to/secret/file --trim=false
 faas-cli secret update NAME --from-literal=secret-value --gateway=http://127.0.0.1:8080
 cat /path/to/secret/file | faas-cli secret update NAME`,
 	RunE:    runSecretUpdate,
@@ -34,6 +35,7 @@ func init() {
 	secretUpdateCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	secretUpdateCmd.Flags().StringVar(&literalSecret, "from-literal", "", "Value of the secret")
 	secretUpdateCmd.Flags().StringVar(&secretFile, "from-file", "", "Path to the secret file")
+	secretUpdateCmd.Flags().BoolVar(&trimSecret, "trim", true, "trim whitespace from the start and end of the secret value")
 	secretUpdateCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	secretUpdateCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", "", "Namespace of the function")
 	secretCmd.AddCommand(secretUpdateCmd)
@@ -91,7 +93,9 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 		secret.Value = string(secretStdin)
 	}
 
-	secret.Value = strings.TrimSpace(secret.Value)
+	if trimSecret {
+		secret.Value = strings.TrimSpace(secret.Value)
+	}
 
 	if len(secret.Value) == 0 {
 		return fmt.Errorf("must provide a non empty secret via --from-literal, --from-file or STDIN")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Add flag `--trim` with default value `true`. This allows the user to
  control if whitespace is trimmed from the start and end of the secret
  value. This can be useful if the secret values format requires
  trailing newlines. The default value of `true` preserves backwards
  compatibility

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves #859

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested locally

```sh
➜  ~ kind create cluster
# output omitted
➜  ~ arkade install openfaas -a=false
# output omitted
➜  ~ faas-cli secret create foo
Reading from STDIN - hit (Control + D) to stop.
a
b
c

WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: foo
Created: 202 Accepted

➜  ~ kubectl get secret -n openfaas-fn foo -o jsonpath="{.data.foo}" | base64 --decode
a
b
c% 

➜  ~ faas-cli secret create bar --trim=false
Reading from STDIN - hit (Control + D) to stop.
a
b
c



WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.
Creating secret: bar
Created: 202 Accepted
➜  ~ kubectl get secret -n openfaas-fn bar -o jsonpath="{.data.bar}" | base64 --decode
a
b
c


➜  ~
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
