### PR TITLE
Update GetSystemInfo API return type

### DIFF
--- a/commands/version.go
+++ b/commands/version.go
@@ -104,23 +104,20 @@ func printServerVersions() error {
 	if err != nil {
 		return err
 	}
-	info, err := cliClient.GetSystemInfo(context.Background())
+	gatewayInfo, err := cliClient.GetSystemInfo(context.Background())
 	if err != nil {
 		return err
 	}
 
-	version, sha := getGatewayDetails(info)
+	printGatewayDetails(gatewayAddress, gatewayInfo.Version.Release, gatewayInfo.Version.SHA)
 
-	printGatewayDetails(gatewayAddress, version, sha)
-
-	name, orchestration, sha, version := getProviderDetails(info)
 	fmt.Printf(`
 Provider
  name:          %s
  orchestration: %s
  version:       %s 
  sha:           %s
-`, name, orchestration, version, sha)
+`, gatewayInfo.Provider.Name, gatewayInfo.Provider.Orchestration, gatewayInfo.Provider.Version.Release, gatewayInfo.Provider.Version.SHA)
 	return nil
 }
 
@@ -146,66 +143,6 @@ func printLogo() {
 		figletColoured = aec.GreenF.Apply(figletStr)
 	}
 	fmt.Printf(figletColoured)
-}
-
-func getGatewayDetails(m map[string]interface{}) (version, sha string) {
-	if _, ok := m["orchestration"]; !ok {
-		v := m["version"].(map[string]interface{})
-		version, ok = v["release"].(string)
-		if !ok {
-			version = ""
-		}
-		sha, ok = v["sha"].(string)
-		if !ok {
-			sha = ""
-		}
-	}
-
-	return
-}
-
-func getProviderDetails(m map[string]interface{}) (name, orchestration, sha, version string) {
-	if k, ok := m["provider"]; ok {
-		if kv, ok := k.(map[string]interface{}); ok {
-			name, orchestration, sha, version = getProviderDetailsCurrent(kv)
-		} else {
-			name, orchestration, sha, version = getProviderDetailsLegacy(m)
-		}
-	}
-
-	return
-}
-
-func getProviderDetailsLegacy(m map[string]interface{}) (name, orchestration, sha, version string) {
-	name = m["provider"].(string)
-	orchestration = m["orchestration"].(string)
-	v := m["version"].(map[string]interface{})
-	version = v["release"].(string)
-	sha = v["sha"].(string)
-
-	return
-}
-
-func getProviderDetailsCurrent(m map[string]interface{}) (name, orchestration, sha, version string) {
-	v := m["version"].(map[string]interface{})
-	version, ok := v["release"].(string)
-	if !ok {
-		version = ""
-	}
-	sha, ok = v["sha"].(string)
-	if !ok {
-		sha = ""
-	}
-	name, ok = m["provider"].(string)
-	if !ok {
-		name = ""
-	}
-	orchestration, ok = m["orchestration"].(string)
-	if !ok {
-		orchestration = ""
-	}
-
-	return
 }
 
 const figletStr = `  ___                   _____           ____

--- a/commands/version_test.go
+++ b/commands/version_test.go
@@ -112,18 +112,6 @@ func Test_gateway_and_provider_information(t *testing.T) {
 				{"provider sha", "sha:           "},
 			},
 		},
-		{
-			responseBody: gateway_response_prior_to_0_8_4,
-			params: []struct {
-				name  string
-				value string
-			}{
-				{"provider name", "name:          faas-swarm"},
-				{"provider orchestration", "orchestration: swarm"},
-				{"provider version", "version:       provider-0.3.3"},
-				{"provider sha", "sha:           c890cba302d059de8edbef3f3de7fe15444b1ecf"},
-			},
-		},
 	}
 
 	for _, testCase := range testCases {
@@ -141,14 +129,6 @@ func Test_gateway_and_provider_information(t *testing.T) {
 
 func Test_gateway_uri(t *testing.T) {
 	stdOut, gatewayUri := executeVersionCmd(t, gateway_response_0_8_4_onwards)
-
-	if found, err := regexp.MatchString(fmt.Sprintf(`(?m:uri:     %s)`, gatewayUri), stdOut); err != nil || !found {
-		t.Fatalf("Gateway uri is not as expected - want: %s, got:\n%s", gatewayUri, stdOut)
-	}
-}
-
-func Test_gateway_uri_prior_to_0_8_4(t *testing.T) {
-	stdOut, gatewayUri := executeVersionCmd(t, gateway_response_prior_to_0_8_4)
 
 	if found, err := regexp.MatchString(fmt.Sprintf(`(?m:uri:     %s)`, gatewayUri), stdOut); err != nil || !found {
 		t.Fatalf("Gateway uri is not as expected - want: %s, got:\n%s", gatewayUri, stdOut)

--- a/proxy/version.go
+++ b/proxy/version.go
@@ -9,44 +9,46 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/openfaas/faas/gateway/types"
 )
 
 //GetSystemInfo get system information from /system/info endpoint
-func (c *Client) GetSystemInfo(ctx context.Context) (map[string]interface{}, error) {
+func (c *Client) GetSystemInfo(ctx context.Context) (types.GatewayInfo, error) {
 	infoEndPoint := "/system/info"
+	var info types.GatewayInfo
+
 	req, err := c.newRequest(http.MethodGet, infoEndPoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("invalid HTTP method or invalid URL")
+		return info, fmt.Errorf("invalid HTTP method or invalid URL")
 	}
 
 	response, err := c.doRequest(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+		return info, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
 	}
 
 	if response.Body != nil {
 		defer response.Body.Close()
 	}
 
-	info := make(map[string]interface{})
-
 	switch response.StatusCode {
 	case http.StatusOK:
 		bytesOut, err := ioutil.ReadAll(response.Body)
 		if err != nil {
-			return nil, fmt.Errorf("cannot read result from OpenFaaS on URL: %s", c.GatewayURL.String())
+			return info, fmt.Errorf("cannot read result from OpenFaaS on URL: %s", c.GatewayURL.String())
 		}
 		err = json.Unmarshal(bytesOut, &info)
 		if err != nil {
-			return nil, fmt.Errorf("cannot parse result from OpenFaaS on URL: %s\n%s", c.GatewayURL.String(), err.Error())
+			return info, fmt.Errorf("cannot parse result from OpenFaaS on URL: %s\n%s", c.GatewayURL.String(), err.Error())
 		}
 
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
+		return info, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
 	default:
 		bytesOut, err := ioutil.ReadAll(response.Body)
 		if err == nil {
-			return nil, fmt.Errorf("server returned unexpected status code: %d - %s", response.StatusCode, string(bytesOut))
+			return info, fmt.Errorf("server returned unexpected status code: %d - %s", response.StatusCode, string(bytesOut))
 		}
 	}
 

--- a/vendor/github.com/openfaas/faas/gateway/types/handler_set.go
+++ b/vendor/github.com/openfaas/faas/gateway/types/handler_set.go
@@ -1,0 +1,40 @@
+package types
+
+import "net/http"
+
+// HandlerSet can be initialized with handlers for binding to mux
+type HandlerSet struct {
+	// Proxy invokes functions upstream
+	Proxy http.HandlerFunc
+
+	DeployFunction http.HandlerFunc
+	DeleteFunction http.HandlerFunc
+	ListFunctions  http.HandlerFunc
+	Alert          http.HandlerFunc
+
+	UpdateFunction http.HandlerFunc
+
+	// QueryFunction queries the metdata for a function
+	QueryFunction http.HandlerFunc
+
+	// QueuedProxy queue work and return synchronous response
+	QueuedProxy http.HandlerFunc
+
+	// AsyncReport report a deferred execution result
+	AsyncReport http.HandlerFunc
+
+	// ScaleFunction enables a function to be scaled
+	ScaleFunction http.HandlerFunc
+
+	// InfoHandler provides version and build info
+	InfoHandler http.HandlerFunc
+
+	// SecretHandler enables secrets to be managed
+	SecretHandler http.HandlerFunc
+
+	// LogProxyHandler enables streaming of logs for functions
+	LogProxyHandler http.HandlerFunc
+
+	// NamespaceListerHandler lists namespaces
+	NamespaceListerHandler http.HandlerFunc
+}

--- a/vendor/github.com/openfaas/faas/gateway/types/inforequest.go
+++ b/vendor/github.com/openfaas/faas/gateway/types/inforequest.go
@@ -1,0 +1,25 @@
+package types
+
+// Platform architecture the gateway is running on
+var Arch string
+
+// GatewayInfo provides information about the gateway and it's connected components
+type GatewayInfo struct {
+	Provider *ProviderInfo `json:"provider"`
+	Version  *VersionInfo  `json:"version"`
+	Arch     string        `json:"arch"`
+}
+
+// ProviderInfo provides information about the configured provider
+type ProviderInfo struct {
+	Name          string       `json:"provider"`
+	Version       *VersionInfo `json:"version"`
+	Orchestration string       `json:"orchestration"`
+}
+
+// VersionInfo provides the commit message, sha and release version number
+type VersionInfo struct {
+	CommitMessage string `json:"commit_message,omitempty"`
+	SHA           string `json:"sha"`
+	Release       string `json:"release"`
+}

--- a/vendor/github.com/openfaas/faas/gateway/types/proxy_client.go
+++ b/vendor/github.com/openfaas/faas/gateway/types/proxy_client.go
@@ -1,0 +1,56 @@
+// Copyright (c) OpenFaaS Author(s) 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// NewHTTPClientReverseProxy proxies to an upstream host through the use of a http.Client
+func NewHTTPClientReverseProxy(baseURL *url.URL, timeout time.Duration, maxIdleConns, maxIdleConnsPerHost int) *HTTPClientReverseProxy {
+	h := HTTPClientReverseProxy{
+		BaseURL: baseURL,
+		Timeout: timeout,
+	}
+
+	h.Client = http.DefaultClient
+	h.Timeout = timeout
+	h.Client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+
+	// These overrides for the default client enable re-use of connections and prevent
+	// CoreDNS from rate limiting the gateway under high traffic
+	//
+	// See also two similar projects where this value was updated:
+	// https://github.com/prometheus/prometheus/pull/3592
+	// https://github.com/minio/minio/pull/5860
+
+	// Taken from http.DefaultTransport in Go 1.11
+	h.Client.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   timeout,
+			KeepAlive: timeout,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          maxIdleConns,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	return &h
+}
+
+// HTTPClientReverseProxy proxy to a remote BaseURL using a http.Client
+type HTTPClientReverseProxy struct {
+	BaseURL *url.URL
+	Client  *http.Client
+	Timeout time.Duration
+}

--- a/vendor/github.com/openfaas/faas/gateway/types/readconfig.go
+++ b/vendor/github.com/openfaas/faas/gateway/types/readconfig.go
@@ -1,0 +1,257 @@
+// Copyright (c) Alex Ellis 2017. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// OsEnv implements interface to wrap os.Getenv
+type OsEnv struct {
+}
+
+// Getenv wraps os.Getenv
+func (OsEnv) Getenv(key string) string {
+	return os.Getenv(key)
+}
+
+// HasEnv provides interface for os.Getenv
+type HasEnv interface {
+	Getenv(key string) string
+}
+
+// ReadConfig constitutes config from env variables
+type ReadConfig struct {
+}
+
+func parseBoolValue(val string) bool {
+	if val == "true" {
+		return true
+	}
+	return false
+}
+
+func parseIntOrDurationValue(val string, fallback time.Duration) time.Duration {
+	if len(val) > 0 {
+		parsedVal, parseErr := strconv.Atoi(val)
+		if parseErr == nil && parsedVal >= 0 {
+			return time.Duration(parsedVal) * time.Second
+		}
+	}
+
+	duration, durationErr := time.ParseDuration(val)
+	if durationErr != nil {
+		return fallback
+	}
+	return duration
+}
+
+// Read fetches gateway server configuration from environmental variables
+func (ReadConfig) Read(hasEnv HasEnv) (*GatewayConfig, error) {
+	cfg := GatewayConfig{
+		PrometheusHost: "prometheus",
+		PrometheusPort: 9090,
+	}
+
+	defaultDuration := time.Second * 8
+
+	cfg.ReadTimeout = parseIntOrDurationValue(hasEnv.Getenv("read_timeout"), defaultDuration)
+	cfg.WriteTimeout = parseIntOrDurationValue(hasEnv.Getenv("write_timeout"), defaultDuration)
+	cfg.UpstreamTimeout = parseIntOrDurationValue(hasEnv.Getenv("upstream_timeout"), defaultDuration)
+
+	if len(hasEnv.Getenv("functions_provider_url")) > 0 {
+		var err error
+		cfg.FunctionsProviderURL, err = url.Parse(hasEnv.Getenv("functions_provider_url"))
+		if err != nil {
+			return nil, fmt.Errorf("if functions_provider_url is provided, then it should be a valid URL, error: %s", err)
+		}
+	}
+
+	if len(hasEnv.Getenv("logs_provider_url")) > 0 {
+		var err error
+		cfg.LogsProviderURL, err = url.Parse(hasEnv.Getenv("logs_provider_url"))
+		if err != nil {
+			return nil, fmt.Errorf("if logs_provider_url is provided, then it should be a valid URL, error: %s", err)
+		}
+	} else if cfg.FunctionsProviderURL != nil {
+		cfg.LogsProviderURL, _ = url.Parse(cfg.FunctionsProviderURL.String())
+	}
+
+	faasNATSAddress := hasEnv.Getenv("faas_nats_address")
+	if len(faasNATSAddress) > 0 {
+		cfg.NATSAddress = &faasNATSAddress
+	}
+
+	faasNATSPort := hasEnv.Getenv("faas_nats_port")
+	if len(faasNATSPort) > 0 {
+		port, err := strconv.Atoi(faasNATSPort)
+		if err == nil {
+			cfg.NATSPort = &port
+		} else {
+			return nil, fmt.Errorf("faas_nats_port invalid number: %s", faasNATSPort)
+		}
+	}
+
+	faasNATSClusterName := hasEnv.Getenv("faas_nats_cluster_name")
+	if len(faasNATSClusterName) > 0 {
+		cfg.NATSClusterName = &faasNATSClusterName
+	} else {
+		v := "faas-cluster"
+		cfg.NATSClusterName = &v
+	}
+
+	faasNATSChannel := hasEnv.Getenv("faas_nats_channel")
+	if len(faasNATSChannel) > 0 {
+		cfg.NATSChannel = &faasNATSChannel
+	} else {
+		v := "faas-request"
+		cfg.NATSChannel = &v
+	}
+
+	prometheusPort := hasEnv.Getenv("faas_prometheus_port")
+	if len(prometheusPort) > 0 {
+		prometheusPortVal, err := strconv.Atoi(prometheusPort)
+		if err != nil {
+			return nil, fmt.Errorf("faas_prometheus_port invalid number: %s", faasNATSPort)
+		}
+		cfg.PrometheusPort = prometheusPortVal
+
+	}
+
+	prometheusHost := hasEnv.Getenv("faas_prometheus_host")
+	if len(prometheusHost) > 0 {
+		cfg.PrometheusHost = prometheusHost
+	}
+
+	cfg.DirectFunctions = parseBoolValue(hasEnv.Getenv("direct_functions"))
+	cfg.DirectFunctionsSuffix = hasEnv.Getenv("direct_functions_suffix")
+
+	cfg.UseBasicAuth = parseBoolValue(hasEnv.Getenv("basic_auth"))
+
+	secretPath := hasEnv.Getenv("secret_mount_path")
+	if len(secretPath) == 0 {
+		secretPath = "/run/secrets/"
+	}
+	cfg.SecretMountPath = secretPath
+	cfg.ScaleFromZero = parseBoolValue(hasEnv.Getenv("scale_from_zero"))
+
+	cfg.MaxIdleConns = 1024
+	cfg.MaxIdleConnsPerHost = 1024
+
+	maxIdleConns := hasEnv.Getenv("max_idle_conns")
+	if len(maxIdleConns) > 0 {
+		val, err := strconv.Atoi(maxIdleConns)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns: %s", maxIdleConns)
+		}
+		cfg.MaxIdleConns = val
+
+	}
+
+	maxIdleConnsPerHost := hasEnv.Getenv("max_idle_conns_per_host")
+	if len(maxIdleConnsPerHost) > 0 {
+		val, err := strconv.Atoi(maxIdleConnsPerHost)
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for max_idle_conns_per_host: %s", maxIdleConnsPerHost)
+		}
+		cfg.MaxIdleConnsPerHost = val
+
+	}
+
+	cfg.AuthProxyURL = hasEnv.Getenv("auth_proxy_url")
+	cfg.AuthProxyPassBody = parseBoolValue(hasEnv.Getenv("auth_proxy_pass_body"))
+
+	cfg.Namespace = hasEnv.Getenv("function_namespace")
+
+	if len(cfg.DirectFunctionsSuffix) > 0 && len(cfg.Namespace) > 0 {
+		if strings.HasPrefix(cfg.DirectFunctionsSuffix, cfg.Namespace) == false {
+			return nil, fmt.Errorf("function_namespace must be a sub-string of direct_functions_suffix")
+		}
+	}
+
+	return &cfg, nil
+}
+
+// GatewayConfig provides config for the API Gateway server process
+type GatewayConfig struct {
+
+	// HTTP timeout for reading a request from clients.
+	ReadTimeout time.Duration
+
+	// HTTP timeout for writing a response from functions.
+	WriteTimeout time.Duration
+
+	// UpstreamTimeout maximum duration of HTTP call to upstream URL
+	UpstreamTimeout time.Duration
+
+	// URL for alternate functions provider.
+	FunctionsProviderURL *url.URL
+
+	// URL for alternate function logs provider.
+	LogsProviderURL *url.URL
+
+	// Address of the NATS service. Required for async mode.
+	NATSAddress *string
+
+	// Port of the NATS Service. Required for async mode.
+	NATSPort *int
+
+	// The name of the NATS Streaming cluster. Required for async mode.
+	NATSClusterName *string
+
+	// NATSChannel is the name of the NATS Streaming channel used for asynchronous function invocations.
+	NATSChannel *string
+
+	// Host to connect to Prometheus.
+	PrometheusHost string
+
+	// Port to connect to Prometheus.
+	PrometheusPort int
+
+	// If set to true we will access upstream functions directly rather than through the upstream provider
+	DirectFunctions bool
+
+	// If set this will be used to resolve functions directly
+	DirectFunctionsSuffix string
+
+	// If set, reads secrets from file-system for enabling basic auth.
+	UseBasicAuth bool
+
+	// SecretMountPath specifies where to read secrets from for embedded basic auth
+	SecretMountPath string
+
+	// Enable the gateway to scale any service from 0 replicas to its configured "min replicas"
+	ScaleFromZero bool
+
+	// MaxIdleConns with a default value of 1024, can be used for tuning HTTP proxy performance
+	MaxIdleConns int
+
+	// MaxIdleConnsPerHost with a default value of 1024, can be used for tuning HTTP proxy performance
+	MaxIdleConnsPerHost int
+
+	// AuthProxyURL specifies URL for an authenticating proxy, disabled when blank, enabled when valid URL i.e. http://basic-auth.openfaas:8080/validate
+	AuthProxyURL string
+
+	// AuthProxyPassBody pass body to validation proxy
+	AuthProxyPassBody bool
+
+	// Namespace for endpoints
+	Namespace string
+}
+
+// UseNATS Use NATSor not
+func (g *GatewayConfig) UseNATS() bool {
+	return g.NATSPort != nil &&
+		g.NATSAddress != nil
+}
+
+// UseExternalProvider decide whether to bypass built-in Docker Swarm engine
+func (g *GatewayConfig) UseExternalProvider() bool {
+	return g.FunctionsProviderURL != nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,6 +33,7 @@ github.com/morikuni/aec
 # github.com/openfaas/faas v0.0.0-20201210155854-272ae94b506c
 ## explicit
 github.com/openfaas/faas/gateway/requests
+github.com/openfaas/faas/gateway/types
 # github.com/openfaas/faas-provider v0.16.1
 ## explicit
 github.com/openfaas/faas-provider/httputil


### PR DESCRIPTION
This updates the GetSystemInfo API to return typed struct rather than `map[string]interface{}`
It also removes support for legacy vesion info response from gateway which are available prior to version
0.8.4

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes: #796

## How Has This Been Tested?
Tested on my local cluster
```
./faas-cli version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:
 version: dev
Handling connection for 8080

Gateway
 uri:     http://127.0.0.1:8080
 version: dev
 sha:


Provider
 name:          faas-netes
 orchestration: kubernetes
 version:       dev
 sha:           819837dcf72d399d54650a30885a7f7074f49b0a
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
