### PR TITLE
Don't warn about insecure connections to localhost

### DIFF
--- a/commands/errors.go
+++ b/commands/errors.go
@@ -9,14 +9,16 @@ import (
 
 const (
 	// NoTLSWarn Warning thrown when no SSL/TLS is used
-	NoTLSWarn = "WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates."
+	NoTLSWarn = "WARNING! You are not using an encrypted connection to the gateway, consider using HTTPS."
 )
 
 // checkTLSInsecure returns a warning message if the given gateway does not have https.
 // Use tsInsecure to skip validations
 func checkTLSInsecure(gateway string, tlsInsecure bool) string {
 	if !tlsInsecure {
-		if !strings.HasPrefix(gateway, "https") {
+		if strings.HasPrefix(gateway, "https") == false &&
+			strings.HasPrefix(gateway, "http://127.0.0.1") == false &&
+			strings.HasPrefix(gateway, "http://localhost") == false {
 			return NoTLSWarn
 		}
 	}

--- a/commands/errors_test.go
+++ b/commands/errors_test.go
@@ -14,14 +14,30 @@ func Test_checkTLSInsecure(t *testing.T) {
 		args args
 		want string
 	}{
-		{name: "secure gateway and tls secure", args: args{gateway: "https://127.0.0.1:8080", tlsInsecure: false}, want: ""},
-		{name: "secure gateway and tls insecure", args: args{gateway: "https://127.0.0.1:8080", tlsInsecure: true}, want: ""},
-		{name: "insecure gateway and tls secure", args: args{gateway: "http://127.0.0.1:8080", tlsInsecure: false}, want: "WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates."},
-		{name: "insecure gateway and tls insecure", args: args{gateway: "http://127.0.0.1:8080", tlsInsecure: true}, want: ""},
+		{name: "HTTPS gateway",
+			args: args{gateway: "https://192.168.0.101:8080", tlsInsecure: false},
+			want: ""},
+		{name: "HTTPS gateway with TLSInsecure",
+			args: args{gateway: "https://192.168.0.101:8080", tlsInsecure: true},
+			want: ""},
+		{name: "HTTP gateway without TLSInsecure",
+			args: args{gateway: "http://192.168.0.101:8080", tlsInsecure: false},
+			want: "WARNING! You are not using an encrypted connection to the gateway, consider using HTTPS."},
+		{name: "HTTP gateway to 127.0.0.1 without TLSInsecure",
+			args: args{gateway: "http://127.0.0.1:8080", tlsInsecure: false},
+			want: ""},
+		{name: "HTTP gateway to localhost without TLSInsecure",
+			args: args{gateway: "http://localhost:8080", tlsInsecure: false},
+			want: ""},
+		{name: "HTTP gateway to remote host with TLSInsecure", args: args{gateway: "http://192.168.0.101:8080", tlsInsecure: true},
+			want: ""},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := checkTLSInsecure(tt.args.gateway, tt.args.tlsInsecure); got != tt.want {
+			got := checkTLSInsecure(tt.args.gateway, tt.args.tlsInsecure)
+
+			if got != tt.want {
 				t.Errorf("checkTLSInsecure() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Don't warn about insecure connections to localhost

## Motivation and Context

This message isn't strictly required or beneficial when
connecting to 127.0.0.1 or localhost, where certificates from
Let's Encrypt are not applicable. If using Kubernetes or SSH
port forwarding, then the connection is encrypted already.

The warning message has been updated since SSL is not
applicable to HTTPS currently.

## How Has This Been Tested?

Tested by creating an SSH tunnel to a faasd instance, and
seeing no warning, then connecting to the same faasd instance
with its IP addresses, and continuing to see the error.

The unit tests have been updated to account for the change 
in behaviour wrt: localhost/127.0.0.1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the unit tests
