### PR TITLE
Remove leaking logs from SDK

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -276,7 +276,9 @@ Error: %s`, fprocessErr.Error())
 			if msg := checkTLSInsecure(services.Provider.GatewayURL, deploySpec.TLSInsecure); len(msg) > 0 {
 				fmt.Println(msg)
 			}
-			statusCode := proxyClient.DeployFunction(ctx, deploySpec)
+			statusCode, deployOutputStr := proxyClient.DeployFunction(ctx, deploySpec)
+			fmt.Println()
+			fmt.Println(deployOutputStr)
 			if badStatusCode(statusCode) {
 				failedStatusCodes[k] = statusCode
 			}
@@ -375,8 +377,9 @@ func deployImage(
 		fmt.Println(msg)
 	}
 
-	statusCode = client.DeployFunction(ctx, deploySpec)
-
+	statusCode, deployOutputStr := client.DeployFunction(ctx, deploySpec)
+	fmt.Println()
+	fmt.Println(deployOutputStr)
 	return statusCode, nil
 }
 

--- a/proxy/delete.go
+++ b/proxy/delete.go
@@ -30,14 +30,12 @@ func (c *Client) DeleteFunction(ctx context.Context, functionName string, namesp
 
 	req, err := c.newRequest(http.MethodDelete, deleteEndpoint, reader)
 	if err != nil {
-		fmt.Println(err)
 		return err
 	}
 	delRes, delErr := c.doRequest(ctx, req)
 
 	if delErr != nil {
-		fmt.Printf("Error removing existing function: %s, gateway=%s, functionName=%s\n", delErr.Error(), c.GatewayURL.String(), functionName)
-		return delErr
+		return fmt.Errorf("error removing existing function: %s, gateway=%s, functionName=%s", delErr.Error(), c.GatewayURL.String(), functionName)
 	}
 
 	if delRes.Body != nil {
@@ -46,7 +44,6 @@ func (c *Client) DeleteFunction(ctx context.Context, functionName string, namesp
 
 	switch delRes.StatusCode {
 	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
-		fmt.Println("Removing old function.")
 	case http.StatusNotFound:
 		err = fmt.Errorf("No existing function to remove")
 	case http.StatusUnauthorized:

--- a/proxy/delete_test.go
+++ b/proxy/delete_test.go
@@ -21,13 +21,10 @@ func Test_DeleteFunction(t *testing.T) {
 	cliAuth := NewTestAuth(nil)
 	proxyClient, _ := NewClient(cliAuth, s.URL, nil, &defaultCommandTimeout)
 
-	stdout := test.CaptureStdout(func() {
-		proxyClient.DeleteFunction(context.Background(), "function-to-delete", "")
-	})
+	err := proxyClient.DeleteFunction(context.Background(), "function-to-delete", "")
 
-	r := regexp.MustCompile(`(?m:Removing old function.)`)
-	if !r.MatchString(stdout) {
-		t.Fatalf("Want: %s, got: %s", "Removing old function", stdout)
+	if err != nil {
+		t.Fatalf("Got error: %s", err.Error())
 	}
 }
 

--- a/proxy/deploy.go
+++ b/proxy/deploy.go
@@ -59,21 +59,15 @@ func generateFuncStr(spec *DeployFunctionSpec) string {
 
 // DeployFunction first tries to deploy a function and if it exists will then attempt
 // a rolling update. Warnings are suppressed for the second API call (if required.)
-func (c *Client) DeployFunction(context context.Context, spec *DeployFunctionSpec) int {
+func (c *Client) DeployFunction(context context.Context, spec *DeployFunctionSpec) (int, string) {
 
-	rollingUpdateInfo := fmt.Sprintf("Function %s already exists, attempting rolling-update.", spec.FunctionName)
 	statusCode, deployOutput := c.deploy(context, spec, spec.Update)
 
 	if spec.Update == true && statusCode == http.StatusNotFound {
 		// Re-run the function with update=false
-
 		statusCode, deployOutput = c.deploy(context, spec, false)
-	} else if statusCode == http.StatusOK {
-		fmt.Println(rollingUpdateInfo)
 	}
-	fmt.Println()
-	fmt.Println(deployOutput)
-	return statusCode
+	return statusCode, deployOutput
 }
 
 // deploy a function to an OpenFaaS gateway over REST

--- a/proxy/invoke.go
+++ b/proxy/invoke.go
@@ -5,7 +5,6 @@ package proxy
 
 import (
 	"bytes"
-	"os"
 
 	"fmt"
 	"io/ioutil"
@@ -53,8 +52,6 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 
 	req, err := http.NewRequest(httpMethod, gatewayURL, reader)
 	if err != nil {
-		fmt.Println()
-		fmt.Println(err)
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}
 
@@ -71,8 +68,6 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 	res, err := client.Do(req)
 
 	if err != nil {
-		fmt.Println()
-		fmt.Println(err)
 		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", gateway)
 	}
 
@@ -82,7 +77,6 @@ func InvokeFunction(gateway string, name string, bytesIn *[]byte, contentType st
 
 	switch res.StatusCode {
 	case http.StatusAccepted:
-		fmt.Fprintf(os.Stderr, "Function submitted asynchronously.\n")
 	case http.StatusOK:
 		var readErr error
 		resBytes, readErr = ioutil.ReadAll(res.Body)


### PR DESCRIPTION
This commit removes leaking logs from the SDK (proxy package) of the CLI by removing
custom print statements within proxy package. It updates method signature for
DeployFunction which now returns deployOutput text along with status code.

Fixes: #853

Signed-off-by: Vivek Singh <vivekkmr45@yahoo.in>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
