### PR TITLE
Remove "openfaas-fn" as default namespace

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	defaultFunctionNamespace = "openfaas-fn"
+	defaultFunctionNamespace = ""
 	resourceKind             = "Function"
 	defaultAPIVersion        = "openfaas.com/v1"
 )

--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -23,7 +23,7 @@ var generateTestcases = []struct {
 	Version    string
 }{
 	{
-		Name: "Default Namespace and API Version",
+		Name: "Specified Namespace and API Version",
 		Input: `
 provider:
   name: openfaas

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -64,13 +64,11 @@ func getNamespace(flagNamespace, stackNamespace string) string {
 	if len(flagNamespace) > 0 {
 		return flagNamespace
 	}
-
-	// if both the namespace flag in stack.yaml and the namespace flag are ommitted
-	// return the defaultNamespace (openfaas-fn)
-	if len(stackNamespace) == 0 && len(flagNamespace) == 0 {
-		return defaultFunctionNamespace
+	// https://github.com/openfaas/faas-cli/issues/742#issuecomment-625746405
+	if len(stackNamespace) > 0 {
+		return stackNamespace
 	}
 
-	// Else return the namespace in stack.yaml
-	return stackNamespace
+	return defaultFunctionNamespace
+
 }

--- a/commands/priority_test.go
+++ b/commands/priority_test.go
@@ -61,7 +61,7 @@ func Test_getOverrideNamespace(t *testing.T) {
 		{
 			stack:    "",
 			flag:     "",
-			want:     "openfaas-fn",
+			want:     "",
 			scenario: "no namespace value set in flag and in namespace field of stack file",
 		},
 


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
A user deployed to Okteto where the namespace by default is their username.  By forcing openfaas-fn by default this was preventing a zero value from being passed which had the effect of always over-riding the users default namespace.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #869 
## How Has This Been Tested?

* Created a k8s cluster on DO.
* Created new namespaces (rgee0 & test)
* Set direct_functions_suffix=rgee0.svc.cluster.local & function_namespace=rgee0

```
$ kubectl describe deploy/gateway -n openfaas                                    
Name:                   gateway
Namespace:              openfaas
CreationTimestamp:      Thu, 11 Mar 2021 18:08:05 +0000
Labels:                 app=openfaas
                        app.kubernetes.io/managed-by=Helm
                        chart=openfaas-7.2.2
                        component=gateway
                        heritage=Helm
                        release=openfaas
Annotations:            deployment.kubernetes.io/revision: 9
                        meta.helm.sh/release-name: openfaas
                        meta.helm.sh/release-namespace: openfaas
Selector:               app=gateway
Replicas:               1 desired | 1 updated | 1 total | 1 available | 0 unavailable
StrategyType:           RollingUpdate
MinReadySeconds:        0
RollingUpdateStrategy:  25% max unavailable, 25% max surge
Pod Template:
  Labels:           app=gateway
  Annotations:      prometheus.io.port: 8082
                    prometheus.io.scrape: true
  Service Account:  openfaas-controller
  Containers:
   gateway:
    Image:      ghcr.io/openfaas/gateway:0.20.11
    Port:       8080/TCP
    Host Port:  0/TCP
    Requests:
      cpu:      50m
      memory:   120Mi
    Liveness:   http-get http://:8080/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
    Readiness:  http-get http://:8080/healthz delay=0s timeout=5s period=10s #success=1 #failure=3
    Environment:
      read_timeout:             65s
      write_timeout:            65s
      upstream_timeout:         60s
      functions_provider_url:   http://127.0.0.1:8081/
      direct_functions:         false
      direct_functions_suffix:  rgee0.svc.cluster.local
      function_namespace:       rgee0
      faas_nats_address:        nats.openfaas.svc.cluster.local
      faas_nats_port:           4222
      faas_nats_channel:        faas-request
      basic_auth:               true
      secret_mount_path:        /var/secrets
      auth_proxy_url:           http://basic-auth-plugin.openfaas:8080/validate
      auth_pass_body:           false
      scale_from_zero:          true
      max_idle_conns:           1024
      max_idle_conns_per_host:  1024
    Mounts:
      /var/secrets from auth (ro)
   faas-netes:
    Image:      ghcr.io/openfaas/faas-netes:0.13.1
    Port:       8081/TCP
    Host Port:  0/TCP
    Requests:
      cpu:     50m
      memory:  120Mi
    Environment:
      port:                                   8081
      function_namespace:                     rgee0
      read_timeout:                           60s
      profiles_namespace:                     openfaas
      write_timeout:                          60s
      image_pull_policy:                      Always
      http_probe:                             true
      set_nonroot_user:                       false
      readiness_probe_initial_delay_seconds:  2
      readiness_probe_timeout_seconds:        1
      readiness_probe_period_seconds:         2
      liveness_probe_initial_delay_seconds:   2
      liveness_probe_timeout_seconds:         1
      liveness_probe_period_seconds:          2
      cluster_role:                           true
      direct_functions_suffix:                rgee0.svc.cluster.local
    Mounts:
      /tmp from faas-netes-temp-volume (rw)
  Volumes:
   faas-netes-temp-volume:
    Type:       EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:     
    SizeLimit:  <unset>
   auth:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  basic-auth
    Optional:    false
```

* Built the CLI locally

```
./faas-cli version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  2fd226eb116a3c635ed4049752d8c0e81b8b4c52
 version: 0.6.13-363-g2fd226eb

Gateway
 uri:     http://144.126.246.50:8080
 version: 0.20.11
 sha:     f8576d5b5d192b60e2af85e0f1d4b50e2bcf3169

Provider
 name:          faas-netes
 orchestration: kubernetes
 version:       0.13.1 
 sha:           75b987f1f9dbf8a292de7b8d5c9682a86296e9be
Your faas-cli version (0.6.13-363-g2fd226eb) may be out of date. Version: 0.13.6 is now available on GitHub.
```

* Check deployments - no functions in `rgee0`, nor `openfaas-fn`, nor `test`

```
$ kubectl get deploy --all-namespaces
NAMESPACE     NAME                READY   UP-TO-DATE   AVAILABLE   AGE
kube-system   cilium-operator     2/2     2            2           92m
kube-system   coredns             2/2     2            2           92m
openfaas      alertmanager        1/1     1            1           84m
openfaas      basic-auth-plugin   1/1     1            1           84m
openfaas      gateway             1/1     1            1           84m
openfaas      nats                1/1     1            1           84m
openfaas      prometheus          1/1     1            1           84m
openfaas      queue-worker        1/1     1            1           84m
```

### Deploy without specifying a namespace in YAML or by Flag

```
$ ./faas-cli deploy newdefault -f newdefault.yml
Deploying: newdefault.
WARNING! You are not using an encrypted connection to the gateway, consider using HTTPS.

Deployed. 202 Accepted.
URL: http://144.126.246.50:8080/function/newdefault

$ cat newdefault.yml                            
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  newdefault:
    lang: go
    handler: ./newdefault
    image: rgee0/newdefault:latest

$ kubectl get deploy --all-namespaces           
NAMESPACE     NAME                READY   UP-TO-DATE   AVAILABLE   AGE
kube-system   cilium-operator     2/2     2            2           93m
kube-system   coredns             2/2     2            2           93m
openfaas      alertmanager        1/1     1            1           85m
openfaas      basic-auth-plugin   1/1     1            1           85m
openfaas      gateway             1/1     1            1           85m
openfaas      nats                1/1     1            1           85m
openfaas      prometheus          1/1     1            1           85m
openfaas      queue-worker        1/1     1            1           85m
rgee0         newdefault          1/1     1            1           35s
```
### Deploy by specifying a namespace in YAML

```
$ ./faas-cli deploy newdefault -f newdefault.yml
Deploying: newdefault.
WARNING! Communication is not secure, please consider using HTTPS. Letsencrypt.org offers free SSL/TLS certificates.

Deployed. 202 Accepted.
URL: http://144.126.246.50:8080/function/newdefault.test

$ cat newdefault.yml                            
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  newdefault:
    namespace: test
    lang: go
    handler: ./newdefault
    image: rgee0/newdefault:latest

$ kubectl get deploy --all-namespaces  
NAMESPACE     NAME                READY   UP-TO-DATE   AVAILABLE   AGE
kube-system   cilium-operator     2/2     2            2           94m
kube-system   coredns             2/2     2            2           94m
openfaas      alertmanager        1/1     1            1           86m
openfaas      basic-auth-plugin   1/1     1            1           86m
openfaas      gateway             1/1     1            1           86m
openfaas      nats                1/1     1            1           86m
openfaas      prometheus          1/1     1            1           86m
openfaas      queue-worker        1/1     1            1           86m
rgee0         newdefault          1/1     1            1           92s
test          newdefault          1/1     1            1           21s
```

### Deploy by specifying a namespace in YAML and Flag (Flag has priority)

```
$  ./faas-cli deploy newdefault -f newdefault.yml -n openfaas-fn
Deploying: newdefault.
WARNING! You are not using an encrypted connection to the gateway, consider using HTTPS.

Deployed. 202 Accepted.
URL: http://144.126.246.50:8080/function/newdefault.openfaas-fn

$ cat newdefault.yml                            
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  newdefault:
    namespace: test
    lang: go
    handler: ./newdefault
    image: rgee0/newdefault:latest

$ kubectl get deploy --all-namespaces 
NAMESPACE     NAME                READY   UP-TO-DATE   AVAILABLE   AGE
kube-system   cilium-operator     2/2     2            2           95m
kube-system   coredns             2/2     2            2           95m
openfaas-fn   newdefault          1/1     1            1           31s
openfaas      alertmanager        1/1     1            1           87m
openfaas      basic-auth-plugin   1/1     1            1           87m
openfaas      gateway             1/1     1            1           87m
openfaas      nats                1/1     1            1           87m
openfaas      prometheus          1/1     1            1           87m
openfaas      queue-worker        1/1     1            1           87m
rgee0         newdefault          1/1     1            1           2m47s
test          newdefault          1/1     1            1           96s
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change) - Previously not specifying a namespace would result in the gateway receiving `openfaas-fn` as a namespace value.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
