### PR TITLE
Add sort order to generate command

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -249,10 +249,8 @@ func generateknativev1ServingServiceCRDYAML(services stack.Services, format sche
 			return "", envErr
 		}
 
-		var env []knativev1.EnvPair
-		for k, v := range allEnvironment {
-			env = append(env, knativev1.EnvPair{Name: k, Value: v})
-		}
+		env := orderknativeEnv(allEnvironment)
+
 		var annotations map[string]string
 
 		if function.Annotations != nil {
@@ -331,4 +329,22 @@ func generateFunctionOrder(functions map[string]stack.Function) []string {
 	sort.Strings(functionNames)
 
 	return functionNames
+}
+
+func orderknativeEnv(environment map[string]string) []knativev1.EnvPair {
+
+	var orderedEnvironment []string
+	var envVars []knativev1.EnvPair
+
+	for k := range environment {
+		orderedEnvironment = append(orderedEnvironment, k)
+	}
+
+	sort.Strings(orderedEnvironment)
+
+	for _, envVar := range orderedEnvironment {
+		envVars = append(envVars, knativev1.EnvPair{Name: envVar, Value: environment[envVar]})
+	}
+
+	return envVars
 }

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"sort"
 
 	v2 "github.com/openfaas/faas-cli/schema/store/v2"
 
@@ -178,7 +179,11 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 			return generateknativev1ServingServiceCRDYAML(services, format, api, functionNamespace, branch, version)
 		}
 
-		for name, function := range services.Functions {
+		orderedNames := generateFunctionOrder(services.Functions)
+
+		for _, name := range orderedNames {
+
+			function := services.Functions[name]
 			//read environment variables from the file
 			fileEnvironment, err := readFiles(function.EnvironmentFile)
 			if err != nil {
@@ -227,7 +232,11 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 func generateknativev1ServingServiceCRDYAML(services stack.Services, format schema.BuildFormat, apiVersion, namespace, branch, version string) (string, error) {
 	crds := []knativev1.ServingServiceCRD{}
 
-	for name, function := range services.Functions {
+	orderedNames := generateFunctionOrder(services.Functions)
+
+	for _, name := range orderedNames {
+
+		function := services.Functions[name]
 
 		fileEnvironment, err := readFiles(function.EnvironmentFile)
 		if err != nil {
@@ -309,4 +318,17 @@ func generateknativev1ServingServiceCRDYAML(services stack.Services, format sche
 	}
 
 	return objectsString, nil
+}
+
+func generateFunctionOrder(functions map[string]stack.Function) []string {
+
+	var functionNames []string
+
+	for functionName := range functions {
+		functionNames = append(functionNames, functionName)
+	}
+
+	sort.Strings(functionNames)
+
+	return functionNames
 }


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change seeks to introduce a pre-processing stage where a slice of function names is created and a rudimentary sort applied. This slice is then used to iterate through the map using the function name.

## Motivation and Context
The output from faas-cli generate is not deterministic.  The function detail is stored in a map which is by design non-deterministic.
This behaviour is undesirable as generating from the same stack will result in a different output, hence makes tracking diffs, particularly in git, quite a challenge.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes #777

## How Has This Been Tested?
Previous mode of operation is described in https://github.com/openfaas/faas-cli/issues/777#issuecomment-797420368.  The following is provided as a comparison.
### Testing output
```
$ faas-cli version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  2ef6d23a62d371d72a6fcdc7cb87afeccde4a001-dirty
 version: 0.6.13-365-g2ef6d23a
Your faas-cli version (0.6.13-365-g2ef6d23a) may be out of date. Version: 0.13.9 is now available on GitHub.
```
* Check stack.yml being used:
```
$ cat fn1.yml
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  fn1:
    lang: python3
    handler: ./fn1
    image: fn1:latest

  fn2:
    lang: python3
    handler: ./fn2
    image: fn2:latest

  fn3:
    lang: python3
    handler: ./fn3
    image: fn3:latest

  fn4:
    lang: python3
    handler: ./fn4
    image: fn4:latest

  fn5:
    lang: python3
    handler: ./fn5
    image: fn5:latest

  fn6:
    lang: python3
    handler: ./fn6
    image: fn6:latest

  fn7:
    lang: python3
    handler: ./fn7
    image: fn7:latest

  fn8:
    lang: python3
    handler: ./fn8
    image: fn8:latest

  fn9:
    lang: python3
    handler: ./fn9
    image: fn9:latest

  fn10:
    lang: python3
    handler: ./fn10
    image: fn10:latest

  fn11:
    lang: python3
    handler: ./fn11
    image: fn11:latest

  fn12:
    lang: python3
    handler: ./fn12
    image: fn12:latest

  fn13:
    lang: python3
    handler: ./fn13
    image: fn13:latest

  fn14:
    lang: python3
    handler: ./fn14
    image: fn14:latest

  fn15:
    lang: python3
    handler: ./fn15
    image: fn15:latest

  fn16:
    lang: python3
    handler: ./fn16
    image: fn16:latest

  fn17:
    lang: python3
    handler: ./fn17
    image: fn17:latest

  fn18:
    lang: python3
    handler: ./fn18
    image: fn18:latest

  fn19:
    lang: python3
    handler: ./fn19
    image: fn19:latest

  fn20:
    lang: python3
    handler: ./fn20
    image: fn20:latest
```
* Run generate 20 times against the stack.yml to create a set of generated files from the same input.
```
$ for i in {1..20}; do faas-cli generate  -f fn1.yml > ./generated2/$i.yml ; done
$ ls generated2
1.yml	10.yml	11.yml	12.yml	13.yml	14.yml	15.yml	16.yml	17.yml	18.yml	19.yml	2.yml	20.yml	3.yml	4.yml	5.yml	6.yml	7.yml	8.yml	9.yml
```
* Compare all generated files to find any differences:
```
$ cd generated2 
$ for i in {1..20}; do for j in {1..20}; do cmp -b $i.yml $j.yml >> diffs.txt ; done ; done
$ cat diffs.txt 
$ 
```
No differences observed
* Compare two generated files in detail to confirm
```
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn1							  name: fn1
spec:								spec:
  name: fn1							  name: fn1
  image: fn1:latest						  image: fn1:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn10							  name: fn10
spec:								spec:
  name: fn10							  name: fn10
  image: fn10:latest						  image: fn10:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn11							  name: fn11
spec:								spec:
  name: fn11							  name: fn11
  image: fn11:latest						  image: fn11:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn12							  name: fn12
spec:								spec:
  name: fn12							  name: fn12
  image: fn12:latest						  image: fn12:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn13							  name: fn13
spec:								spec:
  name: fn13							  name: fn13
  image: fn13:latest						  image: fn13:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn14							  name: fn14
spec:								spec:
  name: fn14							  name: fn14
  image: fn14:latest						  image: fn14:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn15							  name: fn15
spec:								spec:
  name: fn15							  name: fn15
  image: fn15:latest						  image: fn15:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn16							  name: fn16
spec:								spec:
  name: fn16							  name: fn16
  image: fn16:latest						  image: fn16:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn17							  name: fn17
spec:								spec:
  name: fn17							  name: fn17
  image: fn17:latest						  image: fn17:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn18							  name: fn18
spec:								spec:
  name: fn18							  name: fn18
  image: fn18:latest						  image: fn18:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn19							  name: fn19
spec:								spec:
  name: fn19							  name: fn19
  image: fn19:latest						  image: fn19:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn2							  name: fn2
spec:								spec:
  name: fn2							  name: fn2
  image: fn2:latest						  image: fn2:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn20							  name: fn20
spec:								spec:
  name: fn20							  name: fn20
  image: fn20:latest						  image: fn20:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn3							  name: fn3
spec:								spec:
  name: fn3							  name: fn3
  image: fn3:latest						  image: fn3:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn4							  name: fn4
spec:								spec:
  name: fn4							  name: fn4
  image: fn4:latest						  image: fn4:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn5							  name: fn5
spec:								spec:
  name: fn5							  name: fn5
  image: fn5:latest						  image: fn5:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn6							  name: fn6
spec:								spec:
  name: fn6							  name: fn6
  image: fn6:latest						  image: fn6:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn7							  name: fn7
spec:								spec:
  name: fn7							  name: fn7
  image: fn7:latest						  image: fn7:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn8							  name: fn8
spec:								spec:
  name: fn8							  name: fn8
  image: fn8:latest						  image: fn8:latest
---								---
apiVersion: openfaas.com/v1					apiVersion: openfaas.com/v1
kind: Function							kind: Function
metadata:							metadata:
  name: fn9							  name: fn9
spec:								spec:
  name: fn9							  name: fn9
  image: fn9:latest						  image: fn9:latest
```
* For completeness perform same steps with --api serving.knative.dev/v1
```
mkdir generated3
$ for i in {1..20}; do faas-cli generate --api serving.knative.dev/v1  -f fn1.yml > ./generated3/$i.yml ; done
$ ls generated3                                                                                      
1.yml	10.yml	11.yml	12.yml	13.yml	14.yml	15.yml	16.yml	17.yml	18.yml	19.yml	2.yml	20.yml	3.yml	4.yml	5.yml	6.yml	7.yml	8.yml	9.yml
$ cd generated3                                                                                                                   
$ for i in {1..20}; do for j in {1..20}; do cmp -b $i.yml $j.yml >> diffs.txt ; done ; done                                       
$ cat diffs.txt                                                                                                                   
$ diff -y -W 120  1.yml 2.yml                                                                                                     
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn1							  name: fn1
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn1:latest					      - image: fn1:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn10							  name: fn10
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn10:latest					      - image: fn10:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn11							  name: fn11
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn11:latest					      - image: fn11:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn12							  name: fn12
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn12:latest					      - image: fn12:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn13							  name: fn13
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn13:latest					      - image: fn13:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn14							  name: fn14
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn14:latest					      - image: fn14:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn15							  name: fn15
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn15:latest					      - image: fn15:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn16							  name: fn16
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn16:latest					      - image: fn16:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn17							  name: fn17
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn17:latest					      - image: fn17:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn18							  name: fn18
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn18:latest					      - image: fn18:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn19							  name: fn19
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn19:latest					      - image: fn19:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn2							  name: fn2
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn2:latest					      - image: fn2:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn20							  name: fn20
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn20:latest					      - image: fn20:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn3							  name: fn3
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn3:latest					      - image: fn3:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn4							  name: fn4
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn4:latest					      - image: fn4:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn5							  name: fn5
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn5:latest					      - image: fn5:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn6							  name: fn6
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn6:latest					      - image: fn6:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn7							  name: fn7
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn7:latest					      - image: fn7:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn8							  name: fn8
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn8:latest					      - image: fn8:latest
---								---
apiVersion: serving.knative.dev/v1				apiVersion: serving.knative.dev/v1
kind: Service							kind: Service
metadata:							metadata:
  name: fn9							  name: fn9
spec:								spec:
  template:							  template:
    spec:							    spec:
      containers:						      containers:
      - image: fn9:latest					      - image: fn9:latest
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
