### PR TITLE
build: fix image name when having the case foo:1234/bar

### DIFF
--- a/schema/image.go
+++ b/schema/image.go
@@ -65,7 +65,8 @@ func (i *BuildFormat) Set(value string) error {
 // BuildImageName builds a Docker image tag for build, push or deploy
 func BuildImageName(format BuildFormat, image string, version string, branch string) string {
 	imageVal := image
-	if strings.Contains(image, ":") == false {
+	splitImage := strings.Split(image, "/")
+	if strings.Contains(splitImage[len(splitImage)-1], ":") == false {
 		imageVal += ":latest"
 	}
 

--- a/schema/image_test.go
+++ b/schema/image_test.go
@@ -11,9 +11,27 @@ func Test_BuildImageName_DefaultFormat(t *testing.T) {
 	}
 }
 
+func Test_BuildImageName_DefaultFormat_WithCustomServerPort(t *testing.T) {
+	want := "registry:8080/honk/img:latest"
+	got := BuildImageName(DefaultFormat, "registry:8080/honk/img", "ef384", "master")
+
+	if got != want {
+		t.Errorf("BuildImageName want: \"%s\", got: \"%s\"", want, got)
+	}
+}
+
 func Test_BuildImageName_SHAFormat(t *testing.T) {
 	want := "img:latest-ef384"
 	got := BuildImageName(SHAFormat, "img", "ef384", "master")
+
+	if got != want {
+		t.Errorf("BuildImageName want: \"%s\", got: \"%s\"", want, got)
+	}
+}
+
+func Test_BuildImageName_SHAFormat_WithCustomServerPort(t *testing.T) {
+	want := "registry:5000/honk/img:latest-ef384"
+	got := BuildImageName(SHAFormat, "registry:5000/honk/img", "ef384", "master")
 
 	if got != want {
 		t.Errorf("BuildImageName want: \"%s\", got: \"%s\"", want, got)
@@ -29,9 +47,27 @@ func Test_BuildImageName_SHAFormat_WithNumericVersion(t *testing.T) {
 	}
 }
 
+func Test_BuildImageName_SHAFormat_WithNumericVersion_WithCustomServerPort(t *testing.T) {
+	want := "registry:3000/honk/img:0.2-ef384"
+	got := BuildImageName(SHAFormat, "registry:3000/honk/img:0.2", "ef384", "master")
+
+	if got != want {
+		t.Errorf("BuildImageName want: \"%s\", got: \"%s\"", want, got)
+	}
+}
+
 func Test_BuildImageName_BranchAndSHAFormat(t *testing.T) {
 	want := "img:latest-master-ef384"
 	got := BuildImageName(BranchAndSHAFormat, "img", "ef384", "master")
+
+	if got != want {
+		t.Errorf("BuildImageName want: \"%s\", got: \"%s\"", want, got)
+	}
+}
+
+func Test_BuildImageName_BranchAndSHAFormat_WithCustomServerPort(t *testing.T) {
+	want := "registry:80/honk/img:latest-master-ef384"
+	got := BuildImageName(BranchAndSHAFormat, "registry:80/honk/img", "ef384", "master")
 
 	if got != want {
 		t.Errorf("BuildImageName want: \"%s\", got: \"%s\"", want, got)


### PR DESCRIPTION
## Description
Fixes the issue described in https://github.com/openfaas/faas-cli/issues/875

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: https://github.com/openfaas/faas-cli/issues/875

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build this PR, and you can follow the steps described in the issue https://github.com/openfaas/faas-cli/issues/875

```
$ faas-cli build --tag sha --image foo:1234/bar --handler ./foo --name foo --lang go
....
#29 writing image sha256:3010593902cbc6c65947e710e240e4f40f25533b5721628a94a25a4a2313245b done
#29 naming to foo:1234/bar:latest-a26c44e done
#29 DONE 0.0s
Image: foo:1234/bar:latest-a26c44e built.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

cc @alexellis 