### PR TITLE
Refactor Proxy Secrets CRUD to new 3 value returns

### DIFF
--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -126,8 +126,11 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Creating secret: " + secret.Name)
-	_, output := client.CreateSecret(context.Background(), secret)
-	fmt.Printf(output)
+	_, err = client.CreateSecret(context.Background(), secret)
+	if err != nil {
+		return err
+	}
+	fmt.Println("Secret Created")
 
 	return nil
 }

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -58,7 +58,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	secrets, err := client.GetSecretList(context.Background(), functionNamespace)
+	secrets, _, err := client.GetSecretList(context.Background(), functionNamespace)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -6,11 +6,10 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
-
 	"github.com/openfaas/faas-cli/proxy"
-	types "github.com/openfaas/faas-provider/types"
+	"github.com/openfaas/faas-provider/types"
 	"github.com/spf13/cobra"
+	"os"
 )
 
 var secretRemoveCmd = &cobra.Command{
@@ -43,7 +42,7 @@ func preRunSecretRemoveCmd(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runSecretRemove(cmd *cobra.Command, args []string) error {
+func runSecretRemove(_ *cobra.Command, args []string) error {
 	var gatewayAddress string
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
@@ -66,12 +65,13 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = client.RemoveSecret(context.Background(), secret)
+	_, err = client.RemoveSecret(context.Background(), secret)
+
 	if err != nil {
 		return err
 	}
 
-	fmt.Print("Removed.. OK.\n")
+	fmt.Println("Removed OK")
 
 	return nil
 }

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -112,8 +112,11 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Updating secret: " + secret.Name)
-	_, output := client.UpdateSecret(context.Background(), secret)
-	fmt.Printf(output)
+	_, err = client.UpdateSecret(context.Background(), secret)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Secret updated")
 
 	return nil
 }

--- a/proxy/deploy_test.go
+++ b/proxy/deploy_test.go
@@ -164,7 +164,7 @@ type testAuth struct {
 	err error
 }
 
-func (c *testAuth) Set(req *http.Request) error {
+func (c *testAuth) Set(_ *http.Request) error {
 	return c.err
 }
 

--- a/proxy/errors.go
+++ b/proxy/errors.go
@@ -1,0 +1,33 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type OpenFaaSError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e OpenFaaSError) Error() string {
+	switch e.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Sprintf("unauthorized access, run \"faas-cli login\" to setup authentication for this server - http status %d", e.StatusCode)
+	case http.StatusNotFound:
+		return fmt.Sprintf("resource not found - http status %d", e.StatusCode)
+	case http.StatusInternalServerError:
+		return fmt.Sprintf("openfaas encountered an internal server error - http status: %d", e.StatusCode)
+	case http.StatusBadRequest:
+		return fmt.Sprintf("bad request - http status: %d", e.StatusCode)
+	default:
+		return fmt.Sprintf("%s - http status: %d", e.Message, e.StatusCode)
+	}
+}
+
+func NewOpenFaaSError(message string, statusCode int) error {
+	return OpenFaaSError{
+		StatusCode: statusCode,
+		Message:    message,
+	}
+}

--- a/proxy/secret.go
+++ b/proxy/secret.go
@@ -16,7 +16,7 @@ const (
 )
 
 // GetSecretList get secrets list
-func (c *Client) GetSecretList(ctx context.Context, namespace string) ([]types.Secret, error) {
+func (c *Client) GetSecretList(ctx context.Context, namespace string) ([]types.Secret, *http.Response, error) {
 	var (
 		results    []types.Secret
 		err        error
@@ -30,161 +30,123 @@ func (c *Client) GetSecretList(ctx context.Context, namespace string) ([]types.S
 	getRequest, err := c.newRequest(http.MethodGet, secretPath, nil)
 
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+		return nil, nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
 	}
 
 	res, err := c.doRequest(ctx, getRequest)
 	if err != nil {
-		return nil, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+		return nil, res, fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
 	}
 
 	if res.Body != nil {
 		defer res.Body.Close()
 	}
 
-	switch res.StatusCode {
-	case http.StatusOK, http.StatusAccepted:
-
-		bytesOut, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			return nil, fmt.Errorf("cannot read result from OpenFaaS on URL: %s", c.GatewayURL.String())
-		}
-
-		jsonErr := json.Unmarshal(bytesOut, &results)
-		if jsonErr != nil {
-			return nil, fmt.Errorf("cannot parse result from OpenFaaS on URL: %s\n%s", c.GatewayURL.String(), jsonErr.Error())
-		}
-
-	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
-
-	default:
-		bytesOut, err := ioutil.ReadAll(res.Body)
-		if err == nil {
-			return nil, fmt.Errorf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
-		}
+	bytesOut, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, res, err
 	}
 
-	return results, nil
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusAccepted:
+		jsonErr := json.Unmarshal(bytesOut, &results)
+		if jsonErr != nil {
+			return nil, res, fmt.Errorf("cannot parse result from OpenFaaS: %s", jsonErr.Error())
+		}
+
+	default:
+		return nil, res, NewOpenFaaSError(string(bytesOut), res.StatusCode)
+	}
+
+	return results, res, nil
 }
 
 // UpdateSecret update a secret via the OpenFaaS API by name
-func (c *Client) UpdateSecret(ctx context.Context, secret types.Secret) (int, string) {
-	var output string
+func (c *Client) UpdateSecret(ctx context.Context, secret types.Secret) (*http.Response, error) {
 	reqBytes, _ := json.Marshal(&secret)
 
 	putRequest, err := c.newRequest(http.MethodPut, secretEndpoint, bytes.NewBuffer(reqBytes))
-
 	if err != nil {
-		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
-		return http.StatusInternalServerError, output
+		return nil, err
 	}
 
 	res, err := c.doRequest(ctx, putRequest)
 	if err != nil {
-		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
-		return http.StatusInternalServerError, output
+		return res, err
 	}
 
 	if res.Body != nil {
 		defer res.Body.Close()
 	}
-
-	switch res.StatusCode {
-	case http.StatusOK, http.StatusAccepted:
-		output += fmt.Sprintf("Updated: %s\n", res.Status)
-		break
-
-	case http.StatusNotFound:
-		output += fmt.Sprintf("unable to find secret: %s", secret.Name)
-
-	case http.StatusUnauthorized:
-		output += fmt.Sprintf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
-
-	default:
-		bytesOut, err := ioutil.ReadAll(res.Body)
-		if err == nil {
-			output += fmt.Sprintf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
-		}
+	bytesOut, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return res, err
 	}
 
-	return res.StatusCode, output
+	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusAccepted {
+		return res, nil
+	}
+
+	return res, NewOpenFaaSError(string(bytesOut), res.StatusCode)
 }
 
 // RemoveSecret remove a secret via the OpenFaaS API by name
-func (c *Client) RemoveSecret(ctx context.Context, secret types.Secret) error {
+func (c *Client) RemoveSecret(ctx context.Context, secret types.Secret) (*http.Response, error) {
 	body, _ := json.Marshal(secret)
 	req, err := c.newRequest(http.MethodDelete, secretEndpoint, bytes.NewBuffer(body))
 	if err != nil {
-		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+		return nil, err
 	}
 
 	res, err := c.doRequest(ctx, req)
 	if err != nil {
-		return fmt.Errorf("cannot connect to OpenFaaS on URL: %s", c.GatewayURL.String())
+		return res, err
 	}
 
 	if res.Body != nil {
 		defer res.Body.Close()
 	}
 
-	switch res.StatusCode {
-	case http.StatusOK, http.StatusAccepted:
-		break
-	case http.StatusNotFound:
-		return fmt.Errorf("unable to find secret: %s", secret.Name)
-	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
-
-	default:
-		bytesOut, err := ioutil.ReadAll(res.Body)
-		if err == nil {
-			return fmt.Errorf("server returned unexpected status code: %d - %s", res.StatusCode, string(bytesOut))
-		}
+	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusAccepted {
+		return res, nil
 	}
 
-	return nil
+	bytesOut, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return res, err
+	}
+
+	return res, NewOpenFaaSError(string(bytesOut), res.StatusCode)
 }
 
 // CreateSecret create secret
-func (c *Client) CreateSecret(ctx context.Context, secret types.Secret) (int, string) {
-	var output string
+func (c *Client) CreateSecret(ctx context.Context, secret types.Secret) (*http.Response, error) {
 	reqBytes, _ := json.Marshal(&secret)
 	reader := bytes.NewReader(reqBytes)
 
-	request, err := c.newRequest(http.MethodPost, secretEndpoint, reader)
+	req, err := c.newRequest(http.MethodPost, secretEndpoint, reader)
 
 	if err != nil {
-		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s\n", c.GatewayURL.String())
-		return http.StatusInternalServerError, output
+		return nil, err
 	}
 
-	res, err := c.doRequest(ctx, request)
+	res, err := c.doRequest(ctx, req)
 	if err != nil {
-		output += fmt.Sprintf("cannot connect to OpenFaaS on URL: %s\n", c.GatewayURL.String())
-		return http.StatusInternalServerError, output
+		return res, err
 	}
 
 	if res.Body != nil {
 		defer res.Body.Close()
 	}
 
-	switch res.StatusCode {
-	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
-		output += fmt.Sprintf("Created: %s\n", res.Status)
-
-	case http.StatusUnauthorized:
-		output += fmt.Sprintln("unauthorized access, run \"faas-cli login\" to setup authentication for this server")
-
-	case http.StatusConflict:
-		output += fmt.Sprintf("secret with the name %q already exists\n", secret.Name)
-
-	default:
-		bytesOut, err := ioutil.ReadAll(res.Body)
-		if err == nil {
-			output += fmt.Sprintf("server returned unexpected status code: %d - %s\n", res.StatusCode, string(bytesOut))
-		}
+	if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusAccepted || res.StatusCode == http.StatusCreated {
+		return res, nil
 	}
 
-	return res.StatusCode, output
+	bytesOut, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return res, err
+	}
+
+	return res, NewOpenFaaSError(string(bytesOut), res.StatusCode)
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This commit refactors the proxy secrets code to return 2 (or 3, for
list) values of (optional) data, *http.Response, error (either generic,
or OpenFaaS error type if its not a json unmarshal or other i/o type
error)

This can be used as showin in the tests, if you want to get status code
now you have access to the http response, or you can see what type the
returned error is, if its OpenFaaS error it should contain the http
status code and response (from upstream)

New unit tests added and faas-cli tested with 401, i/0 (no gw running)
and OK responses against faas-netes

## Also
I removed the error return on 
```go
type ClientAuth interface {
	Set(req *http.Request)
}
```
(Set used to optionally return an error, but we never returned one anywhere)


Signed-off-by: Alistair Hey <alistair@heyal.co.uk>

<!--- Provide a general summary of your changes in the Title above -->



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
-

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
see description, unit tests and locally against faas-netes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
signature of proxy changes, anyone using it and upgrading will need to use new return signatures.
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
