### PR TITLE
Add function YAML config to ignore paths during shrinkwrap

### DIFF
--- a/builder/publish.go
+++ b/builder/publish.go
@@ -16,7 +16,7 @@ import (
 // PublishImage will publish images as multi-arch
 // TODO: refactor signature to a struct to simplify the length of the method header
 func PublishImage(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string,
-	buildOptions []string, tagMode schema.BuildFormat, buildLabelMap map[string]string, quietBuild bool, copyExtraPaths []string, platforms string, extraTags []string) error {
+	buildOptions []string, tagMode schema.BuildFormat, buildLabelMap map[string]string, quietBuild bool, copyExtraPaths []string, ignorePaths []string, platforms string, extraTags []string) error {
 
 	if stack.IsValidTemplate(language) {
 		pathToTemplateYAML := fmt.Sprintf("./template/%s/template.yml", language)
@@ -40,7 +40,7 @@ func PublishImage(image string, handler string, functionName string, language st
 			return fmt.Errorf("building %s, %s is an invalid path", imageName, handler)
 		}
 
-		tempPath, buildErr := createBuildContext(functionName, handler, language, isLanguageTemplate(language), langTemplate.HandlerFolder, copyExtraPaths)
+		tempPath, buildErr := createBuildContext(functionName, handler, language, isLanguageTemplate(language), langTemplate.HandlerFolder, copyExtraPaths, ignorePaths)
 		fmt.Printf("Building: %s with %s template. Please wait..\n", imageName, language)
 		if buildErr != nil {
 			return buildErr

--- a/commands/build.go
+++ b/commands/build.go
@@ -190,6 +190,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			buildLabelMap,
 			quietBuild,
 			copyExtra,
+			nil,
 		)
 		if err != nil {
 			return err
@@ -255,6 +256,7 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 						buildLabelMap,
 						quietBuild,
 						combinedExtraPaths,
+						function.IgnorePaths,
 					)
 
 					if err != nil {

--- a/commands/publish.go
+++ b/commands/publish.go
@@ -69,12 +69,12 @@ var publishCmd = &cobra.Command{
 	Short: "Builds and pushes multi-arch OpenFaaS container images",
 	Long: `Builds and pushes multi-arch OpenFaaS container images using Docker buildx.
 Most users will want faas-cli build or faas-cli up for development and testing.
-This command is designed to make releasing and publishing multi-arch container 
+This command is designed to make releasing and publishing multi-arch container
 images easier.
 
-A stack.yaml file is required, and any images that are built will not be 
-available in the local Docker library. This is due to technical constraints in 
-Docker and buildx. You must use a multi-arch template to use this command with 
+A stack.yaml file is required, and any images that are built will not be
+available in the local Docker library. This is due to technical constraints in
+Docker and buildx. You must use a multi-arch template to use this command with
 correctly configured TARGETPLATFORM and BUILDPLATFORM arguments.
 
 See also: faas-cli build`,
@@ -205,6 +205,7 @@ func publish(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bo
 						buildLabelMap,
 						quietBuild,
 						combinedExtraPaths,
+						function.IgnorePaths,
 						platforms,
 						extraTags,
 					)

--- a/commands/version.go
+++ b/commands/version.go
@@ -39,7 +39,7 @@ func init() {
 // versionCmd displays version information
 var versionCmd = &cobra.Command{
 	Use:   "version [--short-version] [--gateway GATEWAY_URL]",
-	Short: "Display the clients version information",
+	Short: "Display the clients version information. Foo",
 	Long: fmt.Sprintf(`The version command returns the current clients version information.
 
 This currently consists of the GitSHA from which the client was built.
@@ -115,7 +115,7 @@ func printServerVersions() error {
 Provider
  name:          %s
  orchestration: %s
- version:       %s 
+ version:       %s
  sha:           %s
 `, gatewayInfo.Provider.Name, gatewayInfo.Provider.Orchestration, gatewayInfo.Provider.Version.Release, gatewayInfo.Provider.Version.SHA)
 	return nil

--- a/stack.yml
+++ b/stack.yml
@@ -32,6 +32,8 @@ functions:
     lang: node
     handler: ./sample/nodejs-echo
     image: alexellis/faas-nodejs-echo:0.1
+    ignore_paths:
+      - node_modules
 #    limits:
 #      memory: 40m
 #    requests:

--- a/stack/schema.go
+++ b/stack/schema.go
@@ -60,6 +60,10 @@ type Function struct {
 	// BuildArgs for providing build-args
 	BuildArgs map[string]string `yaml:"build_args,omitempty"`
 
+	// IgnorePaths are relative files or directories that will not be copied to the
+	// build folder e.g. node_modules
+	IgnorePaths []string `yaml:"ignore_paths,omitempty"`
+
 	// Platforms for use with buildx and faas-cli publish
 	Platforms string `yaml:"platforms,omitempty"`
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->

This change handles an `ignore_paths` configuration array that prevents
specified folders and files from being copied into the handler build
folder.

This is useful for node applications where the process of copying a
handler's node_modules folder can take a long time. In such case, the
node_modules folder is not needed as it is ignored during the Docker
build process anyway.

This change also applies to file paths that are copied from the
configurations.copy array.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md)) https://github.com/openfaas/faas-cli/issues/889

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Go tests and example in `sample` folder and `stack.yml`. The following commands should show that the `sample/nodejs-echo/node_modules/foo` is not added to the `build` folder

```sh
$ ./bin/faas-cli-darwin build
$ ls -lha build/nodejs-echo/function/node_modules
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
