### PR TITLE
Add annotations to generated OpenFaaS CRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 faas-cli is the official CLI for [OpenFaaS](https://github.com/openfaas/faas)
 
+Run a demo with `faas-cli --help`
+
 The CLI can be used to build and deploy functions to [OpenFaaS](https://github.com/openfaas/faas). You can build OpenFaaS functions from a set of supported language templates (such as Node.js, Python, CSharp and Ruby). That means you just write a handler file such as (handler.py/handler.js) and the CLI does the rest to create a Docker image.
 
 New user? See how it works: [Morning coffee with the faas-cli](https://blog.alexellis.io/quickstart-openfaas-cli/)

--- a/commands/generate.go
+++ b/commands/generate.go
@@ -204,6 +204,7 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 				Image:       imageName,
 				Environment: allEnvironment,
 				Labels:      function.Labels,
+				Annotations: function.Annotations,
 				Limits:      function.Limits,
 				Requests:    function.Requests,
 				Constraints: function.Constraints,

--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -50,7 +50,38 @@ spec:
 		Branch:     "",
 		Version:    "",
 	},
-
+	{
+		Name: "Annotation present",
+		Input: `
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+ url-ping:
+   lang: python
+   handler: ./sample/url-ping
+   image: alexellis/faas-url-ping:0.2
+   annotations:
+     com.scale.zero: 1
+`,
+		Output: []string{`---
+apiVersion: openfaas.com/v1
+kind: Function
+metadata:
+  name: url-ping
+  namespace: openfaas-fn
+spec:
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+  annotations:
+    com.scale.zero: "1"
+`},
+		Format:     schema.DefaultFormat,
+		APIVersion: "openfaas.com/v1",
+		Namespace:  "openfaas-fn",
+		Branch:     "",
+		Version:    "",
+	},
 	{
 		Name: "Blank namespace",
 		Input: `
@@ -179,7 +210,7 @@ func Test_generateCRDYAML(t *testing.T) {
 		parsedServices, err := stack.ParseYAMLData([]byte(testcase.Input), "", "", true)
 
 		if err != nil {
-			t.Fatalf("%s failed: error while parsing the input data.", testcase.Name)
+			t.Fatalf("%s failed: error while parsing the input data", testcase.Name)
 		}
 
 		if parsedServices == nil {
@@ -189,11 +220,11 @@ func Test_generateCRDYAML(t *testing.T) {
 
 		generatedYAML, err := generateCRDYAML(services, testcase.Format, testcase.APIVersion, testcase.Namespace, testcase.Branch, testcase.Version)
 		if err != nil {
-			t.Fatalf("%s failed: error while generating CRD YAML.", testcase.Name)
+			t.Fatalf("%s failed: error while generating CRD YAML", testcase.Name)
 		}
 
 		if !stringInSlice(generatedYAML, testcase.Output) {
-			t.Fatalf("%s failed: ouput is not as expected: %s", testcase.Name, generatedYAML)
+			t.Fatalf("%s failed: want:\n%q, but got:\n%q", testcase.Name, testcase.Output, generatedYAML)
 		}
 	}
 

--- a/schema/openfaas/v1/crd.go
+++ b/schema/openfaas/v1/crd.go
@@ -22,6 +22,8 @@ type Spec struct {
 
 	Labels *map[string]string `yaml:"labels,omitempty"`
 
+	Annotations *map[string]string `yaml:"annotations,omitempty"`
+
 	//Limits for the function
 	Limits *stack.FunctionResources `yaml:"limits,omitempty"`
 

--- a/stack.yml
+++ b/stack.yml
@@ -7,6 +7,10 @@ provider:
 
 functions:
   url-ping:
+    annotations:
+      test: true
+    labels:
+      com.openfaas: 1
     lang: python
     handler: ./sample/url-ping
     image: ${DOCKER_USER:-alexellis}/faas-url-ping:0.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add annotations to generated OpenFaaS Custom Resources

## Motivation and Context

Fixes: #890 

## How Has This Been Tested?

A new unit test was added for when an annotation is present, a new binary was built and produced the following output for `./faas-cli generate --filter url-ping`:

```yaml
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: url-ping
spec:
  name: url-ping
  image: alexellis/faas-url-ping:0.2
  environment:
    debug: "true"
  labels:
    com.openfaas: "1"
  annotations:
    test: "true"
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

