### PR TITLE
Add the openfaas-fn namespace to function store Custom Resources

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -27,11 +27,12 @@ const (
 )
 
 var (
-	api               string
-	functionNamespace string
-	fromStore         string
-	desiredArch       string
-	annotationArgs    []string
+	api                  string
+	functionNamespace    string
+	crdFunctionNamespace string
+	fromStore            string
+	desiredArch          string
+	annotationArgs       []string
 )
 
 func init() {
@@ -39,7 +40,7 @@ func init() {
 	generateCmd.Flags().StringVar(&fromStore, "from-store", "", "generate using a store image")
 
 	generateCmd.Flags().StringVar(&api, "api", defaultAPIVersion, "CRD API version e.g openfaas.com/v1, serving.knative.dev/v1")
-	generateCmd.Flags().StringVarP(&functionNamespace, "namespace", "n", defaultFunctionNamespace, "Kubernetes namespace for functions")
+	generateCmd.Flags().StringVarP(&crdFunctionNamespace, "namespace", "n", "openfaas-fn", "Kubernetes namespace for functions")
 	generateCmd.Flags().Var(&tagFormat, "tag", "Override latest tag on function Docker image, accepts 'latest', 'sha', 'branch', 'describe'")
 	generateCmd.Flags().BoolVar(&envsubst, "envsubst", true, "Substitute environment variables in stack.yml file")
 	generateCmd.Flags().StringVar(&desiredArch, "arch", "x86_64", "Desired image arch. (Default x86_64)")
@@ -95,10 +96,6 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	annotations, annotationErr := parseMap(annotationArgs, "annotation")
 	if annotationErr != nil {
 		return fmt.Errorf("error parsing annotations: %v", annotationErr)
-	}
-
-	if len(functionNamespace) == 0 {
-		functionNamespace = defaultFunctionNamespace
 	}
 
 	if len(fromStore) > 0 {
@@ -157,7 +154,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	objectsString, err := generateCRDYAML(services, tagFormat, api, functionNamespace, branch, version)
+	objectsString, err := generateCRDYAML(services, tagFormat, api, crdFunctionNamespace, branch, version)
 	if err != nil {
 		return err
 	}
@@ -176,7 +173,7 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 	if len(services.Functions) > 0 {
 
 		if apiVersion == knativev1.APIVersionLatest {
-			return generateknativev1ServingServiceCRDYAML(services, format, api, functionNamespace, branch, version)
+			return generateknativev1ServingServiceCRDYAML(services, format, api, crdFunctionNamespace, branch, version)
 		}
 
 		orderedNames := generateFunctionOrder(services.Functions)


### PR DESCRIPTION
Add `defaultFunctionNamespace` to avoid empty namespace on Kubernetes CRD YAML generation.

Resolves #892

Signed-off-by: Yankee Maharjan <yankee.exe@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Generates CRD YAML file with default namespace (`openfaas-fn`) if not provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Generate YAML config with default namespace: 

<img src="https://user-images.githubusercontent.com/13623913/121990190-16cd5300-cdbd-11eb-98d5-8cd673a6c2c1.jpg" width="500"/>


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
