### PR TITLE
Create files as secrets in binary format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gotestyourself/gotestyourself v1.4.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/morikuni/aec v1.0.0
-	github.com/openfaas/faas-provider v0.17.3
+	github.com/openfaas/faas-provider v0.18.5
 	github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285
 	github.com/pkg/errors v0.9.1
 	github.com/ryanuber/go-glob v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/openfaas/faas-provider v0.17.3 h1:LN76lrXUKAx27o5X8l+daKWEzsdiW2E99jMOlI1SO5Q=
 github.com/openfaas/faas-provider v0.17.3/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
+github.com/openfaas/faas-provider v0.18.5 h1:y7CCkbh0dW9aWpRisXbjgG9MTZVrdiDKLNt7qqo8M5c=
+github.com/openfaas/faas-provider v0.18.5/go.mod h1:fq1JL0mX4rNvVVvRLaLRJ3H6o667sHuyP5p/7SZEe98=
 github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285 h1:oLrTwALS1EyjvG5AXZQM43CDZPNXoIcjDpeAK3UG/yM=
 github.com/openfaas/faas/gateway v0.0.0-20210311210633-a6dbb4cd0285/go.mod h1:ZZUyq1Ghd3zvhKvSWfXelAsvbUxWP1TqWtvapP4701Q=
 github.com/openfaas/nats-queue-worker v0.0.0-20200512211843-8e9eefd5a320/go.mod h1:BfT8MB890hbhbtPid+X/oU0HAznGFS581NiG2hkr8Rc=

--- a/vendor/github.com/openfaas/faas-provider/types/model.go
+++ b/vendor/github.com/openfaas/faas-provider/types/model.go
@@ -2,6 +2,22 @@ package types
 
 import "time"
 
+// Secret for underlying orchestrator
+type Secret struct {
+	// Name of the secret
+	Name string `json:"name"`
+
+	// Namespace if applicable for the secret
+	Namespace string `json:"namespace,omitempty"`
+
+	// Value is a string representing the string's value
+	Value string `json:"value,omitempty"`
+
+	// RawValue can be used to provide binary data when
+	// Value is not set
+	RawValue []byte `json:"rawValue,omitempty"`
+}
+
 // FunctionDeployment represents a request to create or update a Function.
 type FunctionDeployment struct {
 
@@ -44,13 +60,6 @@ type FunctionDeployment struct {
 	// ReadOnlyRootFilesystem removes write-access from the root filesystem
 	// mount-point.
 	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem,omitempty"`
-}
-
-// Secret for underlying orchestrator
-type Secret struct {
-	Name      string `json:"name"`
-	Namespace string `json:"namespace,omitempty"`
-	Value     string `json:"value,omitempty"`
 }
 
 // FunctionResources Memory and CPU

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/mitchellh/go-homedir
 # github.com/morikuni/aec v1.0.0
 ## explicit
 github.com/morikuni/aec
-# github.com/openfaas/faas-provider v0.17.3
+# github.com/openfaas/faas-provider v0.18.5
 ## explicit
 github.com/openfaas/faas-provider/httputil
 github.com/openfaas/faas-provider/logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Create files as secrets in binary format

## Motivation and Context

The `--trim=false` flag option was added to allow users to provide files and have them uploaded verbatim, but it seems that the faas-netes handlers still converted all inputs to strings.

This change creates files as binary through the RawValue field, and is backwards compatible since the Value field is also populated.
 
## How Has This Been Tested?

Tested e2e through and the file was accepted by my function, which failed previously.

```bash
/home/alex/go/src/github.com/openfaas/faas-cli/faas-cli secret create astra-secure-connect --from-file ./astra-secure-connect.zip
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
