### PR TITLE
Show help message with no stack file and flags

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	v2 "github.com/openfaas/faas-cli/schema/store/v2"
@@ -150,6 +151,11 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 		if parsedServices != nil {
 			services = *parsedServices
 		}
+	} else {
+		fmt.Println(
+			`"stack.yml" file not found in the current directory.
+Use "--yaml" to pass a file or "--from-store" to generate using function store.`)
+		os.Exit(1)
 	}
 
 	branch, version, err := builder.GetImageTagValues(tagFormat)


### PR DESCRIPTION
Signed-off-by: Yankee Maharjan <yankee.exe@gmail.com>

Addresses #894 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Show help message when no flags are passed (`--yaml` or `--from-store`) and no `stack.yml` file is present in the current working directory.

![image](https://user-images.githubusercontent.com/13623913/123141714-63c5bf00-d478-11eb-9f56-8dbee506be4e.png)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Currently the CLI returns no result, confusing user what happened. Showing help message will guide the user to take corrective actions for the `generate` command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run the command below with no flags and no `stack.yml` file in current working directory.

```bash 
go run . generate
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
