### PR TITLE
Fix describe command formatting

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -146,19 +146,23 @@ func printFunctionDescription(funcDesc schema.FunctionDescription) {
 	fmt.Fprintln(w, "Function process:\t "+funcDesc.EnvProcess)
 	fmt.Fprintln(w, "URL:\t "+funcDesc.URL)
 	fmt.Fprintln(w, "Async URL:\t "+funcDesc.AsyncURL)
+	printMap(w, "Labels", *funcDesc.Labels)
+	printMap(w, "Annotations", *funcDesc.Annotations)
 
-	if funcDesc.Labels != nil {
-		fmt.Fprintf(w, "Labels:")
-		for key, value := range *funcDesc.Labels {
-			fmt.Fprintln(w, " \t "+key+" : "+value)
-		}
-	}
-
-	if funcDesc.Annotations != nil {
-		fmt.Fprintf(w, "Annotations:")
-		for key, value := range *funcDesc.Annotations {
-			fmt.Fprintln(w, " \t "+key+" : "+value)
-		}
-	}
 	w.Flush()
+}
+
+func printMap(w *tabwriter.Writer, name string, m map[string]string) {
+	fmt.Fprintf(w, name)
+
+	if len(m) == 0 {
+		fmt.Fprintln(w, " \t <none>")
+		return
+	}
+
+	for key, value := range m {
+		fmt.Fprintln(w, " \t "+key+" : "+value)
+	}
+
+	return
 }


### PR DESCRIPTION
When the Labels were empty they would appear on the same line as the Annotations.

Signed-off-by: Haris Razis <haris@razis.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A new function was created, that handles both Labels and Annotations. <none> is printed when no labels exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
#900 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 1 annotation and no labels
  ```
  ➜ faas-cli describe figlet-1              
  Name:                figlet-1
  Status:              Ready
  Replicas:            1
  Available replicas:  1
  Invocations:         0
  Image:               
  Function process:    figlet
  URL:                 http://10.40.98.209:8080/function/figlet-1
  Async URL:           http://10.40.98.209:8080/async-function/figlet-1
  Labels               <none>
  Annotations          person : xrazis
  ```

- 0 annotations and 1 label
  ```
  ➜ faas-cli describe figlet-2              
  Name:                figlet-2
  Status:              Ready
  Replicas:            1
  Available replicas:  1
  Invocations:         0
  Image:               
  Function process:    figlet
  URL:                 http://10.40.98.209:8080/function/figlet-2
  Async URL:           http://10.40.98.209:8080/async-function/figlet-2
  Labels               enviroment : dev
  Annotations          <none>
  ```

- 2 annotations and no labels
  ```
  ➜ faas-cli describe figlet-3              
  Name:                figlet-3
  Status:              Ready
  Replicas:            1
  Available replicas:  1
  Invocations:         0
  Image:               
  Function process:    figlet
  URL:                 http://10.40.98.209:8080/function/figlet-3
  Async URL:           http://10.40.98.209:8080/async-function/figlet-3
  Labels               <none>
  Annotations          imageregistry : https://hub.docker.com/
                       person : xrazis
  ```

- 2 annotations and 2 labels
  ```
  ➜ faas-cli describe figlet-4              
  Name:                figlet-4
  Status:              Ready
  Replicas:            1
  Available replicas:  1
  Invocations:         0
  Image:               
  Function process:    figlet
  URL:                 http://10.40.98.209:8080/function/figlet-4
  Async URL:           http://10.40.98.209:8080/async-function/figlet-4
  Labels               enviroment : dev
                       release : canary
  Annotations          build : 04/10/2021
                       person : xrazis
  ```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
