### PR TITLE
Support PKCE for auth command for OpenFaaS Pro users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*"))"
 
 # ldflags "-s -w" strips binary
 # ldflags -X injects commit version into binary
-RUN /usr/bin/license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Author(s)"
+RUN /usr/bin/license-check -path ./ --verbose=false "Alex Ellis" "OpenFaaS Author(s)" "OpenFaaS Ltd"
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     go test $(go list ./... | grep -v /vendor/ | grep -v /template/|grep -v /build/|grep -v /sample/) -cover

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,14 @@
+Annotated portions of this project are licensed under the OpenFaaS Pro
+commercial license, for which a license is required to use the software.
+
+EULA: https://github.com/openfaas/faas/blob/master/pro/EULA.md
+
+The remainder of the source code is licensed under the MIT license.
+
 MIT License
 
-Copyright (c) 2016-2017 Alex Ellis
+Copyright (c) 2016-2021 OpenFaaS Ltd
+Copyright (c) 2017-2021 OpenFaaS Author(s)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The main commands supported by the CLI are:
 
 * `faas-cli secret` - manage secrets for your functions
 
-* `faas-cli auth` - (alpha) initiates an OAuth2 authorization flow to obtain a cookie
+* `faas-cli auth` - initiates an OAuth2 authorization flow to obtain a token
 
 * `faas-cli registry-login` - generate registry auth file in correct format by providing username and password for docker/ecr/self hosted registry
 
@@ -116,13 +116,15 @@ You can chose between using a [programming language template](https://github.com
 
 #### `faas-cli auth`
 
-The `auth` command is currently available for alpha testing. Use the `auth` command to obtain a JWT to use as a Bearer token.
+The `auth` command is only licensed for OpenFaaS Pro customers.
 
-Two flow-types are supported in the CLI.
+Use the `auth` command to obtain a JWT to use as a Bearer token.
 
 ##### `code` grant - default
 
-Use this flow to obtain a token.
+Use this flow to obtain a token for interactive use from your workstation.
+
+The code grant flow uses the PKCE extension.
 
 At this time the `token` cannot be saved or retained in your OpenFaaS config file. You can pass the token using a CLI flag of `--token=$TOKEN`.
 
@@ -131,6 +133,7 @@ Example:
 ```sh
 faas-cli auth \
   --auth-url https://tenant0.eu.auth0.com/authorize \
+  --token-url https://tenant0.eu.auth0.com/oauth/token \
   --audience http://gw.example.com \
   --client-id "${OAUTH_CLIENT_ID}"
 ```
@@ -402,4 +405,6 @@ See [contributing guide](https://github.com/openfaas/faas-cli/blob/master/CONTRI
 
 ### License
 
-This project is part of OpenFaaS and is licensed under the MIT License.
+Portions of this project are licensed under the OpenFaaS Pro EULA.
+
+The remaining source unless annotated is licensed under the MIT License.

--- a/commands/auth_test.go
+++ b/commands/auth_test.go
@@ -1,5 +1,7 @@
-// Copyright (c) OpenFaaS Author(s) 2020. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Copyright (c) OpenFaaS Ltd 2021. All rights reserved.
+//
+// Licensed for use with OpenFaaS Pro only
+// See EULA: https://github.com/openfaas/faas/blob/master/pro/EULA.md
 
 package commands
 
@@ -12,6 +14,7 @@ func Test_auth(t *testing.T) {
 	testCases := []struct {
 		name     string
 		authURL  string
+		eula     bool
 		clientID string
 		wantErr  string
 	}{
@@ -20,31 +23,42 @@ func Test_auth(t *testing.T) {
 			authURL:  "",
 			clientID: "",
 			wantErr:  "--auth-url is required and must be a valid OIDC URL",
+			eula:     true,
 		},
 		{
 			name:     "Invalid auth-url",
 			authURL:  "xyz",
 			clientID: "",
 			wantErr:  "--auth-url is an invalid URL: xyz",
+			eula:     true,
+		},
+		{
+			name:     "Invalid eula acceptance",
+			authURL:  "http://xyz",
+			clientID: "id",
+			wantErr:  "the auth command is only licensed for OpenFaaS Pro customers, see: https://github.com/openfaas/faas/blob/master/pro/EULA.md",
+			eula:     false,
 		},
 		{
 			name:     "Valid auth-url, invalid client-id",
 			authURL:  "http://xyz",
 			clientID: "",
 			wantErr:  "--client-id is required",
+			eula:     true,
 		},
 		{
 			name:     "Valid auth-url and client-id",
 			authURL:  "http://xyz",
 			clientID: "abc",
 			wantErr:  "",
+			eula:     true,
 		},
 	}
 
 	for _, testCase := range testCases {
 
 		t.Run(testCase.name, func(t *testing.T) {
-			err := checkValues(testCase.authURL, testCase.clientID)
+			err := checkValues(testCase.authURL, testCase.clientID, testCase.eula)
 			gotErr := ""
 			if err != nil {
 				gotErr = err.Error()


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Support PKCE for auth command for OpenFaaS Pro users

## Motivation and Context

The implicit flow is considered insecure, PKCE takes its place.

* Enables PKCE in the place of implicit auth flow.
* Auth command requires EULA acceptance and valid OpenFaaS Pro
license or trial.
* Updates feature status from alpha to generally-available

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with Auth0 using a Web Application that I created. The token is saved into the local cache for re-use.

I also generated an error on purpose to check for error handling. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

I've updated the LICENSE for new portions of code that are licensed under the OpenFaaS Pro EULA and am changing the OpenFaaS docs to mention the code flow should be used instead of implicit.
