### PR TITLE
feat: Add missing fields to the describe output

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -222,12 +222,12 @@ func printMap(w io.Writer, name string, m map[string]string, verbose bool) {
 	fmt.Fprintf(w, name+":")
 
 	if len(m) == 0 {
-		fmt.Fprintln(w, " \t <none>")
+		fmt.Fprintln(w, "\t <none>")
 		return
 	}
 
 	for key, value := range m {
-		fmt.Fprintln(w, " \t "+key+": "+value)
+		fmt.Fprintln(w, "\t "+key+": "+value)
 	}
 
 	return
@@ -241,12 +241,12 @@ func printList(w io.Writer, name string, data []string, verbose bool) {
 	fmt.Fprintf(w, name+":")
 
 	if len(data) == 0 {
-		fmt.Fprintln(w, " \t <none>")
+		fmt.Fprintln(w, "\t <none>")
 		return
 	}
 
 	for _, value := range data {
-		fmt.Fprintln(w, " \t - "+value)
+		fmt.Fprintln(w, "\t - "+value)
 	}
 
 	return
@@ -260,12 +260,12 @@ func printResources(w io.Writer, name string, data *types.FunctionResources, ver
 	fmt.Fprintf(w, name+":")
 
 	if data == nil {
-		fmt.Fprintln(w, " \t <none>")
+		fmt.Fprintln(w, "\t <none>")
 		return
 	}
 
-	fmt.Fprintln(w, " \t CPU: "+data.CPU)
-	fmt.Fprintln(w, " \t Memory: "+data.Memory)
+	fmt.Fprintln(w, "\t CPU: "+data.CPU)
+	fmt.Fprintln(w, "\t Memory: "+data.Memory)
 
 	return
 }

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -201,17 +201,17 @@ func printUsage(w io.Writer, usage *types.FunctionUsage, verbose bool) {
 	}
 
 	if usage == nil {
-		fmt.Fprintln(w, "No usage information available")
+		fmt.Fprintln(w, "Usage:\t <none>")
 		return
 	}
 
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "RAM:\t %.2f MB\n", (usage.TotalMemoryBytes / 1024 / 1024))
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintf(w, "  RAM:\t %.2f MB\n", (usage.TotalMemoryBytes / 1024 / 1024))
 	cpu := usage.CPU
 	if cpu < 0 {
 		cpu = 1
 	}
-	fmt.Fprintf(w, "CPU:\t %.0f Mi\n", (cpu))
+	fmt.Fprintf(w, "  CPU:\t %.0f Mi\n", (cpu))
 }
 
 func printMap(w io.Writer, name string, m map[string]string, verbose bool) {
@@ -219,13 +219,12 @@ func printMap(w io.Writer, name string, m map[string]string, verbose bool) {
 		return
 	}
 
-	fmt.Fprintf(w, name+":")
-
 	if len(m) == 0 {
-		fmt.Fprintln(w, "\t <none>")
+		fmt.Fprintf(w, "%s:\t <none>\n", name)
 		return
 	}
 
+	fmt.Fprintf(w, "%s:\n", name)
 	for key, value := range m {
 		fmt.Fprintln(w, "\t "+key+": "+value)
 	}
@@ -238,13 +237,12 @@ func printList(w io.Writer, name string, data []string, verbose bool) {
 		return
 	}
 
-	fmt.Fprintf(w, name+":")
-
 	if len(data) == 0 {
-		fmt.Fprintln(w, "\t <none>")
+		fmt.Fprintf(w, "%s:\t <none>\n", name)
 		return
 	}
 
+	fmt.Fprintf(w, "%s:\n", name)
 	for _, value := range data {
 		fmt.Fprintln(w, "\t - "+value)
 	}

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openfaas/faas-cli/proxy"
 	"github.com/openfaas/faas-cli/schema"
 	"github.com/openfaas/faas-cli/stack"
+	"github.com/openfaas/faas-provider/types"
 
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,7 @@ var describeCmd = &cobra.Command{
 	Use:   "describe FUNCTION_NAME [--gateway GATEWAY_URL]",
 	Short: "Describe an OpenFaaS function",
 	Long:  `Display details of an OpenFaaS function`,
-	Example: `faas-cli describe figlet 
+	Example: `faas-cli describe figlet
 faas-cli describe env --gateway http://127.0.0.1:8080
 faas-cli describe echo -g http://127.0.0.1.8080`,
 	PreRunE: preRunDescribe,
@@ -103,20 +104,11 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	url, asyncURL := getFunctionURLs(gatewayAddress, functionName, functionNamespace)
 
 	funcDesc := schema.FunctionDescription{
-		Name:              function.Name,
-		Status:            status,
-		Replicas:          int(function.Replicas),
-		AvailableReplicas: int(function.AvailableReplicas),
-		InvocationCount:   int(invocationCount),
-		Image:             function.Image,
-		EnvProcess:        function.EnvProcess,
-		URL:               url,
-		AsyncURL:          asyncURL,
-		Labels:            function.Labels,
-		Annotations:       function.Annotations,
-	}
-	if function.Usage != nil {
-		funcDesc.Usage = function.Usage
+		FunctionStatus:  function,
+		Status:          status,
+		InvocationCount: int(invocationCount),
+		URL:             url,
+		AsyncURL:        asyncURL,
 	}
 
 	printFunctionDescription(funcDesc)
@@ -140,17 +132,26 @@ func getFunctionURLs(gateway string, functionName string, functionNamespace stri
 
 func printFunctionDescription(funcDesc schema.FunctionDescription) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.TabIndent)
+	process := "<default>"
+	if funcDesc.EnvProcess != "" {
+		process = funcDesc.EnvProcess
+	}
 	fmt.Fprintln(w, "Name:\t "+funcDesc.Name)
 	fmt.Fprintln(w, "Status:\t "+funcDesc.Status)
-	fmt.Fprintln(w, "Replicas:\t "+strconv.Itoa(funcDesc.Replicas))
-	fmt.Fprintln(w, "Available replicas:\t "+strconv.Itoa(funcDesc.AvailableReplicas))
+	fmt.Fprintln(w, "Replicas:\t "+strconv.Itoa(int(funcDesc.Replicas)))
+	fmt.Fprintln(w, "Available replicas:\t "+strconv.Itoa(int(funcDesc.AvailableReplicas)))
 	fmt.Fprintln(w, "Invocations:\t "+strconv.Itoa(funcDesc.InvocationCount))
 	fmt.Fprintln(w, "Image:\t "+funcDesc.Image)
-	fmt.Fprintln(w, "Function process:\t "+funcDesc.EnvProcess)
+	fmt.Fprintln(w, "Function process:\t "+process)
 	fmt.Fprintln(w, "URL:\t "+funcDesc.URL)
 	fmt.Fprintln(w, "Async URL:\t "+funcDesc.AsyncURL)
 	printMap(w, "Labels", *funcDesc.Labels)
 	printMap(w, "Annotations", *funcDesc.Annotations)
+	printList(w, "Constraints", funcDesc.Constraints)
+	printMap(w, "Environment", funcDesc.EnvVars)
+	printList(w, "Secrets", funcDesc.Secrets)
+	printResources(w, "Requests", funcDesc.Requests)
+	printResources(w, "Limits", funcDesc.Limits)
 	if funcDesc.Usage != nil {
 		fmt.Println()
 
@@ -160,14 +161,13 @@ func printFunctionDescription(funcDesc schema.FunctionDescription) {
 			cpu = 1
 		}
 		fmt.Fprintf(w, "CPU:\t %.0f Mi\n", (cpu))
-
 	}
 
 	w.Flush()
 }
 
 func printMap(w *tabwriter.Writer, name string, m map[string]string) {
-	fmt.Fprintf(w, name)
+	fmt.Fprintf(w, name+":")
 
 	if len(m) == 0 {
 		fmt.Fprintln(w, " \t <none>")
@@ -175,8 +175,37 @@ func printMap(w *tabwriter.Writer, name string, m map[string]string) {
 	}
 
 	for key, value := range m {
-		fmt.Fprintln(w, " \t "+key+" : "+value)
+		fmt.Fprintln(w, " \t "+key+": "+value)
 	}
+
+	return
+}
+
+func printList(w *tabwriter.Writer, name string, data []string) {
+	fmt.Fprintf(w, name+":")
+
+	if len(data) == 0 {
+		fmt.Fprintln(w, " \t <none>")
+		return
+	}
+
+	for _, value := range data {
+		fmt.Fprintln(w, " \t - "+value)
+	}
+
+	return
+}
+
+func printResources(w *tabwriter.Writer, name string, data *types.FunctionResources) {
+	fmt.Fprintf(w, name+":")
+
+	if data == nil {
+		fmt.Fprintln(w, " \t <none>")
+		return
+	}
+
+	fmt.Fprintln(w, " \t CPU: "+data.CPU)
+	fmt.Fprintln(w, " \t Memory: "+data.Memory)
 
 	return
 }

--- a/commands/describe_test.go
+++ b/commands/describe_test.go
@@ -43,7 +43,7 @@ func TestDescribeOuput(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name: "minimal output, non-verbose",
+			name: "non-verbose minimal output",
 			function: schema.FunctionDescription{
 				FunctionStatus: types.FunctionStatus{
 					Name:        "figlet",
@@ -57,7 +57,7 @@ func TestDescribeOuput(t *testing.T) {
 			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\n",
 		},
 		{
-			name: "minimal output, verbose",
+			name: "verbose minimal output",
 			function: schema.FunctionDescription{
 				FunctionStatus: types.FunctionStatus{
 					Name:        "figlet",
@@ -68,7 +68,57 @@ func TestDescribeOuput(t *testing.T) {
 				Status: "Ready",
 			},
 			verbose:        true,
-			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nURL:\t<none>\nAsync URL:\t<none>\nLabels:\t<none>\nAnnotations:\t<none>\nConstraints:\t<none>\nEnvironment:\t<none>\nSecrets:\t<none>\nRequests:\t<none>\nLimits:\t<none>\nNo usage information available\n",
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nURL:\t<none>\nAsync URL:\t<none>\nLabels:\t<none>\nAnnotations:\t<none>\nConstraints:\t<none>\nEnvironment:\t<none>\nSecrets:\t<none>\nRequests:\t<none>\nLimits:\t<none>\nUsage:\t<none>\n",
+		},
+		{
+			name: "non-verbose formats output with non-empty labels, env variables, and secrets",
+			function: schema.FunctionDescription{
+				FunctionStatus: types.FunctionStatus{
+					Name:        "figlet",
+					Image:       "openfaas/figlet:latest",
+					Labels:      &map[string]string{"quadrant": "alpha"},
+					Annotations: &map[string]string{},
+					EnvVars:     map[string]string{"FOO": "bar"},
+					Secrets:     []string{"db-password"},
+				},
+				Status: "Ready",
+			},
+			verbose:        false,
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nLabels:\n quadrant: alpha\nEnvironment:\n FOO: bar\nSecrets:\n - db-password\n",
+		},
+		{
+			name: "verbose formats output with non-empty labels, env variables, and secrets",
+			function: schema.FunctionDescription{
+				FunctionStatus: types.FunctionStatus{
+					Name:        "figlet",
+					Image:       "openfaas/figlet:latest",
+					Labels:      &map[string]string{"quadrant": "alpha"},
+					Annotations: &map[string]string{},
+					EnvVars:     map[string]string{"FOO": "bar"},
+					Secrets:     []string{"db-password"},
+				},
+				Status: "Ready",
+			},
+			verbose:        true,
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nURL:\t<none>\nAsync URL:\t<none>\nLabels:\n quadrant: alpha\nAnnotations:\t<none>\nConstraints:\t<none>\nEnvironment:\n FOO: bar\nSecrets:\n - db-password\nRequests:\t<none>\nLimits:\t<none>\nUsage:\t<none>\n",
+		},
+		{
+			name: "formats non-empty usage",
+			function: schema.FunctionDescription{
+				FunctionStatus: types.FunctionStatus{
+					Name:        "figlet",
+					Image:       "openfaas/figlet:latest",
+					Labels:      &map[string]string{},
+					Annotations: &map[string]string{},
+					Usage: &types.FunctionUsage{
+						TotalMemoryBytes: 1024 * 1024 * 1024,
+						CPU:              1.5,
+					},
+				},
+				Status: "Ready",
+			},
+			verbose:        false,
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nUsage:\n\tRAM:\t1024.00 MB\n\tCPU:\t2 Mi\n",
 		},
 	}
 	for _, tc := range cases {

--- a/commands/describe_test.go
+++ b/commands/describe_test.go
@@ -1,6 +1,13 @@
 package commands
 
-import "testing"
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/openfaas/faas-cli/schema"
+	"github.com/openfaas/faas-provider/types"
+)
 
 func Test_getFunctionURLs(t *testing.T) {
 	cases := []struct {
@@ -22,6 +29,55 @@ func Test_getFunctionURLs(t *testing.T) {
 
 			if url != tc.expectedURL || asyncURL != tc.expectedAsyncURL {
 				t.Fatalf("incorrect URL(s), want: %q and %q, got: %q and %q", tc.expectedURL, tc.expectedAsyncURL, url, asyncURL)
+			}
+		})
+	}
+}
+
+func TestDescribeOuput(t *testing.T) {
+	spaces := regexp.MustCompile(`[ ]{2,}`)
+	cases := []struct {
+		name           string
+		function       schema.FunctionDescription
+		verbose        bool
+		expectedOutput string
+	}{
+		{
+			name: "minimal output, non-verbose",
+			function: schema.FunctionDescription{
+				FunctionStatus: types.FunctionStatus{
+					Name:        "figlet",
+					Image:       "openfaas/figlet:latest",
+					Labels:      &map[string]string{},
+					Annotations: &map[string]string{},
+				},
+				Status: "Ready",
+			},
+			verbose:        false,
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\n",
+		},
+		{
+			name: "minimal output, verbose",
+			function: schema.FunctionDescription{
+				FunctionStatus: types.FunctionStatus{
+					Name:        "figlet",
+					Image:       "openfaas/figlet:latest",
+					Labels:      &map[string]string{},
+					Annotations: &map[string]string{},
+				},
+				Status: "Ready",
+			},
+			verbose:        true,
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nURL:\t<none>\nAsync URL:\t<none>\nLabels:\t<none>\nAnnotations:\t<none>\nConstraints:\t<none>\nEnvironment:\t<none>\nSecrets:\t<none>\nRequests:\t<none>\nLimits:\t<none>\nNo usage information available\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var dst bytes.Buffer
+			printFunctionDescription(&dst, tc.function, tc.verbose)
+			result := spaces.ReplaceAllString(dst.String(), "\t")
+			if result != tc.expectedOutput {
+				t.Fatalf("incorrect output,\nwant: %q\nnorm: %q\ngot: %q", tc.expectedOutput, result, dst.String())
 			}
 		})
 	}

--- a/schema/describe.go
+++ b/schema/describe.go
@@ -7,16 +7,9 @@ import "github.com/openfaas/faas-provider/types"
 
 //FunctionDescription information related to a function
 type FunctionDescription struct {
-	Name              string
-	Status            string
-	Replicas          int
-	AvailableReplicas int
-	InvocationCount   int
-	Image             string
-	EnvProcess        string
-	URL               string
-	AsyncURL          string
-	Labels            *map[string]string
-	Annotations       *map[string]string
-	Usage             *types.FunctionUsage
+	types.FunctionStatus
+	Status          string
+	InvocationCount int
+	URL             string
+	AsyncURL        string
 }


### PR DESCRIPTION
Add the function
* constraints
* environment variables
* secrets
* requests and limits

to the `faas-cli describe` output.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Resolves #913 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


Create a test cluster using KinD

```sh
kind create cluster --config=cluster.yaml
arkade install openfaas -a=false --function-pull-policy=IfNotPresent --wait

faas-cli store deploy nodeinfo --annotation sample=true --label status=418
```

Now deploy a sample function

```sh
$ faas-cli describe nodeinfo
Name:                nodeinfo
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               ghcr.io/openfaas/nodeinfo:latest
Function process:    <default>
URL:                 http://127.0.0.1:8080/function/nodeinfo
Async URL:           http://127.0.0.1:8080/async-function/nodeinfo
Labels               faas_function : nodeinfo
                     status : 418
Annotations          sample : true
                     prometheus.io.scrape : false
Constraints          <none>
Environment          <none>
Secrets              <none>
Requests             <none>
Limits               <none>

```

Now we add some more interesting values, like a secret and env variables.

```sh
$ faas-cli secret create db-password --from-literal=password
Creating secret: db-password.
Created: 202 Accepted

$ faas-cli store deploy nodeinfo --annotation sample=true --label status=418 --secret db-password --env db-user=postgres --env db-host=rds.aws.example.com

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/nodeinfo

$ faas-cli describe nodeinfo
Name:                nodeinfo
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               ghcr.io/openfaas/nodeinfo:latest
Function process:    <default>
URL:                 http://127.0.0.1:8080/function/nodeinfo
Async URL:           http://127.0.0.1:8080/async-function/nodeinfo
Labels:              faas_function: nodeinfo
                     status: 418
                     uid: 736815901
Annotations:         prometheus.io.scrape: false
                     sample: true
Constraints:         <none>
Environment:         <none>
Secrets:              - db-password
Requests:            <none>
Limits:              <none>
```

To see how multiple Secrets and the Requests and Limits are rendered, use

```yaml
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  nodeinfo:
    lang: Dockerfile
    image: ghcr.io/openfaas/nodeinfo:latest
    secrets:
      - cache-password
      - db-password
    environment:
      db-host: rds.aws.example.com
      cache-host: redis.aws.example.com
    labels:
      status: 481
    annotations:
      sample: "true"
    requests:
      cpu: 100m
      memory: 128Mi
    limits:
      cpu: 200m
      memory: 256Mi
```
then

```sh
$ faas-cli secret create cache-password --from-literal=password
Creating secret: cache-password.
Created: 202 Accepted
$ faas-cli deploy
Deploying: nodeinfo.

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/nodeinfo

$ faas-cli describe nodeinfo
Name:                nodeinfo
Status:              Ready
Replicas:            1
Available replicas:  1
Invocations:         0
Image:               ghcr.io/openfaas/nodeinfo:latest
Function process:    <default>
URL:                 http://127.0.0.1:8080/function/nodeinfo
Async URL:           http://127.0.0.1:8080/async-function/nodeinfo
Labels:              faas_function: nodeinfo
                     status: 481
                     uid: 679245186
Annotations:         prometheus.io.scrape: false
                     sample: true
Constraints:         <none>
Environment:         <none>
Secrets:             - cache-password
                     - db-password
Requests:            CPU: 100m
                     Memory: 128Mi
Limits:              CPU: 200m
                     Memory: 256Mi
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
