### PR TITLE
feat(deploy): support overriding environment files for each function via CLI

### DIFF
--- a/commands/testdata/deploy/func1.yml
+++ b/commands/testdata/deploy/func1.yml
@@ -1,0 +1,4 @@
+environment:
+  db_host: localhost
+  db_name: default
+  db_user: root

--- a/commands/testdata/deploy/func2.yml
+++ b/commands/testdata/deploy/func2.yml
@@ -1,0 +1,5 @@
+environment:
+  db_host: localhost
+  db_name: default
+  db_user: root
+  redis_host: localhost

--- a/commands/testdata/deploy/stack.yml
+++ b/commands/testdata/deploy/stack.yml
@@ -1,0 +1,11 @@
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"
+functions:
+  func1:
+    environment_file:
+      - testdata/deploy/func1.yml
+  func2:
+    environment_file:
+      - testdata/deploy/func2.yml

--- a/commands/testdata/deploy/test-env-files.yml
+++ b/commands/testdata/deploy/test-env-files.yml
@@ -1,0 +1,8 @@
+func1:
+  environment_file:
+    - test-func1.yml
+func2:
+  environment:
+    redis_pass: 123456
+  environment_file:
+    - test-func2.yml

--- a/commands/testdata/deploy/test-func1.yml
+++ b/commands/testdata/deploy/test-func1.yml
@@ -1,0 +1,4 @@
+environment:
+  db_host: 192.168.10.2
+  db_name: func1_db
+  db_user: func1_usr

--- a/commands/testdata/deploy/test-func2.yml
+++ b/commands/testdata/deploy/test-func2.yml
@@ -1,0 +1,4 @@
+environment:
+  db_name: func2_db
+  db_user: func2_user
+  redis_host: 192.168.0.1

--- a/test/utils.go
+++ b/test/utils.go
@@ -15,6 +15,7 @@ type Request struct {
 	Uri                string
 	ResponseStatusCode int
 	ResponseBody       interface{}
+	Hook               func(r *http.Request)
 }
 
 type server struct {
@@ -78,6 +79,10 @@ func MockHttpServer(t *testing.T, requests []Request) *server {
 			} else {
 				w.Write([]byte(s))
 			}
+		}
+
+		if request.Hook != nil {
+			request.Hook(r)
 		}
 
 		s.requestCounter++


### PR DESCRIPTION
Ability to override environment files for each function in `stack.yml` from CLI by providing YAML-file with dictionary `finction_name -> environment_files`.

Relates to https://github.com/openfaas/faas-cli/issues/907.


## Description
Added flag `--environment-file` which accepts the path to YAML-file which contains a list of environment files an variables for each function. Example of this file `test-env.yml`:

```yaml
function-1:
  environment:
    var1: val1
    var2: val2
  environment_file:
    - test-file-1.yml
    - test-file-2.yml
function-2:
  environment:
    var3: val3
    var4: val4
  environment_file:
    - test-file-3.yml
    - test-file-4.yml
```

You can use it by command:

```bash
faas-cli deploy -f stack.yml --environment-file /path/to/test-env.yml
```

Test data available in repository in directory `commands/testdata/deploy`.

## Motivation and Context

As described in issue https://github.com/openfaas/faas-cli/issues/907, we should have ability to override list of environment files for different environments.

But we can have different environment files for different functions in `stack.yaml`. As result we can't just override all environment files for all functions to the same list. I added ability to specify different env files for different functions.

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

I added required test and test data to repository.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
