### PR TITLE
Add custom build flags to docker

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -151,6 +151,7 @@ func Test_buildFlagSlice(t *testing.T) {
 		buildArgMap   map[string]string
 		buildPackages []string
 		expectedSlice []string
+		buildFlags    []string
 		buildLabelMap map[string]string
 	}{
 		{
@@ -161,6 +162,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--no-cache"},
 		},
 		{
@@ -171,6 +173,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--no-cache", "--squash"},
 		},
 		{
@@ -181,6 +184,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpsProxy:    "",
 			buildArgMap:   make(map[string]string),
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1"},
 		},
 		{
@@ -191,6 +195,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -201,6 +206,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -211,6 +217,7 @@ func Test_buildFlagSlice(t *testing.T) {
 			httpsProxy:    "127.0.0.1",
 			buildArgMap:   make(map[string]string),
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--build-arg", "http_proxy=192.168.0.1", "--build-arg", "https_proxy=127.0.0.1"},
 		},
 		{
@@ -223,6 +230,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"muppet": "ernie",
 			},
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--build-arg", "muppet=ernie"},
 		},
 		{
@@ -235,6 +243,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"muppets": "burt and ernie",
 			},
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie"},
 		},
 		{
@@ -248,6 +257,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"playschool": "Jemima",
 			},
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
 		{
@@ -261,6 +271,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"playschool": "Jemima",
 			},
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			expectedSlice: []string{"--no-cache", "--squash", "--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima"},
 		},
 		{
@@ -274,6 +285,7 @@ func Test_buildFlagSlice(t *testing.T) {
 				"playschool": "Jemima",
 			},
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			buildLabelMap: map[string]string{
 				"org.label-schema.name": "test function",
 			},
@@ -290,11 +302,48 @@ func Test_buildFlagSlice(t *testing.T) {
 				"playschool": "Jemima",
 			},
 			buildPackages: []string{},
+			buildFlags:    []string{},
 			buildLabelMap: map[string]string{
 				"org.label-schema.name":        "test function",
 				"org.label-schema.description": "This is a test function",
 			},
 			expectedSlice: []string{"--build-arg", "muppets=burt and ernie", "--build-arg", "playschool=Jemima", "--label", "org.label-schema.name=test function", "--label", "org.label-schema.description=This is a test function"},
+		},
+		{
+			title:         "build flags with values",
+			nocache:       false,
+			squash:        false,
+			httpProxy:     "",
+			httpsProxy:    "",
+			buildArgMap:   map[string]string{},
+			buildPackages: []string{},
+			buildLabelMap: map[string]string{},
+			buildFlags:    []string{"--ssh default"},
+			expectedSlice: []string{"--ssh", "default"},
+		},
+		{
+			title:         "build flags with no values",
+			nocache:       false,
+			squash:        false,
+			httpProxy:     "",
+			httpsProxy:    "",
+			buildArgMap:   map[string]string{},
+			buildPackages: []string{},
+			buildLabelMap: map[string]string{},
+			buildFlags:    []string{"--disable-content-trust"},
+			expectedSlice: []string{"--disable-content-trust"},
+		},
+		{
+			title:         "build flags combination with and without values",
+			nocache:       false,
+			squash:        false,
+			httpProxy:     "",
+			httpsProxy:    "",
+			buildArgMap:   map[string]string{},
+			buildPackages: []string{},
+			buildLabelMap: map[string]string{},
+			buildFlags:    []string{"--progress plain", "--disable-content-trust"},
+			expectedSlice: []string{"--progress", "plain", "--disable-content-trust"},
 		},
 	}
 
@@ -302,7 +351,17 @@ func Test_buildFlagSlice(t *testing.T) {
 
 		t.Run(test.title, func(t *testing.T) {
 
-			flagSlice := buildFlagSlice(test.nocache, test.squash, test.httpProxy, test.httpsProxy, test.buildArgMap, test.buildPackages, test.buildLabelMap)
+			b := dockerBuild{
+				NoCache:          test.nocache,
+				Squash:           test.squash,
+				HTTPProxy:        test.httpProxy,
+				HTTPSProxy:       test.httpsProxy,
+				BuildArgMap:      test.buildArgMap,
+				BuildOptPackages: test.buildPackages,
+				BuildLabelMap:    test.buildLabelMap,
+				BuildFlags:       test.buildFlags,
+			}
+			flagSlice := buildFlagSlice(b)
 			fmt.Println(flagSlice)
 			if len(flagSlice) != len(test.expectedSlice) {
 				t.Errorf("Slices differ in size - wanted: %d, found %d", len(test.expectedSlice), len(flagSlice))

--- a/builder/publish.go
+++ b/builder/publish.go
@@ -101,8 +101,7 @@ func PublishImage(image string, handler string, functionName string, language st
 }
 
 func getDockerBuildxCommand(build dockerBuild) (string, []string) {
-	flagSlice := buildFlagSlice(build.NoCache, build.Squash, build.HTTPProxy, build.HTTPSProxy, build.BuildArgMap,
-		build.BuildOptPackages, build.BuildLabelMap)
+	flagSlice := buildFlagSlice(build)
 
 	// pushOnly defined at https://github.com/docker/buildx
 	const pushOnly = "--output=type=registry,push=true"


### PR DESCRIPTION
Signed-off-by: Oleksandr Simonov <oleksandr@amoniac.eu>

The reason for this change is because i have this function depends on a private pypi repository on github which requires a providing ssh key inside Dockerfile. To avoid put sensitive data into the images, i decided to make this change to take the benifit of using docker buildkit secrets and ssh support.

## Description

In our work we required to have ability to fetch a private libraries for Python through GitHub repo. 
I have made a research and have found that there are already a discussion #785  and PR #786. But PR is too specific and in discussion a proposal for more generic variant. So I have added ability to provide a custom arguments to docker build like `--ssh` or `--secret`

Example usage for now is next:

```sh
faas-cli build --build-flags "--ssh default"
```

## Motivation and Context

Provide ability to fetch from any secure package storage from any git repository or through secrets to fetch from any private package manager's host.

## How Has This Been Tested?

Yes, i have added new tests for such feature.  

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
