### PR TITLE
Upgrade to Go 1.18 and introduce timeout for deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM teamserverless/license-check:0.3.9 as license-check
+FROM ghcr.io/openfaas/license-check:0.4.1 as license-check
 
 # Build stage
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18 as builder
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -40,7 +40,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} CGO_ENABLED=0 \
     -a -installsuffix cgo -o faas-cli
 
 # CICD stage
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.13 as root
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.16.2 as root
 
 ARG REPO_URL
 
@@ -57,7 +57,7 @@ ENV PATH=$PATH:/usr/bin/
 ENTRYPOINT [ "faas-cli" ]
 
 # Release stage
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.13 as release
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.16.2 as release
 
 ARG REPO_URL
 

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -1,7 +1,7 @@
-FROM teamserverless/license-check:0.3.6 as license-check
+FROM ghcr.io/openfaas/license-check:0.4.1 as license-check
 
 # Build stage
-FROM golang:1.17 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18 as builder
 
 ARG GIT_COMMIT
 ARG VERSION
@@ -62,7 +62,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w \
        -a -installsuffix cgo -o faas-cli-arm64
 
 # Release stage
-FROM alpine:3.13
+FROM alpine:3.16.2
 
 RUN apk --no-cache add ca-certificates git
 

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -28,6 +28,7 @@ func init() {
 	storeDeployCmd.Flags().StringArrayVarP(&storeDeployFlags.annotationOpts, "annotation", "", []string{}, "Set one or more annotation (ANNOTATION=VALUE)")
 	storeDeployCmd.Flags().BoolVar(&tlsInsecure, "tls-no-verify", false, "Disable TLS validation")
 	storeDeployCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
+	storeDeployCmd.Flags().DurationVar(&timeoutOverride, "timeout", commandTimeout, "Timeout for any HTTP calls made to the OpenFaaS API.")
 
 	// Set bash-completion.
 	_ = storeDeployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
@@ -119,8 +120,8 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	transport := GetDefaultCLITransport(tlsInsecure, &commandTimeout)
-	proxyClient, err := proxy.NewClient(cliAuth, gateway, transport, &commandTimeout)
+	transport := GetDefaultCLITransport(tlsInsecure, &timeoutOverride)
+	proxyClient, err := proxy.NewClient(cliAuth, gateway, transport, &timeoutOverride)
 	if err != nil {
 		return err
 	}

--- a/sample/imagemagick/Dockerfile
+++ b/sample/imagemagick/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.16.2
 
 # Alternatively use ADD https:// (which will not be cached by Docker builder)
 RUN apk --no-cache add curl ca-certificates imagemagick \ 


### PR DESCRIPTION
Signed-off-by: Alex Ellis (OpenFaaS Ltd) <alexellis2@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Upgrade to Go 1.18 and introduce timeout for deploy

* Go is upgraded to 1.18 for builds
* Alpine Linux is upgraded for the runtime container
* The deploy command gains a timeout for use with faaasd
which is synchronous and would time-out otherwise.

## Motivation and Context

I couldn't deploy a large > 1GB image to faasd, since it has a hard-coded timeout of 60s.

```
ubuntu@ubuntu:~/imagenet-openfaas$ faas-cli deploy
Deploying: imagenet.

Is OpenFaaS deployed? Do you need to specify the --gateway flag?
Post "http://127.0.0.1:8080/system/functions": context deadline exceeded (Client.Timeout exceeded while awaiting headers)

Function 'imagenet' failed to deploy with status code: 500
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

The CLI flag `--timeout` was added, and I may mention this in Serverless For Everyone Else too.