### PR TITLE
Fix generate command for read-only root filesystem setting

### DIFF
--- a/commands/generate.go
+++ b/commands/generate.go
@@ -203,15 +203,16 @@ func generateCRDYAML(services stack.Services, format schema.BuildFormat, apiVers
 			imageName := schema.BuildImageName(format, function.Image, version, branch)
 
 			spec := openfaasv1.Spec{
-				Name:        name,
-				Image:       imageName,
-				Environment: allEnvironment,
-				Labels:      function.Labels,
-				Annotations: function.Annotations,
-				Limits:      function.Limits,
-				Requests:    function.Requests,
-				Constraints: function.Constraints,
-				Secrets:     function.Secrets,
+				Name:                   name,
+				Image:                  imageName,
+				Environment:            allEnvironment,
+				Labels:                 function.Labels,
+				Annotations:            function.Annotations,
+				Limits:                 function.Limits,
+				Requests:               function.Requests,
+				Constraints:            function.Constraints,
+				Secrets:                function.Secrets,
+				ReadOnlyRootFilesystem: function.ReadOnlyRootFilesystem,
 			}
 
 			crd := openfaasv1.CRD{

--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -202,6 +202,35 @@ spec:
 		Branch:     "",
 		Version:    "",
 	},
+	{
+		Name: "Read-only root filesystem",
+		Input: `
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+ url-ping:
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2
+  readonly_root_filesystem: true`,
+		Output: []string{`---
+apiVersion: openfaas.com/v1
+kind: Function
+metadata:
+  name: url-ping
+  namespace: openfaas-fn
+spec:
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+  readOnlyRootFilesystem: true
+`},
+		Format:     schema.DefaultFormat,
+		APIVersion: "openfaas.com/v1",
+		Namespace:  "openfaas-fn",
+		Branch:     "",
+		Version:    "",
+	},
 }
 
 func Test_generateCRDYAML(t *testing.T) {

--- a/schema/openfaas/v1/crd.go
+++ b/schema/openfaas/v1/crd.go
@@ -34,6 +34,8 @@ type Spec struct {
 
 	//Secrets list of secrets to be made available to function
 	Secrets []string `yaml:"secrets,omitempty"`
+
+	ReadOnlyRootFilesystem bool `yaml:"readOnlyRootFilesystem,omitempty"`
 }
 
 //CRD root level YAML definition for the object


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make sure the readonly_root_filesystem setting is included in the resulting CRD when running `faas-cli generate`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Closes #928 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
1. Verified output of generate command

Stack.yml:

```yaml
version: 1.0
provider:
  name: openfaas
  gateway: http://127.0.0.1:8080
functions:
  python3-http-fn:
    lang: python3-http
    handler: ./python3-http-fn
    image: welteki2/python3-http-fn:latest
    readonly_root_filesystem: true
```

Generated CRD:

```yaml
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: python3-http-fn
  namespace: openfaas-fn
spec:
  name: python3-http-fn
  image: welteki2/python3-http-fn:latest
  readOnlyRootFilesystem: true

```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
