### PR TITLE
Make envVar output from describe deterministic

### DIFF
--- a/commands/describe.go
+++ b/commands/describe.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"text/tabwriter"
@@ -225,6 +226,15 @@ func printMap(w io.Writer, name string, m map[string]string, verbose bool) {
 	}
 
 	fmt.Fprintf(w, "%s:\n", name)
+
+	if name == "Environment" {
+		orderedKeys := generateMapOrder(m)
+		for _, keyName := range orderedKeys {
+			fmt.Fprintln(w, "\t "+keyName+": "+m[keyName])
+		}
+		return
+	}
+
 	for key, value := range m {
 		fmt.Fprintln(w, "\t "+key+": "+value)
 	}
@@ -285,4 +295,17 @@ func isEmpty(a interface{}) bool {
 		return v.IsNil()
 	}
 	return false
+}
+
+func generateMapOrder(m map[string]string) []string {
+
+	var keyNames []string
+
+	for keyName := range m {
+		keyNames = append(keyNames, keyName)
+	}
+
+	sort.Strings(keyNames)
+
+	return keyNames
 }

--- a/commands/describe_test.go
+++ b/commands/describe_test.go
@@ -148,3 +148,56 @@ func TestDescribeOuput(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateMapOrder(t *testing.T) {
+	var generateMapOrderTestcases = []struct {
+		Name       string
+		Input      map[string]string
+		Output     []string
+		expectFail bool
+	}{
+		{
+			Name: "One item",
+			Input: map[string]string{
+				"AAA": "aaa",
+			},
+			Output:     []string{"AAA"},
+			expectFail: false,
+		},
+		{
+			Name: "Multiple items",
+			Input: map[string]string{
+				"AAA": "aaa",
+				"BBB": "bbb",
+				"CCC": "ccc",
+				"DDD": "ddd",
+			},
+			Output:     []string{"AAA", "BBB", "CCC", "DDD"},
+			expectFail: false,
+		},
+		{
+			Name: "Multiple items but use a value",
+			Input: map[string]string{
+				"AAA": "aaa",
+				"BBB": "bbb",
+				"CCC": "ccc",
+				"DDD": "ddd",
+			},
+			Output:     []string{"AAA", "BBB", "CCC", "ddd"},
+			expectFail: true,
+		},
+	}
+	for _, testcase := range generateMapOrderTestcases {
+		orderedSlice := generateMapOrder(testcase.Input)
+		if len(orderedSlice) != len(testcase.Output) {
+			t.Errorf("Slice sizes do not match: %s", testcase.Name)
+			t.Fail()
+		}
+		for i, v := range testcase.Output {
+			if v != orderedSlice[i] && !testcase.expectFail {
+				t.Errorf("Exected %s got %s: %s", v, orderedSlice[i], testcase.Name)
+				t.Fail()
+			}
+		}
+	}
+}

--- a/commands/describe_test.go
+++ b/commands/describe_test.go
@@ -120,6 +120,22 @@ func TestDescribeOuput(t *testing.T) {
 			verbose:        false,
 			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nUsage:\n\tRAM:\t1024.00 MB\n\tCPU:\t2 Mi\n",
 		},
+		{
+			name: "Multiple env variables",
+			function: schema.FunctionDescription{
+				FunctionStatus: types.FunctionStatus{
+					Name:        "figlet",
+					Image:       "openfaas/figlet:latest",
+					Labels:      &map[string]string{"quadrant": "alpha"},
+					Annotations: &map[string]string{},
+					EnvVars:     map[string]string{"DDD": "ddd", "AAA": "aaa", "BBB": "bbb", "CCC": "ccc"},
+					Secrets:     []string{"db-password"},
+				},
+				Status: "Ready",
+			},
+			verbose:        true,
+			expectedOutput: "Name:\tfiglet\nStatus:\tReady\nReplicas:\t0\nAvailable Replicas: 0\nInvocations:\t0\nImage:\topenfaas/figlet:latest\nFunction Process:\t<default>\nURL:\t<none>\nAsync URL:\t<none>\nLabels:\n quadrant: alpha\nAnnotations:\t<none>\nConstraints:\t<none>\nEnvironment:\n AAA: aaa\n BBB: bbb\n CCC: ccc\n DDD: ddd\nSecrets:\n - db-password\nRequests:\t<none>\nLimits:\t<none>\nUsage:\t<none>\n",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
As `describe` uses a map to store the env var kv pairs its output varies in its ordering.  This is undesirable.

This change introduces a means by which env var output ordering is predictable.

## Motivation and Context
- [x] I have raised an issue to propose this change (Fixes #932)

## How Has This Been Tested?
Wrote a test that will intermittently fail because of the env var order changing
Pushed the commit and observed CI output:

https://github.com/openfaas/faas-cli/actions/runs/3119630183/jobs/5059713636#step:6:6018

After adding the required code....

Created a multipass ubuntu vm and installed faasd
Deployed env from the store using:
```
faas-cli store deploy env  --gateway http://<IP-ADDRESS>:8080 -e FRED=fred -e BURT=burt -e RICH=rich -e ALEX=alex
```
Ran watch with the current `faas-cli` version:
```
faas-cli version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  0451db85faebbc4b2c9c69c8af64686ff6617825
 version: 0.14.7
```

![preChange](https://user-images.githubusercontent.com/16418793/192116569-c9a5a4d9-6e58-4ab7-a77a-973f8423a559.gif)
Note that the time changes along with the ordering

Ran the same test using the local build binary
```
./faas-cli version
  ___                   _____           ____
 / _ \ _ __   ___ _ __ |  ___|_ _  __ _/ ___|
| | | | '_ \ / _ \ '_ \| |_ / _` |/ _` \___ \
| |_| | |_) |  __/ | | |  _| (_| | (_| |___) |
 \___/| .__/ \___|_| |_|_|  \__,_|\__,_|____/
      |_|

CLI:
 commit:  1df64ad2bcdf71ae9db172850962442ac7c6b747
 version: 0.6.13-399-g1df64ad2
Your faas-cli version (0.6.13-399-g1df64ad2) may be out of date. Version: 0.14.7 is now available on GitHub.

```
![postChange_](https://user-images.githubusercontent.com/16418793/192118278-ce122647-e371-4b72-a715-988f036ca5f5.gif)

Note that the time changes but the ordering doesn't

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
