### PR TITLE
Remove hardcoded kubeseal from findRelease

### DIFF
--- a/commands/cloud.go
+++ b/commands/cloud.go
@@ -216,7 +216,7 @@ func findRelease(url string) (string, error) {
 
 	loc := res.Header.Get("Location")
 	if len(loc) == 0 {
-		return "", fmt.Errorf("unable to determine release of kubeseal")
+		return "", fmt.Errorf("unable to determine release from %s", url)
 	}
 	version := loc[strings.LastIndex(loc, "/")+1:]
 	return version, nil


### PR DESCRIPTION
Signed-off-by: Richard Gee <richard@technologee.co.uk>

## Description
Removes the hardcoded reference to kubeseal in favour of using the provided url instead.

## Motivation and Context
- [x] I have raised an issue to propose this change ([required](fixes #935)

## How Has This Been Tested?


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
