### PR TITLE
fix: set the client user agent

### DIFF
--- a/proxy/client.go
+++ b/proxy/client.go
@@ -11,9 +11,11 @@ import (
 	gopath "path"
 	"strings"
 	"time"
+
+	"github.com/openfaas/faas-cli/version"
 )
 
-//Client an API client to perform all operations
+// Client an API client to perform all operations
 type Client struct {
 	httpClient *http.Client
 	//ClientAuth a type implementing ClientAuth interface for client authentication
@@ -24,13 +26,13 @@ type Client struct {
 	UserAgent string
 }
 
-//ClientAuth an interface for client authentication.
+// ClientAuth an interface for client authentication.
 // to add authentication to the client implement this interface
 type ClientAuth interface {
 	Set(req *http.Request) error
 }
 
-//NewClient initializes a new API client
+// NewClient initializes a new API client
 func NewClient(auth ClientAuth, gatewayURL string, transport http.RoundTripper, timeout *time.Duration) (*Client, error) {
 	gatewayURL = strings.TrimRight(gatewayURL, "/")
 	baseURL, err := url.Parse(gatewayURL)
@@ -51,10 +53,11 @@ func NewClient(auth ClientAuth, gatewayURL string, transport http.RoundTripper, 
 		ClientAuth: auth,
 		httpClient: client,
 		GatewayURL: baseURL,
+		UserAgent:  fmt.Sprintf("faas-cli/%s", version.BuildVersion()),
 	}, nil
 }
 
-//newRequest create a new HTTP request with authentication
+// newRequest create a new HTTP request with authentication
 func (c *Client) newRequest(method, path string, query url.Values, body io.Reader) (*http.Request, error) {
 
 	// deep copy gateway url and then add the supplied path  and args to the copy so that
@@ -85,7 +88,7 @@ func (c *Client) newRequest(method, path string, query url.Values, body io.Reade
 	return req, err
 }
 
-//doRequest perform an HTTP request with context
+// doRequest perform an HTTP request with context
 func (c *Client) doRequest(ctx context.Context, req *http.Request) (*http.Response, error) {
 	req = req.WithContext(ctx)
 
@@ -123,7 +126,7 @@ func addQueryParams(u string, params map[string]string) (string, error) {
 	return parsedURL.String(), nil
 }
 
-//AddCheckRedirect add CheckRedirect to the client
+// AddCheckRedirect add CheckRedirect to the client
 func (c *Client) AddCheckRedirect(checkRedirect func(*http.Request, []*http.Request) error) {
 	c.httpClient.CheckRedirect = checkRedirect
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,7 +1,5 @@
 package version
 
-const UserAgent = "OpenFaaS CLI"
-
 var (
 	Version, GitCommit string
 )


### PR DESCRIPTION
The code already existed for setting the UserAgent header, but a value was never passed to the client. This change will now set a string matching the following format

```
faas-cli/<build version>
```

For example:

```
faas-cli/0.14.6-5-ga9c2b10f
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
The missing user agent was noticed in my nginx access logs while debugging a function today 
![image](https://user-images.githubusercontent.com/891889/197596942-eee835a3-d0ae-4bdc-8392-ae60f5b45ef6.png)
 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested in the same environment as before, i now see `faas-cli/<version>` in the access logs
![image](https://user-images.githubusercontent.com/891889/197597498-348c79a7-044d-4f60-a7ac-0f1c2e05c26c.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
