### PR TITLE
doc: remove 'faas-cli auth'  information

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ The main commands supported by the CLI are:
 
 * `faas-cli secret` - manage secrets for your functions
 
-* `faas-cli auth` - initiates an OAuth2 authorization flow to obtain a token
-
 * `faas-cli registry-login` - generate registry auth file in correct format by providing username and password for docker/ecr/self hosted registry
 
 The default gateway URL of `127.0.0.1:8080` can be overridden in three places including an environmental variable.
@@ -113,45 +111,6 @@ Help for all of the commands supported by the CLI can be found by running:
 * `faas-cli help` or `faas-cli [command] --help`
 
 You can chose between using a [programming language template](https://github.com/openfaas/templates/tree/master/template) where you only need to provide a handler file, or a Docker that you can build yourself.
-
-#### `faas-cli auth`
-
-The `auth` command is only licensed for OpenFaaS Pro customers.
-
-Use the `auth` command to obtain a JWT to use as a Bearer token.
-
-##### `code` grant - default
-
-Use this flow to obtain a token for interactive use from your workstation.
-
-The code grant flow uses the PKCE extension.
-
-At this time the `token` cannot be saved or retained in your OpenFaaS config file. You can pass the token using a CLI flag of `--token=$TOKEN`.
-
-Example:
-
-```sh
-faas-cli auth \
-  --auth-url https://tenant0.eu.auth0.com/authorize \
-  --token-url https://tenant0.eu.auth0.com/oauth/token \
-  --audience http://gw.example.com \
-  --client-id "${OAUTH_CLIENT_ID}"
-```
-
-##### `client_credentials` grant
-
-Use this flow for machine to machine communication such as when you want to deploy a function to a gateway that uses OAuth2 / OIDC.
-
-Example:
-
-```sh
-faas-cli auth \
-  --grant client_credentials \
-  --auth-url https://tenant0.eu.auth0.com/oauth/token \
-  --client-id "${OAUTH_CLIENT_ID}" \
-  --client-secret "${OAUTH_CLIENT_SECRET}"\
-  --audience http://gw.example.com
-```
 
 ##### Environment variable substitution
 


### PR DESCRIPTION
remove 'faas-cli auth' explanatory information from Readme.md, the project delete  command 'faas-cli auth', but some message information remained Readme.md;

![image](https://user-images.githubusercontent.com/23071653/202657641-561f904e-4ccf-44da-a865-e9779b814de0.png)


Signed-off-by: 流雨声 <212724256@qq.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
