### PR TITLE
feat: add run command for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ obj
 .idea
 .DS_Store
 
-
 template
 
 *.pem

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -420,6 +420,10 @@ func compileEnvironment(envvarOpts []string, yamlEnvironment map[string]string, 
 func deriveFprocess(function stack.Function) (string, error) {
 	var fprocess string
 
+	if function.FProcess != "" {
+		return function.FProcess, nil
+	}
+
 	pathToTemplateYAML := "./template/" + function.Language + "/template.yml"
 	if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
 		return "", err

--- a/commands/local_run.go
+++ b/commands/local_run.go
@@ -1,0 +1,227 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"os/exec"
+
+	"github.com/openfaas/faas-cli/stack"
+	"github.com/spf13/cobra"
+)
+
+const localSecretsDir = ".secrets"
+
+func init() {
+	faasCmd.AddCommand(newLocalRunCmd())
+}
+
+type runOptions struct {
+	print    bool
+	port     int
+	network  string
+	extraEnv map[string]string
+	output   io.Writer
+	err      io.Writer
+}
+
+func newLocalRunCmd() *cobra.Command {
+	opts := runOptions{}
+
+	cmd := &cobra.Command{
+		Use:   `local-run NAME --port PORT -f YAML_FILE`,
+		Short: "Start a function with docker for local testing.",
+		Long: `Providing faas-cli build has already been run, this command will use the 
+docker command to start a container on your local machine using its image.
+
+The function will be bound to the port specified by the --port flag, or 8080
+by default.
+
+There is limited support for secrets, and the function cannot contact other 
+services deployed within your OpenFaaS cluster.`,
+		Example: `
+  # Run a function locally
+  faas-cli local-run stronghash
+
+  # Run on a custom port
+  faas-cli local-run stronghash --port 8081
+  # Use a custom YAML file other than stack.yml
+  faas-cli local-run stronghash -f ./stronghash.yml
+		`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) < 1 {
+				return fmt.Errorf("expected the name of the function")
+			}
+
+			if len(args) > 1 {
+				return fmt.Errorf("only one function name is allowed")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			opts.output = cmd.OutOrStdout()
+			opts.err = cmd.ErrOrStderr()
+
+			return runFunction(ctx, args[0], opts)
+		},
+		// TODO: unhide once we are happy with the DX.
+		Hidden: true,
+	}
+
+	cmd.Flags().BoolVar(&opts.print, "print", false, "Print the docker command instead of running it")
+	cmd.Flags().IntVarP(&opts.port, "port", "p", 8080, "port to bind the function to")
+	cmd.Flags().StringVar(&opts.network, "network", "", "connect function to an existing network, use 'host' to access other process already running on localhost. When using this, '--port' is ignored, if you have port collisions, you may change the port using '-e port=NEW_PORT'")
+	cmd.Flags().StringToStringVarP(&opts.extraEnv, "env", "e", map[string]string{}, "additional environment variables (ENVVAR=VALUE), use this to experiment with different values for your function")
+
+	return cmd
+}
+
+func runFunction(ctx context.Context, name string, opts runOptions) error {
+	services, err := stack.ParseYAMLFile(yamlFile, "", name, true)
+	if err != nil {
+		return err
+	}
+
+	if len(services.Functions) > 1 {
+		return fmt.Errorf("multiple functions matching %q in the stack file", name)
+	}
+
+	fnc := services.Functions[name]
+	// TODO: we should probably use a levelled logger here
+	// fmt.Fprintf(opts.output, "%#v\n\n", fnc)
+
+	cmd, err := buildDockerRun(ctx, fnc, opts)
+	if err != nil {
+		return err
+	}
+
+	if opts.print {
+		fmt.Fprintf(opts.output, "%s\n", cmd.String())
+		return nil
+	}
+
+	cmd.Stdout = opts.output
+	cmd.Stderr = opts.err
+
+	fmt.Printf("Starting local-run for: %s on: http://0.0.0.0:%d\n\n", name, opts.port)
+
+	if err = cmd.Start(); err != nil {
+		return err
+	}
+
+	return cmd.Wait()
+}
+
+// buildDockerRun constructs a exec.Cmd from the given stack Function
+func buildDockerRun(ctx context.Context, fnc stack.Function, opts runOptions) (*exec.Cmd, error) {
+	args := []string{"run", "--rm", "-i", fmt.Sprintf("-p=%d:8080", opts.port)}
+
+	if opts.network != "" {
+		args = append(args, fmt.Sprintf("--network=%s", opts.network))
+	}
+
+	fprocess, err := deriveFprocess(fnc)
+	if err != nil {
+		return nil, err
+	}
+
+	for name, value := range fnc.Environment {
+		args = append(args, fmt.Sprintf("-e=%s=%s", name, value))
+	}
+
+	moreEnv, err := readFiles(fnc.EnvironmentFile)
+	if err != nil {
+		return nil, err
+	}
+
+	for name, value := range moreEnv {
+		args = append(args, fmt.Sprintf("-e=%s=%s", name, value))
+	}
+
+	for name, value := range opts.extraEnv {
+		args = append(args, fmt.Sprintf("-e=%s=%s", name, value))
+	}
+
+	if fnc.ReadOnlyRootFilesystem {
+		args = append(args, "--read-only")
+	}
+
+	if fnc.Limits != nil {
+		if fnc.Limits.Memory != "" {
+			// use a soft limit for debugging
+			args = append(args, fmt.Sprintf("--memory-reservation=%s", fnc.Limits.Memory))
+		}
+
+		if fnc.Limits.CPU != "" {
+			args = append(args, fmt.Sprintf("--cpus=%s", fnc.Limits.CPU))
+		}
+	}
+
+	if len(fnc.Secrets) > 0 {
+		secretsPath, err := filepath.Abs(localSecretsDir)
+		if err != nil {
+			return nil, fmt.Errorf("can't determine secrets folder: %w", err)
+		}
+
+		err = os.MkdirAll(secretsPath, 0700)
+		if err != nil {
+			return nil, fmt.Errorf("can't create local secrets folder %q: %w", secretsPath, err)
+		}
+
+		if !opts.print {
+			err = dirContainsFiles(secretsPath, fnc.Secrets...)
+			if err != nil {
+				return nil, fmt.Errorf("missing files: %w", err)
+			}
+		}
+
+		args = append(args, fmt.Sprintf("--volume=%s:/var/openfaas/secrets", secretsPath))
+	}
+
+	args = append(args, fmt.Sprintf("-e=fprocess=%s", fprocess))
+	args = append(args, fnc.Image)
+
+	cmd := exec.CommandContext(ctx, "docker", args...)
+
+	return cmd, nil
+}
+
+func dirContainsFiles(dir string, names ...string) error {
+	var err = &missingFileError{
+		dir:     dir,
+		missing: []string{},
+	}
+
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		_, statErr := os.Stat(path)
+		if statErr != nil {
+			err.missing = append(err.missing, name)
+		}
+	}
+
+	if len(err.missing) > 0 {
+		return err
+	}
+
+	return nil
+}
+
+type missingFileError struct {
+	missing []string
+	dir     string
+}
+
+func (m missingFileError) Error() string {
+	return fmt.Sprintf("create the following secrets (%s) in: %q", strings.Join(m.missing, ", "), m.dir)
+}
+
+func (m *missingFileError) AddMissingSecret(p string) {
+	m.missing = append(m.missing, p)
+}

--- a/commands/local_run.go
+++ b/commands/local_run.go
@@ -17,7 +17,9 @@ import (
 const localSecretsDir = ".secrets"
 
 func init() {
-	faasCmd.AddCommand(newLocalRunCmd())
+	if v, ok := os.LookupEnv("OPENFAAS_EXPERIMENTAL"); ok && v == "1" {
+		faasCmd.AddCommand(newLocalRunCmd())
+	}
 }
 
 type runOptions struct {
@@ -34,13 +36,13 @@ func newLocalRunCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   `local-run NAME --port PORT -f YAML_FILE`,
-		Short: "Start a function with docker for local testing.",
+		Short: "Start a function with docker for local testing (experimental feature)",
 		Long: `Providing faas-cli build has already been run, this command will use the 
 docker command to start a container on your local machine using its image.
 
 The function will be bound to the port specified by the --port flag, or 8080
 by default.
-
+ 
 There is limited support for secrets, and the function cannot contact other 
 services deployed within your OpenFaaS cluster.`,
 		Example: `
@@ -49,6 +51,7 @@ services deployed within your OpenFaaS cluster.`,
 
   # Run on a custom port
   faas-cli local-run stronghash --port 8081
+
   # Use a custom YAML file other than stack.yml
   faas-cli local-run stronghash -f ./stronghash.yml
 		`,

--- a/commands/update_gitignore.go
+++ b/commands/update_gitignore.go
@@ -18,7 +18,7 @@ func contains(s []string, e string) bool {
 func updateContent(content string) (updated_content string) {
 	// append files to ignore to file content if it is not already ignored
 
-	filesToIgnore := []string{"template", "build"}
+	filesToIgnore := []string{"template", "build", ".secrets"}
 
 	lines := strings.Split(content, "\n")
 
@@ -34,7 +34,7 @@ func updateContent(content string) (updated_content string) {
 }
 
 func updateGitignore() (err error) {
-	// update .gitignore file if it already present othewise creates it
+	// update .gitignore file if it already present otherwise creates it
 
 	f, err := os.OpenFile(".gitignore", os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {

--- a/commands/update_gitignore_test.go
+++ b/commands/update_gitignore_test.go
@@ -12,17 +12,17 @@ var testcases = []struct {
 	{
 		testcase_name: "Testcase 1",
 		input:         "",
-		output:        "template\nbuild",
+		output:        "template\nbuild\n.secrets",
 	},
 	{
 		testcase_name: "Testcase 2",
 		input:         "/path/to/folder\n*.pyc\n.DS_STORE",
-		output:        "/path/to/folder\n*.pyc\n.DS_STORE\ntemplate\nbuild",
+		output:        "/path/to/folder\n*.pyc\n.DS_STORE\ntemplate\nbuild\n.secrets",
 	},
 	{
 		testcase_name: "Testcase 3",
 		input:         "/path/to/folder\ntemplate\n*.pyc\n.DS_STORE",
-		output:        "/path/to/folder\ntemplate\n*.pyc\n.DS_STORE\nbuild",
+		output:        "/path/to/folder\ntemplate\n*.pyc\n.DS_STORE\nbuild\n.secrets",
 	},
 }
 

--- a/stack.yml
+++ b/stack.yml
@@ -14,10 +14,10 @@ functions:
     image: ${DOCKER_USER:-alexellis2}/url-ping:0.3
     environment:
       debug: true
-#    requests:
-#      memory: 32Mi
-#    limits:
-#      memory: 64Mi
+  #    requests:
+  #      memory: 32Mi
+  #    limits:
+  #      memory: 64Mi
 
   # skip_build is useful for deploying pre-existing images from stack.yml
   stronghash:
@@ -27,7 +27,8 @@ functions:
     environment:
       fprocess: sha512sum
     secrets:
-     - test1
+      - test1
+      - test2
 
   nodejs-echo:
     lang: node


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Improve the DX by simplifying the process to run a functional locally. This makes it easier to quickly build and test a function.

For simplicity, this only supports running functions defined in stack files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

1. First install using `make local-install`
2. Then attempt to run a function using these commands

a) basic operations that don't run a container
```sh
faas-cli run --help
faas-cli run stronghash --print
```

b) very simple function spec
```sh
faas-cli template store pull python 
faas-cli build --filter 'url-ping'
faas-cli run url-ping
```
now in a new terminal
```sh
$ curl -XPOST localhost:8080 -d "foo"
Handle this -> foo
Give me a URL and I'll ping it for you.
$ curl -XPOST localhost:8080 -d "https://google.com"
Handle this -> https://google.com
```

c) function that requires a secret

```sh
$  faas-cli run stronghash
Function requires secrets, but can not all can be found: directory "/home/lucas/code/openfaas/faas-cli/.secrets" requires the following files: test1, test2

$ echo 'foobar' > .secrets/test1
$ faas-cli run stronghash
Function requires secrets, but can not all can be found: directory "/home/lucas/code/openfaas/faas-cli/.secrets" requires the following files: test2


$ echo 'foobar' > .secrets/test2
$ faas-cli run stronghash
2022/12/03 12:17:59 Version: 0.1.4      SHA: 86e85231a20df03bc9187a31c400f4bbc4e2b9ba
2022/12/03 12:17:59 Timeouts: read: 5s, write: 5s hard: 0s.
2022/12/03 12:17:59 Listening on port: 8080
2022/12/03 12:17:59 Writing lock-file to: /tmp/.lock
2022/12/03 12:17:59 Metrics listening on port: 8081
```

Now in a new terminal

```sh
$ curl -XPOST localhost:8080 -d "foo"
f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
