### PR TITLE
Fix registry-login command for ecr

### DIFF
--- a/commands/registry_login.go
+++ b/commands/registry_login.go
@@ -30,7 +30,7 @@ func init() {
 	registryLoginCommand.Flags().String("password", "", "The registry password")
 	registryLoginCommand.Flags().BoolP("password-stdin", "s", false, "Reads the docker password from stdin, either pipe to the command or remember to press ctrl+d when reading interactively")
 
-	registryLoginCommand.Flags().Bool("ecr", false, "If we are using ECR we need a different set of flags, so if this is set, we need to set --username and --password")
+	registryLoginCommand.Flags().Bool("ecr", false, "If we are using ECR we need a different set of flags, so if this is set, we need to set --account-id and --region")
 	registryLoginCommand.Flags().String("account-id", "", "Your AWS Account id")
 	registryLoginCommand.Flags().String("region", "", "Your AWS region")
 
@@ -38,17 +38,17 @@ func init() {
 }
 
 func generateRegistryPreRun(command *cobra.Command, args []string) error {
-	server, err := command.Flags().GetString("server")
+	_, err := command.Flags().GetString("server")
 	if err != nil {
 		return fmt.Errorf("error with --server usage: %s", err)
 	}
 
-	username, err = command.Flags().GetString("username")
+	_, err = command.Flags().GetString("username")
 	if err != nil {
 		return fmt.Errorf("error with --username usage: %s", err)
 	}
 
-	password, err = command.Flags().GetString("password")
+	_, err = command.Flags().GetString("password")
 	if err != nil {
 		return fmt.Errorf("error with --password usage: %s", err)
 	}
@@ -74,17 +74,6 @@ func generateRegistryPreRun(command *cobra.Command, args []string) error {
 	}
 
 	if ecr {
-		if len(server) > 0 {
-			return fmt.Errorf("the --server flag is not supported with ECR")
-		}
-
-		if len(password) > 0 {
-			return fmt.Errorf("the --password flag is not supported with ECR")
-		}
-
-		if len(username) > 0 {
-			return fmt.Errorf("the --username flag is not supported with ECR")
-		}
 		if len(accountID) == 0 {
 			return fmt.Errorf("the --account-id flag is required with ECR")
 		}
@@ -104,10 +93,6 @@ func generateRegistryAuthFile(command *cobra.Command, _ []string) error {
 	password, _ := command.Flags().GetString("password")
 	server, _ := command.Flags().GetString("server")
 	passStdin, _ := command.Flags().GetBool("password-stdin")
-
-	if len(username) == 0 {
-		return fmt.Errorf("you must give --username (-u)")
-	}
 
 	if ecrEnabled {
 		if err := generateECRFile(accountID, region); err != nil {


### PR DESCRIPTION
Signed-off-by: Han Verstraete (OpenFaaS Ltd) <han@openfaas.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix registry-login command for ecr:

Running the command with the --ecr flag always fails because it checks if other flags are not set and some have default values.

Ignore these flags instead of exiting when they are provided.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fix flag validation for registry-login command.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Verified flag validation for the command works as expected:

![Screenshot 2023-01-12 at 17 17 47](https://user-images.githubusercontent.com/16267532/212123666-59fa11d1-8c04-4d07-b843-603f9ea6aef4.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
