### PR TITLE
chore: ensure we always ignore the .secrets folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ template
 secrets.yml
 
 /withprivate*
+
+.secrets

--- a/commands/local_run.go
+++ b/commands/local_run.go
@@ -37,13 +37,13 @@ func newLocalRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   `local-run NAME --port PORT -f YAML_FILE`,
 		Short: "Start a function with docker for local testing (experimental feature)",
-		Long: `Providing faas-cli build has already been run, this command will use the 
+		Long: `Providing faas-cli build has already been run, this command will use the
 docker command to start a container on your local machine using its image.
 
 The function will be bound to the port specified by the --port flag, or 8080
 by default.
- 
-There is limited support for secrets, and the function cannot contact other 
+
+There is limited support for secrets, and the function cannot contact other
 services deployed within your OpenFaaS cluster.`,
 		Example: `
   # Run a function locally
@@ -93,6 +93,11 @@ func runFunction(ctx context.Context, name string, opts runOptions) error {
 
 	if len(services.Functions) > 1 {
 		return fmt.Errorf("multiple functions matching %q in the stack file", name)
+	}
+
+	err = updateGitignore()
+	if err != nil {
+		return err
 	}
 
 	fnc := services.Functions[name]


### PR DESCRIPTION
Always update the .gitignore during `local-run` so that we ensure the `.secrets` folder is always ignored.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves a commend from #946 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
