### PR TITLE
Add fprocess to generated CRDs and fix indentation

### DIFF
--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -26,23 +26,23 @@ var generateTestcases = []struct {
 		Name: "Specified Namespace and API Version",
 		Input: `
 provider:
-    name: openfaas
-    gateway: http://127.0.0.1:8080
-    network: "func_functions"            
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"      
 functions:
  url-ping:
-     lang: python
-     handler: ./sample/url-ping
-     image: alexellis/faas-url-ping:0.2`,
+   lang: python
+   handler: ./sample/url-ping
+   image: alexellis/faas-url-ping:0.2`,
 		Output: []string{`---
 apiVersion: openfaas.com/v1
 kind: Function
 metadata:
-    name: url-ping
-    namespace: openfaas-fn
+  name: url-ping
+  namespace: openfaas-fn
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
 `},
 		Format:     schema.DefaultFormat,
 		APIVersion: "openfaas.com/v1",
@@ -54,27 +54,27 @@ spec:
 		Name: "Annotation present",
 		Input: `
 provider:
-    name: openfaas
-    gateway: http://127.0.0.1:8080
+  name: openfaas
+  gateway: http://127.0.0.1:8080
 functions:
  url-ping:
-     lang: python
-     handler: ./sample/url-ping
-     image: alexellis/faas-url-ping:0.2
-     annotations:
-         com.scale.zero: 1
+   lang: python
+   handler: ./sample/url-ping
+   image: alexellis/faas-url-ping:0.2
+   annotations:
+     com.scale.zero: 1
 `,
 		Output: []string{`---
 apiVersion: openfaas.com/v1
 kind: Function
 metadata:
-    name: url-ping
-    namespace: openfaas-fn
+  name: url-ping
+  namespace: openfaas-fn
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2
-    annotations:
-        com.scale.zero: "1"
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+  annotations:
+    com.scale.zero: "1"
 `},
 		Format:     schema.DefaultFormat,
 		APIVersion: "openfaas.com/v1",
@@ -86,22 +86,22 @@ spec:
 		Name: "Blank namespace",
 		Input: `
 provider:
-    name: openfaas
-    gateway: http://127.0.0.1:8080
-    network: "func_functions"
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"
 functions:
  url-ping:
-    lang: python
-    handler: ./sample/url-ping
-    image: alexellis/faas-url-ping:0.2`,
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2`,
 		Output: []string{`---
 apiVersion: openfaas.com/v1
 kind: Function
 metadata:
-    name: url-ping
+  name: url-ping
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
 `},
 		Format:     schema.DefaultFormat,
 		APIVersion: "openfaas.com/v1",
@@ -113,23 +113,23 @@ spec:
 		Name: "BranchAndSHA Image format",
 		Input: `
 provider:
-    name: openfaas
-    gateway: http://127.0.0.1:8080
-    network: "func_functions"
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+  network: "func_functions"
 functions:
  url-ping:
-    lang: python
-    handler: ./sample/url-ping
-    image: alexellis/faas-url-ping:0.2`,
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2`,
 		Output: []string{`---
 apiVersion: openfaas.com/v1
 kind: Function
 metadata:
-    name: url-ping
-    namespace: openfaas-function
+  name: url-ping
+  namespace: openfaas-function
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2-master-6bgf36qd
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2-master-6bgf36qd
 `},
 		Format:     schema.BranchAndSHAFormat,
 		APIVersion: "openfaas.com/v1",
@@ -141,60 +141,60 @@ spec:
 		Name: "Multiple functions",
 		Input: `
 provider:
-    name: openfaas
-    gateway: http://127.0.0.1:8080    
-    network: "func_functions"
+  name: openfaas
+  gateway: http://127.0.0.1:8080  
+  network: "func_functions"
 functions:
  url-ping:
-    lang: python
-    handler: ./sample/url-ping
-    image: alexellis/faas-url-ping:0.2
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2
  astronaut-finder:
-    lang: python3
-    handler: ./astronaut-finder
-    image: astronaut-finder
-    environment:
-     write_debug: true`,
+  lang: python3
+  handler: ./astronaut-finder
+  image: astronaut-finder
+  environment:
+   write_debug: true`,
 		Output: []string{`---
 apiVersion: openfaas.com/v2alpha2
 kind: Function
 metadata:
-    name: url-ping
-    namespace: openfaas-fn
+  name: url-ping
+  namespace: openfaas-fn
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
 ---
 apiVersion: openfaas.com/v2alpha2
 kind: Function
 metadata:
-    name: astronaut-finder
-    namespace: openfaas-fn
+  name: astronaut-finder
+  namespace: openfaas-fn
 spec:
-    name: astronaut-finder
-    image: astronaut-finder:latest
-    environment:
-        write_debug: "true"
+  name: astronaut-finder
+  image: astronaut-finder:latest
+  environment:
+    write_debug: "true"
 `, `---
 apiVersion: openfaas.com/v2alpha2
 kind: Function
 metadata:
-    name: astronaut-finder
-    namespace: openfaas-fn
+  name: astronaut-finder
+  namespace: openfaas-fn
 spec:
-    name: astronaut-finder
-    image: astronaut-finder:latest
-    environment:
-        write_debug: "true"
+  name: astronaut-finder
+  image: astronaut-finder:latest
+  environment:
+    write_debug: "true"
 ---
 apiVersion: openfaas.com/v2alpha2
 kind: Function
 metadata:
-    name: url-ping
-    namespace: openfaas-fn
+  name: url-ping
+  namespace: openfaas-fn
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
 `},
 		Format:     schema.DefaultFormat,
 		APIVersion: "openfaas.com/v2alpha2",
@@ -206,24 +206,24 @@ spec:
 		Name: "Read-only root filesystem",
 		Input: `
 provider:
-    name: openfaas
-    gateway: http://127.0.0.1:8080
+  name: openfaas
+  gateway: http://127.0.0.1:8080
 functions:
  url-ping:
-    lang: python
-    handler: ./sample/url-ping
-    image: alexellis/faas-url-ping:0.2
-    readonly_root_filesystem: true`,
+  lang: python
+  handler: ./sample/url-ping
+  image: alexellis/faas-url-ping:0.2
+  readonly_root_filesystem: true`,
 		Output: []string{`---
 apiVersion: openfaas.com/v1
 kind: Function
 metadata:
-    name: url-ping
-    namespace: openfaas-fn
+  name: url-ping
+  namespace: openfaas-fn
 spec:
-    name: url-ping
-    image: alexellis/faas-url-ping:0.2
-    readOnlyRootFilesystem: true
+  name: url-ping
+  image: alexellis/faas-url-ping:0.2
+  readOnlyRootFilesystem: true
 `},
 		Format:     schema.DefaultFormat,
 		APIVersion: "openfaas.com/v1",
@@ -328,7 +328,7 @@ var generateOrderedTestcases = []struct {
 provider:
   name: openfaas
   gateway: http://127.0.0.1:8080
-  network: "func_functions"      
+  network: "func_functions"    
 functions:
  fn1:
   lang: python3
@@ -385,7 +385,7 @@ functions:
 provider:
   name: openfaas
   gateway: http://127.0.0.1:8080
-  network: "func_functions"      
+  network: "func_functions"    
 functions:
  fn3:
   lang: python3
@@ -442,7 +442,7 @@ functions:
 provider:
   name: openfaas
   gateway: http://127.0.0.1:8080
-  network: "func_functions"      
+  network: "func_functions"    
 functions:
  fn3:
   lang: python3

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"bytes"
 	"encoding/base64"
 
 	"fmt"
@@ -153,12 +154,14 @@ func (configFile *ConfigFile) save() error {
 	}
 	defer file.Close()
 
-	data, err := yaml.Marshal(configFile)
-	if err != nil {
+	var buff bytes.Buffer
+	yamlEncoder := yaml.NewEncoder(&buff)
+	yamlEncoder.SetIndent(2) // this is what you're looking for
+	if err := yamlEncoder.Encode(&configFile); err != nil {
 		return err
 	}
 
-	_, err = file.Write(data)
+	_, err = file.Write(buff.Bytes())
 	return err
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add fprocess to generated CRDs and fix indentation

## Motivation and Context

Indentation changed to four spaces when upgrading to the v3 YAML paser, this reverts to 2 spaces.

The fprocess variable in the store was missing from generated function YAML files with faas-cli generate --from-store - this has now been fixed and an env will be emitted when there is no existing conflicting definition in the store's manifest.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested before/after - env now can be deployed, previously it couldn't be.

Before:

```sh
faas-cli generate --from-store env
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
    name: env
    namespace: openfaas-fn
spec:
    name: env
    image: ghcr.io/openfaas/alpine:latest
    labels: {}
    annotations: {}
```

After:

```sh
go run . generate --from-store env
---
apiVersion: openfaas.com/v1
kind: Function
metadata:
  name: env
  namespace: openfaas-fn
spec:
  name: env
  image: ghcr.io/openfaas/alpine:latest
  environment:
    fprocess: env
  labels: {}
  annotations: {}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
