### PR TITLE
add new remote-builder flag to build with the Function Builder API through faas-cli

### DIFF
--- a/builder/publish.go
+++ b/builder/publish.go
@@ -4,19 +4,45 @@
 package builder
 
 import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	v1execute "github.com/alexellis/go-execute/pkg/v1"
 	"github.com/openfaas/faas-cli/schema"
 	"github.com/openfaas/faas-cli/stack"
+
+	hmac "github.com/alexellis/hmac/v2"
 )
+
+type builderConfig struct {
+	Image     string            `json:"image"`
+	BuildArgs map[string]string `json:"buildArgs,omitempty"`
+}
+
+type builderResult struct {
+	Log    []string `json:"log"`
+	Image  string   `json:"image"`
+	Status string   `json:"status"`
+}
+
+const BuilderConfigFilename = "com.openfaas.docker.config"
 
 // PublishImage will publish images as multi-arch
 // TODO: refactor signature to a struct to simplify the length of the method header
 func PublishImage(image string, handler string, functionName string, language string, nocache bool, squash bool, shrinkwrap bool, buildArgMap map[string]string,
-	buildOptions []string, tagMode schema.BuildFormat, buildLabelMap map[string]string, quietBuild bool, copyExtraPaths []string, platforms string, extraTags []string) error {
+	buildOptions []string, tagMode schema.BuildFormat, buildLabelMap map[string]string, quietBuild bool, copyExtraPaths []string, platforms string, extraTags []string, remoteBuilder, payloadSecretPath string) error {
 
 	if stack.IsValidTemplate(language) {
 		pathToTemplateYAML := fmt.Sprintf("./template/%s/template.yml", language)
@@ -51,47 +77,87 @@ func PublishImage(image string, handler string, functionName string, language st
 			return nil
 		}
 
-		buildOptPackages, buildPackageErr := getBuildOptionPackages(buildOptions, language, langTemplate.BuildOptions)
+		if remoteBuilder != "" {
+			tempDir, err := os.MkdirTemp(os.TempDir(), "builder-*")
+			if err != nil {
+				return fmt.Errorf("failed to create temporary directory for %s, error: %w", functionName, err)
+			}
+			defer os.RemoveAll(tempDir)
 
-		if buildPackageErr != nil {
-			return buildPackageErr
+			tarPath := path.Join(tempDir, "req.tar")
 
+			if err := makeTar(builderConfig{Image: imageName, BuildArgs: buildArgMap}, path.Join("build", functionName), tarPath); err != nil {
+				return fmt.Errorf("failed to create tar file for %s, error: %w", functionName, err)
+			}
+
+			res, err := callBuilder(tarPath, tempPath, remoteBuilder, functionName, payloadSecretPath)
+			if err != nil {
+				return err
+			}
+			defer res.Body.Close()
+
+			data, _ := io.ReadAll(res.Body)
+
+			result := builderResult{}
+			if err := json.Unmarshal(data, &result); err != nil {
+				return err
+			}
+
+			if !quietBuild {
+				for _, logMsg := range result.Log {
+					fmt.Printf("%s\n", logMsg)
+				}
+			}
+
+			if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusAccepted {
+				fmt.Println(res.StatusCode)
+				return fmt.Errorf("%s failure while building or pushing image %s: %s", functionName, imageName, result.Status)
+			}
+
+			log.Printf("%s success building and pushing image: %s", functionName, result.Image)
+
+		} else {
+			buildOptPackages, buildPackageErr := getBuildOptionPackages(buildOptions, language, langTemplate.BuildOptions)
+
+			if buildPackageErr != nil {
+				return buildPackageErr
+			}
+
+			dockerBuildVal := dockerBuild{
+				Image:            imageName,
+				NoCache:          nocache,
+				Squash:           squash,
+				HTTPProxy:        os.Getenv("http_proxy"),
+				HTTPSProxy:       os.Getenv("https_proxy"),
+				BuildArgMap:      buildArgMap,
+				BuildOptPackages: buildOptPackages,
+				BuildLabelMap:    buildLabelMap,
+				Platforms:        platforms,
+				ExtraTags:        extraTags,
+			}
+
+			command, args := getDockerBuildxCommand(dockerBuildVal)
+			fmt.Printf("Publishing with command: %v %v\n", command, args)
+
+			task := v1execute.ExecTask{
+				Cwd:         tempPath,
+				Command:     command,
+				Args:        args,
+				StreamStdio: !quietBuild,
+			}
+
+			res, err := task.Execute()
+
+			if err != nil {
+				return err
+			}
+
+			if res.ExitCode != 0 {
+				return fmt.Errorf("[%s] received non-zero exit code from build, error: %s", functionName, res.Stderr)
+			}
+
+			fmt.Printf("Image: %s built.\n", imageName)
 		}
-
-		dockerBuildVal := dockerBuild{
-			Image:            imageName,
-			NoCache:          nocache,
-			Squash:           squash,
-			HTTPProxy:        os.Getenv("http_proxy"),
-			HTTPSProxy:       os.Getenv("https_proxy"),
-			BuildArgMap:      buildArgMap,
-			BuildOptPackages: buildOptPackages,
-			BuildLabelMap:    buildLabelMap,
-			Platforms:        platforms,
-			ExtraTags:        extraTags,
-		}
-
-		command, args := getDockerBuildxCommand(dockerBuildVal)
-		fmt.Printf("Publishing with command: %v %v\n", command, args)
-
-		task := v1execute.ExecTask{
-			Cwd:         tempPath,
-			Command:     command,
-			Args:        args,
-			StreamStdio: !quietBuild,
-		}
-
-		res, err := task.Execute()
-
-		if err != nil {
-			return err
-		}
-
-		if res.ExitCode != 0 {
-			return fmt.Errorf("[%s] received non-zero exit code from build, error: %s", functionName, res.Stderr)
-		}
-
-		fmt.Printf("Image: %s built.\n", imageName)
 
 	} else {
 		return fmt.Errorf("language template: %s not supported, build a custom Dockerfile", language)
@@ -131,4 +197,93 @@ func getDockerBuildxCommand(build dockerBuild) (string, []string) {
 
 func applyTag(index int, baseImage, tag string) string {
 	return fmt.Sprintf("%s:%s", baseImage[:index], tag)
+}
+
+func makeTar(buildConfig builderConfig, base, tarPath string) error {
+	configBytes, _ := json.Marshal(buildConfig)
+	if err := ioutil.WriteFile(path.Join(base, BuilderConfigFilename), configBytes, 0664); err != nil {
+		return err
+	}
+
+	tarFile, err := os.Create(tarPath)
+	if err != nil {
+		return err
+	}
+
+	tarWriter := tar.NewWriter(tarFile)
+	defer tarWriter.Close()
+
+	err = filepath.Walk(base, func(path string, f os.FileInfo, pathErr error) error {
+		if pathErr != nil {
+			return pathErr
+		}
+
+		targetFile, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		header, err := tar.FileInfoHeader(f, f.Name())
+		if err != nil {
+			return err
+		}
+
+		header.Name = strings.TrimPrefix(path, base)
+		if header.Name != fmt.Sprintf("/%s", BuilderConfigFilename) {
+			header.Name = filepath.Join("context", header.Name)
+		}
+
+		header.Name = strings.TrimPrefix(header.Name, "/")
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return err
+		}
+
+		if f.Mode().IsDir() {
+			return nil
+		}
+
+		_, err = io.Copy(tarWriter, targetFile)
+		return err
+	})
+
+	return err
+}
+
+func callBuilder(tarPath, tempPath, builderAddress, functionName, payloadSecretPath string) (*http.Response, error) {
+
+	payloadSecret, err := os.ReadFile(payloadSecretPath)
+	if err != nil {
+		return nil, err
+	}
+
+	tarFile, err := os.Open(tarPath)
+	if err != nil {
+		return nil, err
+	}
+	defer tarFile.Close()
+
+	tarFileBytes, err := ioutil.ReadAll(tarFile)
+	if err != nil {
+		return nil, err
+	}
+
+	digest := hmac.Sign(tarFileBytes, bytes.TrimSpace(payloadSecret), sha256.New)
+	fmt.Println(hex.EncodeToString(digest))
+
+	r, err := http.NewRequest(http.MethodPost, builderAddress, bytes.NewReader(tarFileBytes))
+	if err != nil {
+		return nil, err
+	}
+
+	r.Header.Set("X-Build-Signature", "sha256="+hex.EncodeToString(digest))
+	r.Header.Set("Content-Type", "application/octet-stream")
+
+	log.Printf("%s invoking the API for build at %s ", functionName, builderAddress)
+	res, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
 }

--- a/commands/build.go
+++ b/commands/build.go
@@ -202,6 +202,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			buildLabelMap,
 			quietBuild,
 			copyExtra,
+			remoteBuilder,
+			payloadSecretPath,
 		)
 		if err != nil {
 			return err
@@ -255,6 +257,8 @@ func build(services *stack.Services, queueDepth int, shrinkwrap, quietBuild bool
 						buildLabelMap,
 						quietBuild,
 						combinedExtraPaths,
+						remoteBuilder,
+						payloadSecretPath,
 					)
 
 					if err != nil {

--- a/commands/up.go
+++ b/commands/up.go
@@ -20,6 +20,9 @@ func init() {
 	upFlagset := pflag.NewFlagSet("up", pflag.ExitOnError)
 	upFlagset.BoolVar(&skipPush, "skip-push", false, "Skip pushing function to remote registry")
 	upFlagset.BoolVar(&skipDeploy, "skip-deploy", false, "Skip function deployment")
+	upFlagset.StringVar(&remoteBuilder, "remote-builder", "", "URL to the builder")
+	upFlagset.StringVar(&payloadSecretPath, "payload-secret", "", "Path to payload secret file")
+
 	upCmd.Flags().AddFlagSet(upFlagset)
 
 	build, _, _ := faasCmd.Find([]string{"build"})
@@ -68,7 +71,7 @@ func upHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Println()
-	if !skipPush {
+	if !skipPush && remoteBuilder == "" {
 		if err := runPush(cmd, args); err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 )
 
 require (
+	github.com/alexellis/hmac/v2 v2.0.0
 	github.com/google/go-containerregistry v0.13.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/alexellis/go-execute v0.5.0 h1:L8kgNlFzNbJov7jrInlaig7i6ZUSz/tYYmqvb8
 github.com/alexellis/go-execute v0.5.0/go.mod h1:AgHTcsCF9wrP0mMVTO8N+lFw1Biy71NybBOk8M+qgy8=
 github.com/alexellis/hmac v1.3.0 h1:DJl5wfuhwj2IjG9XRXzPY6bHZYrwrARFTotpxX3KS08=
 github.com/alexellis/hmac v1.3.0/go.mod h1:WmZwlIfB7EQaDuiScnQoMSs3K+1UalW/7ExXP3Cc2zU=
+github.com/alexellis/hmac/v2 v2.0.0 h1:/sH/UJxDXPpJorUeg2DudeKSeUrWPF32Yamw2TiDoOQ=
+github.com/alexellis/hmac/v2 v2.0.0/go.mod h1:O7hZZgTfh5fp5+vAamzodZPlbw+aQK+nnrrJNHsEvL0=
 github.com/cheggaaa/pb/v3 v3.1.0 h1:3uouEsl32RL7gTiQsuaXD4Bzbfl5tGztXGUvXbs4O04=
 github.com/cheggaaa/pb/v3 v3.1.0/go.mod h1:YjrevcBqadFDaGQKRdmZxTY42pXEqda48Ea3lt0K/BE=
 github.com/containerd/stargz-snapshotter/estargz v0.12.1 h1:+7nYmHJb0tEkcRaAW+MHqoKaJYZmkikupxCqVtmPuY0=

--- a/vendor/github.com/alexellis/hmac/v2/LICENSE
+++ b/vendor/github.com/alexellis/hmac/v2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 Alex Ellis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/alexellis/hmac/v2/README.md
+++ b/vendor/github.com/alexellis/hmac/v2/README.md
@@ -1,0 +1,43 @@
+# hmac
+
+Validate HMAC in Golang.
+
+## Who uses it HMAC?
+
+[GitHub](https://developer.github.com/webhooks/securing/), Patreon and some other parties will use HMAC signing with their outgoing webhooks so that you can verify the webhook is from the expected sender.
+
+## Who uses this project?
+
+A few of the notable dependents on this package, but there are many more:
+
+* [alexellis/derek](https://github.com/alexellis/derek/)
+* [openfaas/faas-cli](https://github.com/openfaas/faas-cli)
+* [openfaas/openfaas-cloud](https://github.com/openfaas/openfaas-cloud/)
+* [crossplane/tbs](https://github.com/crossplane/tbs)
+* [Qolzam/telar-cli](https://github.com/Qolzam/telar-cli)
+* [s8sg/faas-flow](https://github.com/s8sg/faas-flow)
+
+## How it works:
+
+HMAC uses a symmetric key that both sender/receiver share ahead of time. The sender will generate a hash when wanting to transmit a message - this data is sent along with the payload. The recipient will then sign payload with the shared key and if the hash matches then the payload is assumed to be from the sender.
+
+[Read more on Wikipedia](https://en.wikipedia.org/wiki/HMAC)
+
+# Documentation
+
+[![](https://godoc.org/github.com/alexellis/hmac?status.svg)](http://godoc.org/github.com/alexellis/hmac)
+
+## Example:
+
+```
+import "github.com/alexellis/hmac"
+
+...
+var input []byte
+var signature string
+var secret string
+
+valid := hmac.Validate(input, signature, secret)
+
+fmt.Printf("Valid HMAC? %t\n")
+```

--- a/vendor/github.com/alexellis/hmac/v2/pkg.go
+++ b/vendor/github.com/alexellis/hmac/v2/pkg.go
@@ -1,0 +1,67 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"strings"
+)
+
+// CheckMAC verifies hash checksum
+func CheckMAC(message, messageMAC, key []byte, sha func() hash.Hash) bool {
+	mac := hmac.New(sha, key)
+	mac.Write(message)
+	expectedMAC := mac.Sum(nil)
+
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// Sign a message with the key and return bytes.
+// Note: for human readable output see encoding/hex and
+// encode string functions.
+func Sign(message, key []byte, sha func() hash.Hash) []byte {
+	mac := hmac.New(sha, key)
+	mac.Write(message)
+	signed := mac.Sum(nil)
+	return signed
+}
+
+// Validate validate an encodedHash taken
+// from GitHub via X-Hub-Signature HTTP Header.
+// Note: if using another source, just add a 5 letter prefix such as "sha1="
+func Validate(bytesIn []byte, encodedHash string, secretKey string) error {
+	var validated error
+
+	var hashFn func() hash.Hash
+	var payload string
+
+	if strings.HasPrefix(encodedHash, "sha1=") {
+		payload = strings.TrimPrefix(encodedHash, "sha1=")
+
+		hashFn = sha1.New
+
+	} else if strings.HasPrefix(encodedHash, "sha256=") {
+		payload = strings.TrimPrefix(encodedHash, "sha256=")
+
+		hashFn = sha256.New
+	} else {
+		return fmt.Errorf("valid hash prefixes: [sha1=, sha256=], got: %s", encodedHash)
+	}
+
+	messageMAC := payload
+	messageMACBuf, _ := hex.DecodeString(messageMAC)
+
+	res := CheckMAC(bytesIn, []byte(messageMACBuf), []byte(secretKey), hashFn)
+	if !res {
+		validated = fmt.Errorf("invalid message digest or secret")
+	}
+
+	return validated
+}
+
+func init() {
+
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -18,6 +18,9 @@ github.com/alexellis/go-execute/pkg/v1
 # github.com/alexellis/hmac v1.3.0
 ## explicit; go 1.16
 github.com/alexellis/hmac
+# github.com/alexellis/hmac/v2 v2.0.0
+## explicit; go 1.16
+github.com/alexellis/hmac/v2
 # github.com/cheggaaa/pb/v3 v3.1.0
 ## explicit; go 1.12
 github.com/cheggaaa/pb/v3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR works on adding the new `remote-builder` flag for faas-cli to be able to perform build operations from Function Builder API in Openfaas Pro. A new `payload-secret` flag is also added, in which the path of the payload.txt file containing the payload secret is specified.

**Demo's** : 
-  **Basic command** : https://asciinema.org/a/LKpTzW0FhfoqHqbJKmIzkmcK1
- **Building 6 functions, 2 in parallel** : https://asciinema.org/a/DZYpO2oQ7FbNvjoUCaTw3vtb1
- **Up command with remote-builder** : https://asciinema.org/a/No1XmpjK6Fr7fXkYaBV4z1tNn
- **With Build Args** : https://asciinema.org/a/vJPPSqm3GytD51M7wOC3lJvOT

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: https://github.com/openfaas/faas-cli/issues/931
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- publish command with `--remote-builder` flag is successfully run
```
> faas-cli publish --remote-builder http://127.0.0.1:8081/build \
  -f homepage.yml \
  --payload-secret $HOME/.openfaas/payload.txt

Created buildx node: "multiarch"
[0] > Building homepage.
Clearing temporary build folder: ./build/homepage/
Preparing: ./homepage/ build/homepage/function
Building: docker.io/nikhilsharmawe/homepage:latest with golang-http template. Please wait..
1fa0f5174095a059ac57915d6838b0ec41d4223f154bfcdd9cd8068890dc507b
2023/05/10 17:20:41 homepage invoking the API for build at http://127.0.0.1:8081/build
v: 2023-05-10T17:20:41Z [internal] load .dockerignore
v: 2023-05-10T17:20:41Z [internal] load build definition from Dockerfile
v: 2023-05-10T17:20:41Z [internal] load build definition from Dockerfile 0.00s
v: 2023-05-10T17:20:41Z [internal] load .dockerignore 0.00s
v: 2023-05-10T17:20:41Z [internal] load .dockerignore
v: 2023-05-10T17:20:41Z [internal] load build definition from Dockerfile
s: 2023-05-10T17:20:41Z transferring context: 0
s: 2023-05-10T17:20:41Z transferring context: 32
s: 2023-05-10T17:20:41Z transferring context: 41
s: 2023-05-10T17:20:41Z transferring dockerfile: 0
s: 2023-05-10T17:20:41Z transferring dockerfile: 30
s: 2023-05-10T17:20:41Z transferring dockerfile: 1821
v: 2023-05-10T17:20:41Z [internal] load .dockerignore 0.03s
v: 2023-05-10T17:20:41Z [internal] load build definition from Dockerfile 0.05s
v: 2023-05-10T17:20:41Z [internal] load metadata for docker.io/library/alpine:3.17.2
v: 2023-05-10T17:20:41Z [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11
v: 2023-05-10T17:20:41Z [internal] load metadata for docker.io/library/golang:1.19-alpine
v: 2023-05-10T17:20:41Z [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11 0.55s
v: 2023-05-10T17:20:41Z [internal] load metadata for docker.io/library/alpine:3.17.2 2.41s
v: 2023-05-10T17:20:41Z [internal] load metadata for docker.io/library/golang:1.19-alpine 2.66s
v: 2023-05-10T17:20:44Z [ship 1/7] FROM docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517
v: 2023-05-10T17:20:44Z [ship 2/7] RUN apk --no-cache add ca-certificates     && addgroup -S app && adduser -S -g app app
v: 2023-05-10T17:20:44Z [ship 3/7] RUN mkdir -p /home/app     && chown app /home/app
v: 2023-05-10T17:20:44Z [ship 4/7] WORKDIR /home/app
v: 2023-05-10T17:20:44Z [build  1/14] FROM docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103
v: 2023-05-10T17:20:44Z [build  2/14] RUN apk --no-cache add git
v: 2023-05-10T17:20:44Z [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4
v: 2023-05-10T17:20:44Z [build  3/14] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
v: 2023-05-10T17:20:44Z [build  4/14] RUN chmod +x /usr/bin/fwatchdog
v: 2023-05-10T17:20:44Z [build  5/14] RUN mkdir -p /go/src/handler
v: 2023-05-10T17:20:44Z [build  6/14] WORKDIR /go/src/handler
v: 2023-05-10T17:20:44Z [internal] load build context
v: 2023-05-10T17:20:44Z [build  7/14] COPY . .
v: 2023-05-10T17:20:44Z [build  8/14] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run "gofmt -s -w" on your Golang code"; exit 1; }
v: 2023-05-10T17:20:44Z [build  9/14] RUN sh ./modules-cleanup.sh
v: 2023-05-10T17:20:44Z [build 10/14] WORKDIR /go/src/handler/function
v: 2023-05-10T17:20:44Z [build 11/14] RUN mkdir -p /go/src/handler/function/static
v: 2023-05-10T17:20:44Z [build 12/14] RUN GOOS=linux GOARCH=amd64 GOFLAGS= go test ./... -cover
v: 2023-05-10T17:20:44Z [build 13/14] WORKDIR /go/src/handler
v: 2023-05-10T17:20:44Z [build 14/14] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=     go build --ldflags "-s -w" -o handler .
v: 2023-05-10T17:20:44Z [ship 5/7] COPY --from=build --chown=app /go/src/handler/handler           .
v: 2023-05-10T17:20:44Z [ship 6/7] COPY --from=build --chown=app /usr/bin/fwatchdog                .
v: 2023-05-10T17:20:44Z [ship 7/7] COPY --from=build --chown=app /go/src/handler/function/static   static
v: 2023-05-10T17:20:44Z [build  1/14] FROM docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103
v: 2023-05-10T17:20:44Z [internal] load build context 0.00s
v: 2023-05-10T17:20:44Z [ship 1/7] FROM docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517
v: 2023-05-10T17:20:44Z [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4
s: 2023-05-10T17:20:44Z resolve docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103 0
s: 2023-05-10T17:20:44Z resolve docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 0
s: 2023-05-10T17:20:44Z resolve ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0
s: 2023-05-10T17:20:44Z resolve ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0
v: 2023-05-10T17:20:44Z [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0.11s
s: 2023-05-10T17:20:44Z resolve docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103 0
v: 2023-05-10T17:20:44Z [build  1/14] FROM docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103 0.12s
v: 2023-05-10T17:20:44Z [internal] load build context
v: 2023-05-10T17:20:44Z [ship 1/7] FROM docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 0.13s
s: 2023-05-10T17:20:44Z resolve docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 0
s: 2023-05-10T17:20:44Z transferring context: 0
s: 2023-05-10T17:20:44Z transferring context: 32
s: 2023-05-10T17:20:44Z transferring context: 12810
v: 2023-05-10T17:20:44Z [internal] load build context 0.02s
v: 2023-05-10T17:20:44Z [ship 2/7] RUN apk --no-cache add ca-certificates     && addgroup -S app && adduser -S -g app app 0.00s
v: 2023-05-10T17:20:44Z [ship 3/7] RUN mkdir -p /home/app     && chown app /home/app 0.00s
v: 2023-05-10T17:20:44Z [ship 4/7] WORKDIR /home/app 0.00s
v: 2023-05-10T17:20:44Z [build  2/14] RUN apk --no-cache add git 0.00s
v: 2023-05-10T17:20:44Z [build  3/14] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog 0.00s
v: 2023-05-10T17:20:44Z [build  4/14] RUN chmod +x /usr/bin/fwatchdog 0.00s
v: 2023-05-10T17:20:44Z [build  5/14] RUN mkdir -p /go/src/handler 0.00s
v: 2023-05-10T17:20:44Z [build  6/14] WORKDIR /go/src/handler 0.00s
v: 2023-05-10T17:20:44Z [build  7/14] COPY . . 0.00s
v: 2023-05-10T17:20:44Z [build  8/14] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run "gofmt -s -w" on your Golang code"; exit 1; } 0.00s
v: 2023-05-10T17:20:44Z [build  9/14] RUN sh ./modules-cleanup.sh 0.00s
v: 2023-05-10T17:20:44Z [build 10/14] WORKDIR /go/src/handler/function 0.00s
v: 2023-05-10T17:20:44Z [build 11/14] RUN mkdir -p /go/src/handler/function/static 0.00s
v: 2023-05-10T17:20:44Z [build 12/14] RUN GOOS=linux GOARCH=amd64 GOFLAGS= go test ./... -cover 0.00s
v: 2023-05-10T17:20:44Z [build 13/14] WORKDIR /go/src/handler 0.00s
v: 2023-05-10T17:20:44Z [build 14/14] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=     go build --ldflags "-s -w" -o handler . 0.00s
v: 2023-05-10T17:20:44Z [ship 5/7] COPY --from=build --chown=app /go/src/handler/handler           . 0.00s
v: 2023-05-10T17:20:44Z [ship 6/7] COPY --from=build --chown=app /usr/bin/fwatchdog                . 0.00s
v: 2023-05-10T17:20:44Z [ship 7/7] COPY --from=build --chown=app /go/src/handler/function/static   static 0.00s
v: 2023-05-10T17:20:44Z exporting to image
s: 2023-05-10T17:20:44Z exporting layers 0
s: 2023-05-10T17:20:44Z exporting layers 0
s: 2023-05-10T17:20:44Z exporting manifest sha256:bdd4df0c1bab88fad637972342d4d946bcdab79892fb1d7dc5efc6870ad22eb8 0
s: 2023-05-10T17:20:44Z exporting manifest sha256:bdd4df0c1bab88fad637972342d4d946bcdab79892fb1d7dc5efc6870ad22eb8 0
s: 2023-05-10T17:20:44Z exporting config sha256:af35980857a8bc06d203f69883ffa90bb4114871f73a76818e0f0b2c116db6b0 0
s: 2023-05-10T17:20:44Z exporting config sha256:af35980857a8bc06d203f69883ffa90bb4114871f73a76818e0f0b2c116db6b0 0
s: 2023-05-10T17:20:44Z pushing layers 0
s: 2023-05-10T17:20:46Z pushing layers 0
s: 2023-05-10T17:20:46Z pushing manifest for docker.io/nikhilsharmawe/homepage:latest@sha256:bdd4df0c1bab88fad637972342d4d946bcdab79892fb1d7dc5efc6870ad22eb8 0
s: 2023-05-10T17:20:46Z pushing manifest for docker.io/nikhilsharmawe/homepage:latest@sha256:bdd4df0c1bab88fad637972342d4d946bcdab79892fb1d7dc5efc6870ad22eb8 0
v: 2023-05-10T17:20:44Z exporting to image 1.78s
2023/05/10 17:20:46 homepage success building and pushing image: docker.io/nikhilsharmawe/homepage:latest
[0] < Building homepage done in 4.75s.
[0] Worker done.

Total build time: 4.75s
```

- and the created image is successfully deployed:
```
> faas-cli deploy --image nikhilsharmawe/homepage:latest

Deployed. 202 Accepted.
URL: http://127.0.0.1:8080/function/homepage
```
- in case of a syntax error in the handler func:
```
> faas-cli publish --remote-builder http://127.0.0.1:8081/build \
  -f homepage.yml \
  --payload-secret $HOME/.openfaas/payload.txt

Created buildx node: "multiarch"
[0] > Building homepage.
Clearing temporary build folder: ./build/homepage/
Preparing: ./homepage/ build/homepage/function
Building: docker.io/nikhilsharmawe/homepage:latest with golang-http template. Please wait..
2b2a1a5b83e81c1a724ccf80a8871086b595ddba08ed24e63669288f056b6df0
2023/05/10 17:23:29 homepage invoking the API for build at http://127.0.0.1:8081/build
v: 2023-05-10T17:23:29Z [internal] load .dockerignore
v: 2023-05-10T17:23:29Z [internal] load build definition from Dockerfile
v: 2023-05-10T17:23:29Z [internal] load .dockerignore 0.00s
v: 2023-05-10T17:23:29Z [internal] load build definition from Dockerfile 0.00s
v: 2023-05-10T17:23:29Z [internal] load build definition from Dockerfile
v: 2023-05-10T17:23:29Z [internal] load .dockerignore
s: 2023-05-10T17:23:29Z transferring dockerfile: 0
s: 2023-05-10T17:23:29Z transferring dockerfile: 30
s: 2023-05-10T17:23:29Z transferring dockerfile: 1821
s: 2023-05-10T17:23:29Z transferring context: 0
s: 2023-05-10T17:23:29Z transferring context: 32
s: 2023-05-10T17:23:29Z transferring context: 41
v: 2023-05-10T17:23:29Z [internal] load build definition from Dockerfile 0.11s
v: 2023-05-10T17:23:29Z [internal] load .dockerignore 0.17s
v: 2023-05-10T17:23:29Z [internal] load metadata for docker.io/library/alpine:3.17.2
v: 2023-05-10T17:23:29Z [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11
v: 2023-05-10T17:23:29Z [internal] load metadata for docker.io/library/golang:1.19-alpine
v: 2023-05-10T17:23:29Z [internal] load metadata for ghcr.io/openfaas/of-watchdog:0.9.11 0.38s
v: 2023-05-10T17:23:29Z [internal] load metadata for docker.io/library/alpine:3.17.2 2.24s
v: 2023-05-10T17:23:29Z [internal] load metadata for docker.io/library/golang:1.19-alpine 2.29s
v: 2023-05-10T17:23:31Z [ship 1/7] FROM docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517
v: 2023-05-10T17:23:31Z [ship 2/7] RUN apk --no-cache add ca-certificates     && addgroup -S app && adduser -S -g app app
v: 2023-05-10T17:23:31Z [ship 3/7] RUN mkdir -p /home/app     && chown app /home/app
v: 2023-05-10T17:23:31Z [ship 4/7] WORKDIR /home/app
v: 2023-05-10T17:23:31Z [build  1/14] FROM docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103
v: 2023-05-10T17:23:31Z [build  2/14] RUN apk --no-cache add git
v: 2023-05-10T17:23:31Z [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4
v: 2023-05-10T17:23:31Z [build  3/14] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
v: 2023-05-10T17:23:31Z [build  4/14] RUN chmod +x /usr/bin/fwatchdog
v: 2023-05-10T17:23:31Z [build  5/14] RUN mkdir -p /go/src/handler
v: 2023-05-10T17:23:31Z [build  6/14] WORKDIR /go/src/handler
v: 2023-05-10T17:23:31Z [internal] load build context
v: 2023-05-10T17:23:31Z [build  7/14] COPY . .
v: 2023-05-10T17:23:31Z [build  8/14] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run "gofmt -s -w" on your Golang code"; exit 1; }
v: 2023-05-10T17:23:31Z [build  9/14] RUN sh ./modules-cleanup.sh
v: 2023-05-10T17:23:31Z [build 10/14] WORKDIR /go/src/handler/function
v: 2023-05-10T17:23:31Z [build 11/14] RUN mkdir -p /go/src/handler/function/static
v: 2023-05-10T17:23:31Z [build 12/14] RUN GOOS=linux GOARCH=amd64 GOFLAGS= go test ./... -cover
v: 2023-05-10T17:23:31Z [build 13/14] WORKDIR /go/src/handler
v: 2023-05-10T17:23:31Z [build 14/14] RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOFLAGS=     go build --ldflags "-s -w" -o handler .
v: 2023-05-10T17:23:31Z [ship 5/7] COPY --from=build --chown=app /go/src/handler/handler           .
v: 2023-05-10T17:23:31Z [ship 6/7] COPY --from=build --chown=app /usr/bin/fwatchdog                .
v: 2023-05-10T17:23:31Z [ship 7/7] COPY --from=build --chown=app /go/src/handler/function/static   static
v: 2023-05-10T17:23:31Z [build  1/14] FROM docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103
v: 2023-05-10T17:23:31Z [internal] load build context 0.00s
v: 2023-05-10T17:23:31Z [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4
v: 2023-05-10T17:23:31Z [ship 1/7] FROM docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517
s: 2023-05-10T17:23:31Z resolve docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103 0
s: 2023-05-10T17:23:32Z resolve ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0
s: 2023-05-10T17:23:32Z resolve docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 0
v: 2023-05-10T17:23:31Z [build  1/14] FROM docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103 0.22s
s: 2023-05-10T17:23:32Z resolve docker.io/library/golang:1.19-alpine@sha256:9668643a2e62d8bd298ef3663a96de4a70ceb2865b9b7cadd1d5e08387745103 0
s: 2023-05-10T17:23:32Z resolve ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0
v: 2023-05-10T17:23:31Z [watchdog 1/1] FROM ghcr.io/openfaas/of-watchdog:0.9.11@sha256:b84fd6db48e31e3d65dcd36672bf49b7a7b3dfced49ce602f51e877d9d1d56e4 0.25s
v: 2023-05-10T17:23:32Z [internal] load build context
v: 2023-05-10T17:23:31Z [ship 1/7] FROM docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 0.26s
s: 2023-05-10T17:23:32Z resolve docker.io/library/alpine:3.17.2@sha256:ff6bdca1701f3a8a67e328815ff2346b0e4067d32ec36b7992c1fdc001dc8517 0
s: 2023-05-10T17:23:32Z transferring context: 0
s: 2023-05-10T17:23:32Z transferring context: 32
s: 2023-05-10T17:23:32Z transferring context: 12809
v: 2023-05-10T17:23:32Z [internal] load build context 0.05s
v: 2023-05-10T17:23:32Z [build  2/14] RUN apk --no-cache add git 0.00s
v: 2023-05-10T17:23:32Z [build  3/14] COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog 0.00s
v: 2023-05-10T17:23:32Z [build  4/14] RUN chmod +x /usr/bin/fwatchdog 0.00s
v: 2023-05-10T17:23:32Z [build  5/14] RUN mkdir -p /go/src/handler 0.00s
v: 2023-05-10T17:23:32Z [build  6/14] WORKDIR /go/src/handler 0.00s
v: 2023-05-10T17:23:32Z [build  7/14] COPY . . 0.00s
v: 2023-05-10T17:23:32Z [build  8/14] RUN test -z "$(gofmt -l $(find . -type f -name '*.go' -not -path "./vendor/*" -not -path "./function/vendor/*"))" || { echo "Run "gofmt -s -w" on your Golang code"; exit 1; } 0.00s
v: 2023-05-10T17:23:32Z [build  9/14] RUN sh ./modules-cleanup.sh 0.00s
v: 2023-05-10T17:23:32Z [build 10/14] WORKDIR /go/src/handler/function 0.00s
v: 2023-05-10T17:23:32Z [build 11/14] RUN mkdir -p /go/src/handler/function/static 0.00s
v: 2023-05-10T17:23:32Z [build 12/14] RUN GOOS=linux GOARCH=amd64 GOFLAGS= go test ./... -cover
l: 2023-05-10T17:23:32Z go: downloading github.com/openfaas/templates-sdk/go-http v0.0.0-20220408082716-5981c545cb03

l: 2023-05-10T17:23:38Z # handler/function
./handler.go:15:3: syntax error: unexpected return, expecting expression

v: 2023-05-10T17:23:32Z [build 12/14] RUN GOOS=linux GOARCH=amd64 GOFLAGS= go test ./... -cover 7.64s
500
[0] < Building homepage done in 10.54s.
[0] Worker done.

Total build time: 10.54s
Errors received during build:
- homepage failure while building or pushing image docker.io/nikhilsharmawe/homepage:latest: failure: failed to solve: process "/bin/sh -c GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=${GOFLAGS} go test ./... -cover" did not complete successfully: exit code: 2
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
