### PR TITLE
use template store pull in build for fetching the configured template before default templates

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -174,9 +174,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("could not pull templates from function yaml file: %s", err.Error())
 		}
 	} else {
-		templateAddress := getTemplateURL("", os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
-		if pullErr := pullTemplates(templateAddress); pullErr != nil {
-			return fmt.Errorf("could not pull templates for OpenFaaS: %v", pullErr)
+		for _, function := range services.Functions {
+			runTemplateStorePull(cmd, []string{function.Language})
 		}
 	}
 	if len(services.Functions) == 0 {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes the `faas-cli` fetch the template specified in the config yaml of a function before pulling the default templates from `https://github.com/openfaas/templates.git`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
Fixes: #927

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
**Demo**: https://asciinema.org/a/5caWeeVN1fDHWZ8gNqU6GADi5

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
