### PR TITLE
Return identifiable error conditions

### DIFF
--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -27,6 +28,10 @@ func Test_LookupAuthConfig_WithNoConfigFile(t *testing.T) {
 		t.Errorf("Error was not returned")
 	}
 
+	if !errors.Is(err, ErrConfigNotFound) {
+		t.Errorf("Error was not ErrConfigNotFound")
+	}
+
 	r := regexp.MustCompile(`(?m:config file not found)`)
 	if !r.MatchString(err.Error()) {
 		t.Errorf("Error not matched: %s", err.Error())
@@ -43,6 +48,7 @@ func Test_LookupAuthConfig_GatewayWithNoConfig(t *testing.T) {
 	os.Setenv(ConfigLocationEnv, configDir)
 	defer os.Unsetenv(ConfigLocationEnv)
 
+	var authConfigNotFoundError *AuthConfigNotFoundError
 	u := "admin"
 	p := "some pass"
 	gatewayURL := strings.TrimRight("http://openfaas.test/", "/")
@@ -59,6 +65,10 @@ func Test_LookupAuthConfig_GatewayWithNoConfig(t *testing.T) {
 	_, err = LookupAuthConfig("http://openfaas.com")
 	if err == nil {
 		t.Errorf("Error was not returned")
+	}
+
+	if !errors.As(err, &authConfigNotFoundError) {
+		t.Errorf("Error was not AuthConfigNotFoundError")
 	}
 
 	r := regexp.MustCompile(`(?m:no auth config found for)`)
@@ -308,6 +318,10 @@ func Test_RemoveAuthConfig_WithNoConfigFile(t *testing.T) {
 		t.Errorf("Error was not returned")
 	}
 
+	if !errors.Is(err, ErrConfigNotFound) {
+		t.Errorf("Error was not ErrConfigNotFound")
+	}
+
 	r := regexp.MustCompile(`(?m:config file not found)`)
 	if !r.MatchString(err.Error()) {
 		t.Errorf("Error not matched: %s", err.Error())
@@ -324,6 +338,7 @@ func Test_RemoveAuthConfig_WithUnknownGateway(t *testing.T) {
 	os.Setenv(ConfigLocationEnv, configDir)
 	defer os.Unsetenv(ConfigLocationEnv)
 
+	var authConfigNotFoundError *AuthConfigNotFoundError
 	u := "admin"
 	p := "pass"
 	token := EncodeAuth(u, p)
@@ -342,7 +357,11 @@ func Test_RemoveAuthConfig_WithUnknownGateway(t *testing.T) {
 		t.Errorf("Error was not returned")
 	}
 
-	r := regexp.MustCompile(`(?m:gateway)`)
+	if !errors.As(err, &authConfigNotFoundError) {
+		t.Errorf("Error was not AuthConfigNotFoundError")
+	}
+
+	r := regexp.MustCompile(`(?m:no auth config found for)`)
 	if !r.MatchString(err.Error()) {
 		t.Errorf("Error not matched: %s", err.Error())
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Return identifiable error conditions when looking up or removing auth configurations from the config file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Required by the pro plugin to handle distinct errors differently.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Covered by unit test. Verified `faas-cli login` and `faas-cli logout` commands are unaffected by this change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
