### PR TITLE
Fixes for the --watch flag for faas-cli up

### DIFF
--- a/commands/local_run.go
+++ b/commands/local_run.go
@@ -89,7 +89,11 @@ services deployed within your OpenFaaS cluster.`,
 func runLocalRunE(cmd *cobra.Command, args []string) error {
 
 	watch, _ := cmd.Flags().GetBool("watch")
-	fmt.Printf("Watch: %v\n", watch)
+
+	// AE: This doesn't work currently due to the blocking nature of
+	// docker run.
+	// a channel and / or cancellation context will need to be implemented
+	// within the watchLoop utility function.
 	if watch {
 		return watchLoop(cmd, args, localRunExec)
 	}

--- a/commands/up.go
+++ b/commands/up.go
@@ -162,7 +162,7 @@ func upHandler(cmd *cobra.Command, args []string) error {
 				}
 				log.Printf("%s %s", event.Op, event.Name)
 
-				if strings.HasSuffix(event.Name, ".swp") || strings.HasSuffix(event.Name, "~") {
+				if strings.HasSuffix(event.Name, ".swp") || strings.HasSuffix(event.Name, "~") || strings.HasSuffix(event.Name, ".swx") {
 					continue
 				}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fixes for the --watch flag for faas-cli up due to incomplete / defective feature PR.

## Description

* Fixes issue where all functions are rebuilt even if only one changed
* Fixes issue where unrelated files cause rebuilds
* Fixes issue where vim can't trigger and update due to using create
* Adds newly created folders into the watch when within a function's path
* Triggers rebuilds via stack.yml

## Motivation and Context

Fixes: #968

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested with:

* creating a new folder within a function's handler
* editing a function's code multiple times with vim
* editing the stack.yml file
* `faas-cli new --append` during a watch
* two functions, only the changed one is rebuilt
* Out of scope for this PR - "copy extra directories" that can be specified for each function

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
