### PR TITLE
Implement --watch for localrun with cancellation support

### DIFF
--- a/commands/build.go
+++ b/commands/build.go
@@ -192,7 +192,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("please provide the deployed --name of your function")
 		}
 
-		err := builder.BuildImage(image,
+		if err := builder.BuildImage(image,
 			handler,
 			functionName,
 			language,
@@ -207,10 +207,10 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			copyExtra,
 			remoteBuilder,
 			payloadSecretPath,
-		)
-		if err != nil {
+		); err != nil {
 			return err
 		}
+
 		return nil
 	}
 
@@ -222,6 +222,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		}
 		return fmt.Errorf("%s", aec.Apply(errorSummary, aec.RedF))
 	}
+
 	return nil
 }
 

--- a/commands/up.go
+++ b/commands/up.go
@@ -76,6 +76,9 @@ func preRunUp(cmd *cobra.Command, args []string) error {
 func upHandler(cmd *cobra.Command, args []string) error {
 	if watch {
 		return watchLoop(cmd, args, func(cmd *cobra.Command, args []string, ctx context.Context) error {
+
+			fmt.Println("[Watch] Change a file to trigger a rebuild...")
+
 			return upRunner(cmd, args, ctx)
 		})
 	}
@@ -99,11 +102,6 @@ func upRunner(cmd *cobra.Command, args []string, ctx context.Context) error {
 		if err := runDeploy(cmd, args); err != nil {
 			return err
 		}
-
-		if watch {
-			fmt.Println("[Watch] Change a file to trigger a rebuild...")
-		}
-
 	}
 
 	return nil

--- a/commands/up.go
+++ b/commands/up.go
@@ -5,20 +5,12 @@ package commands
 
 import (
 	"bufio"
+	"context"
 	"fmt"
-	"log"
 	"os"
-	"os/signal"
-	"path"
-	"path/filepath"
 	"strings"
-	"syscall"
-	"time"
 
-	"github.com/bep/debounce"
-	"github.com/fsnotify/fsnotify"
 	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
-	"github.com/openfaas/faas-cli/stack"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -82,197 +74,17 @@ func preRunUp(cmd *cobra.Command, args []string) error {
 }
 
 func upHandler(cmd *cobra.Command, args []string) error {
-	return watchLoop(cmd, args, func(cmd *cobra.Command, args []string) error {
-		return upRunner(cmd, args)
-	})
-}
-
-func watchLoop(cmd *cobra.Command, args []string, onChange func(cmd *cobra.Command, args []string) error) error {
-
-	// Always run an initial build to freshen up
-	if err := onChange(cmd, args); err != nil {
-		return err
-	}
-
-	var services stack.Services
-	if len(yamlFile) > 0 {
-		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter, envsubst)
-		if err != nil {
-			return err
-		}
-
-		if parsedServices != nil {
-			services = *parsedServices
-		}
-	}
-
-	fnNames := []string{}
-	for name, _ := range services.Functions {
-		fnNames = append(fnNames, name)
-	}
-
-	fmt.Printf("[Watch] monitoring %d functions: %s\n", len(fnNames), strings.Join(fnNames, ", "))
-
 	if watch {
-		watcher, err := fsnotify.NewWatcher()
-		if err != nil {
-			return err
-		}
-		defer watcher.Close()
-
-		patterns, err := ignorePatterns()
-		if err != nil {
-			return err
-		}
-
-		matcher := gitignore.NewMatcher(patterns)
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		yamlPath := path.Join(cwd, yamlFile)
-
-		debug := os.Getenv("FAAS_DEBUG")
-		if debug == "1" {
-			fmt.Printf("[Watch] added: %s\n", yamlPath)
-		}
-		watcher.Add(yamlPath)
-
-		// map to determine which function belongs to changed files
-		// when responding to events
-		handlerMap := make(map[string]string)
-
-		for serviceName, service := range services.Functions {
-			handlerMap[serviceName] = path.Join(cwd, service.Handler)
-
-			handlerFullPath := path.Join(cwd, service.Handler)
-
-			if err := addPath(watcher, handlerFullPath); err != nil {
-				return err
-			}
-		}
-
-		signalChannel := make(chan os.Signal, 1)
-		// Exit on Ctrl+C or kill
-		signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
-
-		d := debounce.New(2 * time.Second)
-
-		for {
-			select {
-			case event, ok := <-watcher.Events:
-				if !ok {
-					return fmt.Errorf("watcher's Events channel is closed")
-				}
-				log.Printf("%s %s", event.Op, event.Name)
-
-				if strings.HasSuffix(event.Name, ".swp") || strings.HasSuffix(event.Name, "~") || strings.HasSuffix(event.Name, ".swx") {
-					continue
-				}
-
-				if event.Op == fsnotify.Write || event.Op == fsnotify.Create || event.Op == fsnotify.Remove || event.Op == fsnotify.Rename {
-
-					info, err := os.Stat(event.Name)
-					if err != nil {
-						continue
-					}
-					ignore := false
-					if matcher.Match(strings.Split(event.Name, "/"), info.IsDir()) {
-						ignore = true
-					}
-
-					// exact match first
-					target := ""
-					for fnName, fnPath := range handlerMap {
-						if event.Name == fnPath {
-							target = fnName
-						}
-					}
-
-					// fuzzy match after, if none matched exactly
-					if target == "" {
-						for fnName, fnPath := range handlerMap {
-							log.Printf("Checking %s against %s", event.Name, fnPath)
-
-							if strings.HasPrefix(event.Name, fnPath) {
-								target = fnName
-							}
-						}
-					}
-
-					// New sub-directory added for a function, start tracking it
-					if event.Op == fsnotify.Create && info.IsDir() && target != "" {
-						if err := addPath(watcher, event.Name); err != nil {
-							return err
-						}
-					}
-
-					if !ignore {
-						if target == "" {
-							fmt.Printf("Rebuilding %d functions reason: %s to %s\n", len(fnNames), event.Op, event.Name)
-						} else {
-							fmt.Printf("Reloading %s reason: %s to %s\n", target, event.Op, event.Name)
-						}
-					}
-
-					if !ignore {
-						d(func() {
-							filter = target
-
-							go func() {
-								// Assign --filter to "" for all functions if we can't determine the
-								// changed function to direct the calls to build/push/deploy
-
-								if err := onChange(cmd, args); err != nil {
-									fmt.Println("Error rebuilding: ", err)
-									os.Exit(1)
-								}
-							}()
-						})
-					}
-
-				}
-
-			case err, ok := <-watcher.Errors:
-				if !ok {
-					return fmt.Errorf("watcher's Errors channel is closed")
-				}
-				return err
-
-			case <-signalChannel:
-				watcher.Close()
-				return nil
-			}
-		}
+		return watchLoop(cmd, args, func(cmd *cobra.Command, args []string, ctx context.Context) error {
+			return upRunner(cmd, args, ctx)
+		})
 	}
-	return nil
+
+	ctx := context.Background()
+	return upRunner(cmd, args, ctx)
 }
 
-func addPath(watcher *fsnotify.Watcher, rootPath string) error {
-	debug := os.Getenv("FAAS_DEBUG")
-
-	return filepath.WalkDir(rootPath, func(subPath string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			if err := watcher.Add(subPath); err != nil {
-				return fmt.Errorf("unable to watch %s: %s", subPath, err)
-			}
-
-			if debug == "1" {
-				fmt.Printf("[Watch] added: %s\n", subPath)
-			}
-		}
-
-		return nil
-	})
-
-}
-
-func upRunner(cmd *cobra.Command, args []string) error {
+func upRunner(cmd *cobra.Command, args []string, ctx context.Context) error {
 	if err := runBuild(cmd, args); err != nil {
 		return err
 	}

--- a/commands/up.go
+++ b/commands/up.go
@@ -77,9 +77,11 @@ func upHandler(cmd *cobra.Command, args []string) error {
 	if watch {
 		return watchLoop(cmd, args, func(cmd *cobra.Command, args []string, ctx context.Context) error {
 
+			if err := upRunner(cmd, args, ctx); err != nil {
+				return err
+			}
 			fmt.Println("[Watch] Change a file to trigger a rebuild...")
-
-			return upRunner(cmd, args, ctx)
+			return nil
 		})
 	}
 

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -1,0 +1,248 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/bep/debounce"
+	"github.com/fsnotify/fsnotify"
+	"github.com/go-git/go-git/v5/plumbing/format/gitignore"
+	"github.com/openfaas/faas-cli/stack"
+	"github.com/spf13/cobra"
+)
+
+// watchLoop will watch for changes to function handler files and the stack.yml
+// then call onChange when a change is detected
+func watchLoop(cmd *cobra.Command, args []string, onChange func(cmd *cobra.Command, args []string, ctx context.Context) error) error {
+
+	var services stack.Services
+	if len(yamlFile) > 0 {
+		parsedServices, err := stack.ParseYAMLFile(yamlFile, regex, filter, envsubst)
+		if err != nil {
+			return err
+		}
+
+		if parsedServices != nil {
+			services = *parsedServices
+		}
+	}
+
+	fnNames := []string{}
+	for name, _ := range services.Functions {
+		fnNames = append(fnNames, name)
+	}
+
+	fmt.Printf("[Watch] monitoring %d functions: %s\n", len(fnNames), strings.Join(fnNames, ", "))
+
+	canceller := Cancel{}
+
+	if watch {
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			return err
+		}
+		defer watcher.Close()
+
+		patterns, err := ignorePatterns()
+		if err != nil {
+			return err
+		}
+
+		matcher := gitignore.NewMatcher(patterns)
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		yamlPath := path.Join(cwd, yamlFile)
+
+		debug := os.Getenv("FAAS_DEBUG")
+
+		if debug == "1" {
+			fmt.Printf("[Watch] added: %s\n", yamlPath)
+		}
+
+		watcher.Add(yamlPath)
+
+		// map to determine which function belongs to changed files
+		// when responding to events
+		handlerMap := make(map[string]string)
+
+		for serviceName, service := range services.Functions {
+			handlerMap[serviceName] = path.Join(cwd, service.Handler)
+
+			handlerFullPath := path.Join(cwd, service.Handler)
+
+			if err := addPath(watcher, handlerFullPath); err != nil {
+				return err
+			}
+		}
+
+		signalChannel := make(chan os.Signal, 1)
+
+		// Exit on Ctrl+C or kill
+		signal.Notify(signalChannel, os.Interrupt, syscall.SIGTERM)
+
+		bounce := debounce.New(1500 * time.Second)
+
+		var cancel context.CancelFunc
+		var ctx context.Context
+
+		// An initial build is usually done on first load with
+		// live reloaders
+		go bounce(func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			canceller.Set(ctx, cancel)
+
+			if err := onChange(cmd, args, ctx); err != nil {
+				fmt.Println("Error rebuilding: ", err)
+				os.Exit(1)
+			}
+		})
+
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return fmt.Errorf("watcher's Events channel is closed")
+				}
+
+				if debug == "1" {
+					log.Printf("[Watch] event: %s on: %s", event.Op, event.Name)
+				}
+				if strings.HasSuffix(event.Name, ".swp") || strings.HasSuffix(event.Name, "~") || strings.HasSuffix(event.Name, ".swx") {
+					continue
+				}
+
+				if event.Op == fsnotify.Write || event.Op == fsnotify.Create || event.Op == fsnotify.Remove || event.Op == fsnotify.Rename {
+
+					info, err := os.Stat(event.Name)
+					if err != nil {
+						continue
+					}
+					ignore := false
+					if matcher.Match(strings.Split(event.Name, "/"), info.IsDir()) {
+						ignore = true
+					}
+
+					// exact match first
+					target := ""
+					for fnName, fnPath := range handlerMap {
+						if event.Name == fnPath {
+							target = fnName
+						}
+					}
+
+					// fuzzy match after, if none matched exactly
+					if target == "" {
+						for fnName, fnPath := range handlerMap {
+
+							if strings.HasPrefix(event.Name, fnPath) {
+								target = fnName
+							}
+						}
+					}
+
+					// New sub-directory added for a function, start tracking it
+					if event.Op == fsnotify.Create && info.IsDir() && target != "" {
+						if err := addPath(watcher, event.Name); err != nil {
+							return err
+						}
+					}
+
+					if !ignore {
+						if target == "" {
+							fmt.Printf("[Watch] Rebuilding %d functions reason: %s to %s\n", len(fnNames), event.Op, event.Name)
+						} else {
+							fmt.Printf("[Watch] Reloading %s reason: %s to %s\n", target, event.Op, event.Name)
+						}
+					}
+
+					if !ignore {
+						bounce(func() {
+
+							canceller.Cancel()
+
+							ctx, cancel = context.WithCancel(context.Background())
+							canceller.Set(ctx, cancel)
+
+							// Assign --filter to "" for all functions if we can't determine the
+							// changed function to direct the calls to build/push/deploy
+							filter = target
+
+							go func() {
+								if err := onChange(cmd, args, ctx); err != nil {
+									fmt.Println("Error rebuilding: ", err)
+									os.Exit(1)
+								}
+							}()
+						})
+					}
+
+				}
+
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return fmt.Errorf("watcher's Errors channel is closed")
+				}
+				return err
+
+			case <-signalChannel:
+				watcher.Close()
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+func addPath(watcher *fsnotify.Watcher, rootPath string) error {
+	debug := os.Getenv("FAAS_DEBUG")
+
+	return filepath.WalkDir(rootPath, func(subPath string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if err := watcher.Add(subPath); err != nil {
+				return fmt.Errorf("unable to watch %s: %s", subPath, err)
+			}
+
+			if debug == "1" {
+				fmt.Printf("[Watch] added: %s\n", subPath)
+			}
+		}
+
+		return nil
+	})
+
+}
+
+// Cancel is a struct to hold a reference to a context and
+// cancellation function between closures
+type Cancel struct {
+	cancel context.CancelFunc
+	ctx    context.Context
+}
+
+func (c *Cancel) Set(ctx context.Context, cancel context.CancelFunc) {
+	c.cancel = cancel
+	c.ctx = ctx
+}
+
+func (c *Cancel) Cancel() {
+	if c.cancel != nil {
+		c.cancel()
+	}
+
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Implement --watch for localrun with cancellation support

## Motivation and Context

Related to fixes in #969 which were for `faas-cli up --watch`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This commit adds --watch support to localrun by using a context to cancel and remove any running container when a change is detected.

watchLoop has been updated to support a context.

Tested with VSCode - I suggest turning auto-save off when using this feature.

Tested again with faas-cli up to make sure there was no regression:

https://asciinema.org/a/594072

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
