### PR TITLE
chore: additional tidying and use ctx propogation to enable docker build cancellation

### DIFF
--- a/commands/faas.go
+++ b/commands/faas.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/moby/term"
+	"github.com/openfaas/faas-cli/contexts"
 	"github.com/openfaas/faas-cli/version"
 	"github.com/spf13/cobra"
 )
@@ -74,6 +76,9 @@ func init() {
 func Execute(customArgs []string) {
 	checkAndSetDefaultYaml()
 
+	ctx, cancel := contexts.WithSignals(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
 	faasCmd.SilenceUsage = true
 	faasCmd.SilenceErrors = true
 	faasCmd.SetArgs(customArgs[1:])
@@ -105,7 +110,7 @@ func Execute(customArgs []string) {
 		}
 	}
 
-	if err := faasCmd.Execute(); err != nil {
+	if err := faasCmd.ExecuteContext(ctx); err != nil {
 		e := err.Error()
 		fmt.Println(strings.ToUpper(e[:1]) + e[1:])
 		os.Exit(1)

--- a/commands/up.go
+++ b/commands/up.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -89,9 +88,9 @@ func preRunUp(cmd *cobra.Command, args []string) error {
 
 func upHandler(cmd *cobra.Command, args []string) error {
 	if watch {
-		return watchLoop(cmd, args, func(cmd *cobra.Command, args []string, ctx context.Context) error {
+		return watchLoop(cmd, args, func(cmd *cobra.Command, args []string) error {
 
-			if err := upRunner(cmd, args, ctx); err != nil {
+			if err := upRunner(cmd, args); err != nil {
 				return err
 			}
 			fmt.Println("[Watch] Change a file to trigger a rebuild...")
@@ -99,11 +98,10 @@ func upHandler(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	ctx := context.Background()
-	return upRunner(cmd, args, ctx)
+	return upRunner(cmd, args)
 }
 
-func upRunner(cmd *cobra.Command, args []string, ctx context.Context) error {
+func upRunner(cmd *cobra.Command, args []string) error {
 	if usePublish {
 		if err := runPublish(cmd, args); err != nil {
 			return err

--- a/contexts/signals.go
+++ b/contexts/signals.go
@@ -1,0 +1,32 @@
+package contexts
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/signal"
+)
+
+// WithSignals returns a context that is canceled when the process receives one of the given signals.
+// When ctx is nil, a default Background context is used.
+// When signals is empty, the context will be canceled by the default os.Interrupt signal.
+func WithSignals(ctx context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if len(signals) == 0 {
+		signals = []os.Signal{os.Interrupt}
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, signals...)
+	go func() {
+		sig := <-c
+		log.Printf("Received signal: %q. Terminating...", sig.String())
+		cancel()
+	}()
+
+	return ctx, cancel
+}

--- a/execute/exec.go
+++ b/execute/exec.go
@@ -1,0 +1,144 @@
+package execute
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+const ExitCodeCancelled = -1
+
+type ExecTask struct {
+	Command string
+	Args    []string
+	Shell   bool
+	Env     []string
+	Cwd     string
+
+	// Stdin connect a reader to stdin for the command
+	// being executed.
+	Stdin io.Reader
+
+	// StreamStdio prints stdout and stderr directly to os.Stdout/err as
+	// the command runs.
+	StreamStdio bool
+
+	// PrintCommand prints the command before executing
+	PrintCommand bool
+}
+
+type ExecResult struct {
+	// Stdout contains the stdout content from the command
+	Stdout string
+	// Stderr contains the stderr content from the command
+	Stderr string
+	// ExitCode will be the exit code of the command,
+	// or -1 if the command never started or was cancelled.
+	ExitCode int
+	// Cancelled indicates if the command context was cancelled
+	// this can be used to interpret the ExitCode.
+	Cancelled bool
+}
+
+func (et ExecTask) Execute(ctx context.Context) (ExecResult, error) {
+	argsSt := ""
+	if len(et.Args) > 0 {
+		argsSt = strings.Join(et.Args, " ")
+	}
+
+	if et.PrintCommand {
+		fmt.Println("exec: ", et.Command, argsSt)
+	}
+
+	var cmd *exec.Cmd
+
+	if et.Shell {
+		var args []string
+		if len(et.Args) == 0 {
+			startArgs := strings.Split(et.Command, " ")
+			script := strings.Join(startArgs, " ")
+			args = append([]string{"-c"}, fmt.Sprintf("%s", script))
+
+		} else {
+			script := strings.Join(et.Args, " ")
+			args = append([]string{"-c"}, fmt.Sprintf("%s %s", et.Command, script))
+
+		}
+
+		cmd = exec.CommandContext(ctx, "/bin/bash", args...)
+	} else {
+		if strings.Index(et.Command, " ") > 0 {
+			parts := strings.Split(et.Command, " ")
+			command := parts[0]
+			args := parts[1:]
+			cmd = exec.CommandContext(ctx, command, args...)
+
+		} else {
+			cmd = exec.CommandContext(ctx, et.Command, et.Args...)
+		}
+	}
+
+	cmd.Dir = et.Cwd
+
+	if len(et.Env) > 0 {
+		overrides := map[string]bool{}
+		for _, env := range et.Env {
+			key := strings.Split(env, "=")[0]
+			overrides[key] = true
+			cmd.Env = append(cmd.Env, env)
+		}
+
+		for _, env := range os.Environ() {
+			key := strings.Split(env, "=")[0]
+
+			if _, ok := overrides[key]; !ok {
+				cmd.Env = append(cmd.Env, env)
+			}
+		}
+	}
+	if et.Stdin != nil {
+		cmd.Stdin = et.Stdin
+	}
+
+	stdoutBuff := bytes.Buffer{}
+	stderrBuff := bytes.Buffer{}
+
+	var stdoutWriters io.Writer
+	var stderrWriters io.Writer
+
+	if et.StreamStdio {
+		stdoutWriters = io.MultiWriter(os.Stdout, &stdoutBuff)
+		stderrWriters = io.MultiWriter(os.Stderr, &stderrBuff)
+	} else {
+		stdoutWriters = &stdoutBuff
+		stderrWriters = &stderrBuff
+	}
+
+	cmd.Stdout = stdoutWriters
+	cmd.Stderr = stderrWriters
+
+	startErr := cmd.Start()
+
+	if startErr != nil {
+		return ExecResult{}, startErr
+	}
+
+	exitCode := 0
+	execErr := cmd.Wait()
+	if execErr != nil {
+		if exitError, ok := execErr.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return ExecResult{
+		Stdout:    stdoutBuff.String(),
+		Stderr:    stderrBuff.String(),
+		ExitCode:  exitCode,
+		Cancelled: ctx.Err() == context.Canceled,
+	}, nil
+}

--- a/logger/logging.go
+++ b/logger/logging.go
@@ -1,0 +1,36 @@
+// logger should immediately be replaced by https://pkg.go.dev/log/slog@master
+// when the project upgrades to Go 1.21
+package logger
+
+import (
+	"log"
+	"os"
+)
+
+var debug = false
+
+func init() {
+	if os.Getenv("FAAS_DEBUG") == "1" {
+		debug = true
+	}
+}
+
+func Debug(message string) {
+	if debug {
+		log.Println(message)
+	}
+}
+
+func Debugf(format string, v ...interface{}) {
+	if debug {
+		log.Printf(format, v...)
+	}
+}
+
+func Print(message string) {
+	log.Println(message)
+}
+
+func Printf(format string, v ...interface{}) {
+	log.Printf(format, v...)
+}

--- a/proxy/logs.go
+++ b/proxy/logs.go
@@ -9,10 +9,10 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"time"
 
+	"github.com/openfaas/faas-cli/logger"
 	"github.com/openfaas/faas-provider/logs"
 )
 
@@ -26,9 +26,7 @@ func (c *Client) GetLogs(ctx context.Context, params logs.Request) (<-chan logs.
 
 	logRequest.URL.RawQuery = reqAsQueryValues(params).Encode()
 
-	if os.Getenv("FAAS_DEBUG") == "1" {
-		fmt.Printf("%s\n", logRequest.URL.RawQuery)
-	}
+	logger.Debugf("%s\n", logRequest.URL.RawQuery)
 
 	res, err := c.doRequest(ctx, logRequest)
 	if err != nil {


### PR DESCRIPTION
Copy the execute package into the project to add the require context passing. This can be pulled back later once we are happy with the implementation.

Streamline some of the watch and local-run code to use the native Context object instead of the Cancel object.

Use a `WaitGroup` to ensure that each run of the `onChange` is finished before starting the next invocation. This avoids a potential race-condition due to `cmd` object being a shared pointer and the context being cancelled and replaced.

Reduce the number of `FAAS_DEBUG` checks required for logging, by creating a shared logger package for this. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
This is mostly a continuation of https://github.com/openfaas/faas-cli/pull/970

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have manually tested this with the `local-run` 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
