### PR TITLE
Explicitly set default init branch when creating repos

### DIFF
--- a/versioncontrol/git.go
+++ b/versioncontrol/git.go
@@ -43,7 +43,7 @@ var GitInitRepo = &vcsCmd{
 	name: "Git",
 	cmd:  "git",
 	cmds: []string{
-		"init {dir}",
+		"init {dir} --initial-branch=master",
 		"config core.autocrlf false",
 		"config user.email \"contact@openfaas.com\"",
 		"config user.name \"OpenFaaS\"",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Explicitly set default init branch when creating repos.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Prevent tests from failing on systems that are configured to use an other default branch than master.

Fixes #978

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Before this fix unit tests where failing on both my Mac an Ubuntu workstation. They are all passing now.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
