### PR TITLE
feat: allow URL and local files for Store locations

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -71,7 +71,7 @@ func preRunEStoreDeploy(cmd *cobra.Command, args []string) error {
 
 func runStoreDeploy(cmd *cobra.Command, args []string) error {
 	targetPlatform := getTargetPlatform(platformValue)
-	storeItems, err := storeList(storeAddress)
+	storeItems, err := proxy.FunctionStoreList(storeAddress)
 	if err != nil {
 		return err
 	}

--- a/commands/store_describe.go
+++ b/commands/store_describe.go
@@ -9,6 +9,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/mitchellh/go-wordwrap"
+	"github.com/openfaas/faas-cli/proxy"
 	storeV2 "github.com/openfaas/faas-cli/schema/store/v2"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,7 @@ func runStoreDescribe(cmd *cobra.Command, args []string) error {
 	}
 
 	targetPlatform := getTargetPlatform(platformValue)
-	storeItems, err := storeList(storeAddress)
+	storeItems, err := proxy.FunctionStoreList(storeAddress)
 	if err != nil {
 		return err
 	}

--- a/commands/store_list.go
+++ b/commands/store_list.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/openfaas/faas-cli/proxy"
 	storeV2 "github.com/openfaas/faas-cli/schema/store/v2"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,7 @@ var storeListCmd = &cobra.Command{
 func runStoreList(cmd *cobra.Command, args []string) error {
 	targetPlatform := getTargetPlatform(platformValue)
 
-	storeList, err := storeList(storeAddress)
+	storeList, err := proxy.FunctionStoreList(storeAddress)
 	if err != nil {
 		return err
 	}

--- a/commands/template_store_describe.go
+++ b/commands/template_store_describe.go
@@ -13,7 +13,7 @@ import (
 )
 
 func init() {
-	templateStoreDescribeCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, "Use as alternative store for templates")
+	templateStoreDescribeCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, templateStoreDoc)
 
 	templateStoreCmd.AddCommand(templateStoreDescribeCmd)
 }

--- a/commands/template_store_pull.go
+++ b/commands/template_store_pull.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	templateStorePullCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, "Use as alternative store for templates")
+	templateStorePullCmd.PersistentFlags().StringVarP(&templateStoreURL, "url", "u", DefaultTemplatesStore, templateStoreDoc)
 	templatePull, _, _ := faasCmd.Find([]string{"template", "pull"})
 	templateStoreCmd.PersistentFlags().AddFlagSet(templatePull.Flags())
 

--- a/vendor/github.com/alexellis/go-execute/pkg/v2/exec.go
+++ b/vendor/github.com/alexellis/go-execute/pkg/v2/exec.go
@@ -1,0 +1,156 @@
+package execute
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type ExecTask struct {
+	// Command is the command to execute. This can be the path to an executable
+	// or the executable with arguments. The arguments are detected by looking for
+	// a space.
+	//
+	// Examples:
+	//  - Just a binary executable: `/bin/ls`
+	//  - Binary executable with arguments: `/bin/ls -la /`
+	Command string
+	// Args are the arguments to pass to the command. These are ignored if the
+	// Command contains arguments.
+	Args []string
+	// Shell run the command in a bash shell.
+	// Note that the system must have `/bin/bash` installed.
+	Shell bool
+	// Env is a list of environment variables to add to the current environment,
+	// these are used to override any existing environment variables.
+	Env []string
+	// Cwd is the working directory for the command
+	Cwd string
+
+	// Stdin connect a reader to stdin for the command
+	// being executed.
+	Stdin io.Reader
+
+	// StreamStdio prints stdout and stderr directly to os.Stdout/err as
+	// the command runs.
+	StreamStdio bool
+
+	// PrintCommand prints the command before executing
+	PrintCommand bool
+}
+
+type ExecResult struct {
+	Stdout    string
+	Stderr    string
+	ExitCode  int
+	Cancelled bool
+}
+
+func (et ExecTask) Execute(ctx context.Context) (ExecResult, error) {
+	argsSt := ""
+	if len(et.Args) > 0 {
+		argsSt = strings.Join(et.Args, " ")
+	}
+
+	if et.PrintCommand {
+		fmt.Println("exec: ", et.Command, argsSt)
+	}
+
+	// don't try to run if the context is already cancelled
+	if ctx.Err() != nil {
+		return ExecResult{
+			// the exec package returns -1 for cancelled commands
+			ExitCode:  -1,
+			Cancelled: ctx.Err() == context.Canceled,
+		}, ctx.Err()
+	}
+
+	var command string
+	var commandArgs []string
+	if et.Shell {
+		command = "/bin/bash"
+		if len(et.Args) == 0 {
+			// use Split and Join to remove any extra whitespace?
+			startArgs := strings.Split(et.Command, " ")
+			script := strings.Join(startArgs, " ")
+			commandArgs = append([]string{"-c"}, script)
+
+		} else {
+			script := strings.Join(et.Args, " ")
+			commandArgs = append([]string{"-c"}, fmt.Sprintf("%s %s", et.Command, script))
+		}
+	} else {
+		if strings.Contains(et.Command, " ") {
+			parts := strings.Split(et.Command, " ")
+			command = parts[0]
+			commandArgs = parts[1:]
+		} else {
+			command = et.Command
+			commandArgs = et.Args
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, command, commandArgs...)
+	cmd.Dir = et.Cwd
+
+	if len(et.Env) > 0 {
+		overrides := map[string]bool{}
+		for _, env := range et.Env {
+			key := strings.Split(env, "=")[0]
+			overrides[key] = true
+			cmd.Env = append(cmd.Env, env)
+		}
+
+		for _, env := range os.Environ() {
+			key := strings.Split(env, "=")[0]
+
+			if _, ok := overrides[key]; !ok {
+				cmd.Env = append(cmd.Env, env)
+			}
+		}
+	}
+	if et.Stdin != nil {
+		cmd.Stdin = et.Stdin
+	}
+
+	stdoutBuff := bytes.Buffer{}
+	stderrBuff := bytes.Buffer{}
+
+	var stdoutWriters io.Writer
+	var stderrWriters io.Writer
+
+	if et.StreamStdio {
+		stdoutWriters = io.MultiWriter(os.Stdout, &stdoutBuff)
+		stderrWriters = io.MultiWriter(os.Stderr, &stderrBuff)
+	} else {
+		stdoutWriters = &stdoutBuff
+		stderrWriters = &stderrBuff
+	}
+
+	cmd.Stdout = stdoutWriters
+	cmd.Stderr = stderrWriters
+
+	startErr := cmd.Start()
+	if startErr != nil {
+		return ExecResult{}, startErr
+	}
+
+	exitCode := 0
+	execErr := cmd.Wait()
+	if execErr != nil {
+		if exitError, ok := execErr.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+	}
+
+	return ExecResult{
+		Stdout:    stdoutBuff.String(),
+		Stderr:    stderrBuff.String(),
+		ExitCode:  exitCode,
+		Cancelled: ctx.Err() == context.Canceled,
+	}, ctx.Err()
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Enable local files and remote files over HTTP(S) as store locations for the Function and Template stores.

This enables the following commands to work as expected

```sh
faas-cli store list --url $HOME/Downloads/functions.json
faas-cli store list --url ~/Downloads/functions.json
faas-cli store list --url https://internal/organization.com/openfaas/functions.json
faas-cli template store list --url $HOME/Downloads/templates.json
faas-cli template store list --url ~/Downloads/templates.json
faas-cli template store list --url
https://internal.organization.com/openfaas/templates.json
```

Additional locations such as ipfs, blob storage (s3, Google Cloud Storge, etc) and other could also be supported via a small patch to the `ReadJSON` implementation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Resolves #984 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Using modified versions of the store files, I was able to list templates and functions from my Downloads folder 

```sh
$ faas-cli template store list --url $HOME/Downloads/templates.json

NAME       RECOMMENDED DESCRIPTION SOURCE
dockerfile [x]         openfaas    Classic Dockerfile template

$ faas-cli store list --url=$HOME/Downloads/functions.json

FUNCTION AUTHOR   DESCRIPTION
nodeinfo openfaas NodeInfo
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
