### PR TITLE
Add memory/CPU requests and limits to deploy command

### DIFF
--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -31,6 +31,11 @@ func init() {
 	storeDeployCmd.Flags().StringVarP(&token, "token", "k", "", "Pass a JWT token to use instead of basic auth")
 	storeDeployCmd.Flags().DurationVar(&timeoutOverride, "timeout", commandTimeout, "Timeout for any HTTP calls made to the OpenFaaS API.")
 
+	storeDeployCmd.Flags().StringVar(&cpuRequest, "cpu-request", "", "Supply the CPU request for the function in Mi")
+	storeDeployCmd.Flags().StringVar(&cpuLimit, "cpu-limit", "", "Supply the CPU limit for the function in Mi")
+	storeDeployCmd.Flags().StringVar(&memoryRequest, "memory-request", "", "Supply the memory request for the function in Mi")
+	storeDeployCmd.Flags().StringVar(&memoryLimit, "memory-limit", "", "Supply the memory limit for the function in Mi")
+
 	// Set bash-completion.
 	_ = storeDeployCmd.Flags().SetAnnotation("handler", cobra.BashCompSubdirsInDir, []string{})
 
@@ -134,8 +139,21 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	statusCode, err := deployImage(context.Background(), proxyClient, imageName, item.Fprocess, itemName, "", storeDeployFlags,
-		tlsInsecure, item.ReadOnlyRootFilesystem, token, functionNamespace)
+	statusCode, err := deployImage(context.Background(),
+		proxyClient,
+		imageName,
+		item.Fprocess,
+		itemName,
+		"",
+		storeDeployFlags,
+		tlsInsecure,
+		item.ReadOnlyRootFilesystem,
+		token,
+		functionNamespace,
+		cpuRequest,
+		cpuLimit,
+		memoryRequest,
+		memoryLimit)
 
 	if badStatusCode(statusCode) {
 		failedStatusCode := map[string]int{itemName: statusCode}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add memory/CPU requests and limits to deploy command

## Motivation and Context

* Allows for memory/CPU requests and limits to be passed via deploy and store deploy when no additional YAML file is being used.
 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by supplying requests values and looking at the output of faas-cli describe.

Removing the flags removed the values from the function.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
