### PR TITLE
Fix execution of plugins on Windows

### DIFF
--- a/commands/plugin_get.go
+++ b/commands/plugin_get.go
@@ -132,6 +132,17 @@ func runPluginGetCmd(cmd *cobra.Command, args []string) error {
 	if err := archive.Untar(tarFile, pluginDir, gzipped, true); err != nil {
 		return fmt.Errorf("failed to untar %s: %w", tmpTar, err)
 	}
+
+	// Add the .exe filename extension to the plugin executable on windows.
+	// If the .exe extension is missing the plugin will not execute.
+	if runtime.GOOS == "windows" {
+		pluginPath := path.Join(pluginDir, pluginName)
+		err := os.Rename(pluginPath, fmt.Sprintf("%s.exe", pluginPath))
+		if err != nil {
+			return fmt.Errorf("failed to move plugin %w", err)
+		}
+	}
+
 	fmt.Printf("Downloaded in (%ds)\n\nUsage:\n  faas-cli %s\n", int(time.Since(st).Seconds()), pluginName)
 	return nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- syscall.Exec is not supported on Windows systems. Use the os/exec package instead.
- On windows the plugin executables should have the .exe filename extension in order to execute them.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Executing plugins on Windows failed with the error `Error from plugin: not supported by windows`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified `faas-cli plugin get pro` works on windows and stores the executable in the correct path `$HOME/,openfaas/plugins/pro.exe`
<img width="543" alt="Screenshot 2024-01-26 at 12 58 31" src="https://github.com/openfaas/faas-cli/assets/16267532/9813df82-7b1d-4175-ac9a-d18c4355efc4">

- Verified `faas-cli plugin get pro` still works Linux systems.

- Verified running plugins works on Windows systems.

<img width="814" alt="Screenshot 2024-01-26 at 12 59 25" src="https://github.com/openfaas/faas-cli/assets/16267532/480ffeed-5f9f-4d99-88eb-72a96a3498ba">

- Verified running plugins still works on Linux systems.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
