### PR TITLE
Export CreateBuildContext function from the builder package.

### DIFF
--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -9,23 +9,22 @@ import (
 	"github.com/openfaas/faas-cli/stack"
 )
 
-func Test_isLanguageTemplate_Dockerfile(t *testing.T) {
+func Test_isDockerfileTemplate_Dockerfile(t *testing.T) {
 
 	language := "Dockerfile"
 
-	want := false
-	got := isLanguageTemplate(language)
+	want := true
+	got := isDockerfileTemplate(language)
 	if got != want {
 		t.Errorf("language: %s got %v, want %v", language, got, want)
 	}
 }
 
-func Test_isLanguageTemplate_Node(t *testing.T) {
-
+func Test_isDockerfileTemplate_Node(t *testing.T) {
 	language := "node"
 
-	want := true
-	got := isLanguageTemplate(language)
+	want := false
+	got := isDockerfileTemplate(language)
 	if got != want {
 		t.Errorf("language: %s got %v, want %v", language, got, want)
 	}

--- a/builder/publish.go
+++ b/builder/publish.go
@@ -61,7 +61,18 @@ func PublishImage(image string, handler string, functionName string, language st
 			return fmt.Errorf("building %s, %s is an invalid path", functionName, handler)
 		}
 
-		tempPath, err := createBuildContext(functionName, handler, language, isLanguageTemplate(language), langTemplate.HandlerFolder, copyExtraPaths)
+		// To avoid breaking the CLI for custom templates that do not set the language attribute
+		// we ensure it is always set.
+		//
+		// While templates are expected to have the language in `template.yaml` set to the same name as the template folder
+		// this was never enforced.
+		langTemplate.Language = language
+
+		if isDockerfileTemplate(langTemplate.Language) {
+			langTemplate = nil
+		}
+
+		tempPath, err := CreateBuildContext(functionName, handler, langTemplate, copyExtraPaths)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

Simplify the signature of `createBuildContext` and export the function so that it can be used by other packages.

Usage example:

```go
import (
    "log"

    "github.com/openfaas/faas-cli/builder"
    "github.com/openfaas/faas-cli/stack"
)

handler := "./hello-world"
lang := "node20"
fnName := "hello-world"

template, err := stack.LoadLanguageTemplate(handler)
if err != nil {
    log.Fatal(err)
}

buildContext, err := builder.CreateBuildContext(fnName,  handler, template, []string{})
if err != nil {
    log.Fatal(err)
}
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Expose more of the builder functionality use outside of the faas-cli. This change was primarily made for OpenFaaS users that want to integration with the Function Builder API to allow them to easily create the function build context from go code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified the `faas-cli build` and `faas-cli` publish commands still function as expected for functions using both the `dockerfile` template and other templates.

- Used the `CreateBuildContext` function in an updated version of the [function builder examples](https://github.com/openfaas/function-builder-examples)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
