### PR TITLE
Revert changes to createBuildContext to fix #1001

### DIFF
--- a/builder/build.go
+++ b/builder/build.go
@@ -52,18 +52,7 @@ func BuildImage(image string, handler string, functionName string, language stri
 			return fmt.Errorf("building %s, %s is an invalid path", functionName, handler)
 		}
 
-		// To avoid breaking the CLI for custom templates that do not set the language attribute
-		// we ensure it is always set.
-		//
-		// While templates are expected to have the language in `template.yaml` set to the same name as the template folder
-		// this was never enforced.
-		langTemplate.Language = language
-
-		if isDockerfileTemplate(langTemplate.Language) {
-			langTemplate = nil
-		}
-
-		tempPath, err := CreateBuildContext(functionName, handler, langTemplate, copyExtraPaths)
+		tempPath, err := createBuildContext(functionName, handler, language, isLanguageTemplate(language), langTemplate.HandlerFolder, copyExtraPaths)
 		if err != nil {
 			return err
 		}
@@ -314,17 +303,8 @@ func isRunningInCI() bool {
 	return false
 }
 
-// CreateBuildContext creates a Docker build context using the provided function handler and language template.
-//
-// Parameters:
-//   - functionName: the name of the function.
-//   - handler: path to the function handler folder.
-//   - template: function language template to use. Set to nil if no template is required (e.g. the handler folder is the build context with Dockerfile).
-//   - copyExtraPaths: additional path to copy into the function handler folder. Paths should be relative to the current directory.
-//     Any path outside of this current directory will be skipped.
-//
-// Returns the path to the new build context. An error is returned if creating the build context fails.
-func CreateBuildContext(functionName string, handler string, template *stack.LanguageTemplate, copyExtraPaths []string) (string, error) {
+// createBuildContext creates temporary build folder to perform a Docker build with language template
+func createBuildContext(functionName string, handler string, language string, useFunction bool, handlerFolder string, copyExtraPaths []string) (string, error) {
 	tempPath := fmt.Sprintf("./build/%s/", functionName)
 
 	if err := os.RemoveAll(tempPath); err != nil {
@@ -333,18 +313,15 @@ func CreateBuildContext(functionName string, handler string, template *stack.Lan
 
 	functionPath := tempPath
 
-	useTemplate := false
-	if template != nil {
-		useTemplate = true
-	}
-
-	if useTemplate {
-		if len(template.HandlerFolder) > 0 {
-			functionPath = path.Join(functionPath, template.HandlerFolder)
-		} else {
+	if useFunction {
+		if handlerFolder == "" {
 			functionPath = path.Join(functionPath, defaultHandlerFolder)
+		} else {
+			functionPath = path.Join(functionPath, handlerFolder)
 		}
 	}
+
+	// fmt.Printf("Preparing: %s %s\n", handler+"/", functionPath)
 
 	if isRunningInCI() {
 		defaultDirPermissions = 0777
@@ -356,8 +333,8 @@ func CreateBuildContext(functionName string, handler string, template *stack.Lan
 		return tempPath, mkdirErr
 	}
 
-	if useTemplate {
-		if err := CopyFiles(path.Join("./template/", template.Language), tempPath); err != nil {
+	if useFunction {
+		if err := CopyFiles(path.Join("./template/", language), tempPath); err != nil {
 			fmt.Printf("Error copying template directory: %s.\n", err.Error())
 			return tempPath, err
 		}
@@ -373,7 +350,6 @@ func CreateBuildContext(functionName string, handler string, template *stack.Lan
 
 	for _, info := range infos {
 		switch info.Name() {
-		// Ignore the build and template folder.
 		case "build", "template":
 			fmt.Printf("Skipping \"%s\" folder\n", info.Name())
 			continue
@@ -392,12 +368,16 @@ func CreateBuildContext(functionName string, handler string, template *stack.Lan
 		if err != nil {
 			return tempPath, err
 		}
-
-		// Note that if template is nil, i.e. is a `dockerfile` template, then
+		// Note that if useFunction is false, ie is a `dockerfile` template, then
 		// functionPath == tempPath, the docker build context, not the `function` handler folder
 		// inside the docker build context
-		if err := CopyFiles(extraPathAbs, filepath.Clean(path.Join(functionPath, extraPath))); err != nil {
-			return tempPath, err
+		copyErr := CopyFiles(
+			extraPathAbs,
+			filepath.Clean(path.Join(functionPath, extraPath)),
+		)
+
+		if copyErr != nil {
+			return tempPath, copyErr
 		}
 	}
 
@@ -536,6 +516,6 @@ func deDuplicate(buildOptPackages []string) []string {
 	return retPackages
 }
 
-func isDockerfileTemplate(language string) bool {
-	return strings.ToLower(language) == "dockerfile"
+func isLanguageTemplate(language string) bool {
+	return strings.ToLower(language) != "dockerfile"
 }

--- a/builder/build_test.go
+++ b/builder/build_test.go
@@ -9,22 +9,23 @@ import (
 	"github.com/openfaas/faas-cli/stack"
 )
 
-func Test_isDockerfileTemplate_Dockerfile(t *testing.T) {
+func Test_isLanguageTemplate_Dockerfile(t *testing.T) {
 
 	language := "Dockerfile"
 
-	want := true
-	got := isDockerfileTemplate(language)
+	want := false
+	got := isLanguageTemplate(language)
 	if got != want {
 		t.Errorf("language: %s got %v, want %v", language, got, want)
 	}
 }
 
-func Test_isDockerfileTemplate_Node(t *testing.T) {
+func Test_isLanguageTemplate_Node(t *testing.T) {
+
 	language := "node"
 
-	want := false
-	got := isDockerfileTemplate(language)
+	want := true
+	got := isLanguageTemplate(language)
 	if got != want {
 		t.Errorf("language: %s got %v, want %v", language, got, want)
 	}

--- a/builder/publish.go
+++ b/builder/publish.go
@@ -61,18 +61,7 @@ func PublishImage(image string, handler string, functionName string, language st
 			return fmt.Errorf("building %s, %s is an invalid path", functionName, handler)
 		}
 
-		// To avoid breaking the CLI for custom templates that do not set the language attribute
-		// we ensure it is always set.
-		//
-		// While templates are expected to have the language in `template.yaml` set to the same name as the template folder
-		// this was never enforced.
-		langTemplate.Language = language
-
-		if isDockerfileTemplate(langTemplate.Language) {
-			langTemplate = nil
-		}
-
-		tempPath, err := CreateBuildContext(functionName, handler, langTemplate, copyExtraPaths)
+		tempPath, err := createBuildContext(functionName, handler, language, isLanguageTemplate(language), langTemplate.HandlerFolder, copyExtraPaths)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fix nil pointer dereference when getting the build options packages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Fixes #1001 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified the `faas-cli up` command works for function using the dockerfile template.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
