### PR TITLE
Pull templates from store when not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ Find templates with: `faas-cli template store list`
 
 > Note: You can set your own custom store location with `--url` flag or set `OPENFAAS_TEMPLATE_STORE_URL` environmental variable
 
-To pull templates from the store just write the name of the template you want `faas-cli template store pull go` or the repository and name `faas-cli template store pull openfaas/go`
+To pull templates from the store just write the name of the template you want `faas-cli template store pull golang-middleware` or the repository and name `faas-cli template store pull openfaas/golang-middleware`
 
-To get more detail on a template just use the `template store describe` command and pick a template of your choice, example with `go` would look like this `faas-cli template store describe go`
+To get more detail on a template just use the `template store describe` command and pick a template of your choice, example with `go` would look like this `faas-cli template store describe golang-middleware`
 
 > Note: This feature is still in experimental stage and in the future the CLI verbs might be changed
 

--- a/build_integration_test.sh
+++ b/build_integration_test.sh
@@ -43,9 +43,14 @@ build_faas_function() {
     eval $cli new $function_name --lang $TEMPLATE_NAME
 
 cat << EOF > $function_name/handler.py
-def handle(req):
-
-    return "Function output from integration testing: Hello World!"
+def handle(event, context):
+    return {
+        "statusCode": 200,
+        "body": {"message": "Hello from OpenFaaS!"},
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
 EOF
 
     eval $cli build -f $function_name.yml
@@ -126,7 +131,7 @@ EOF
 
 get_templates() {
     echo "Getting templates..."
-    eval $cli template pull $TEMPLATE_NAME
+    eval $cli template store pull $TEMPLATE_NAME
 }
 
 get_templates

--- a/build_integration_test.sh
+++ b/build_integration_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e # Exit script immediately on first error.
+set -x # Print commands and their arguments as they are executed.
+set -o pipefail # Print commands and their arguments as they are
+
 cli="./bin/faas-cli"
 
 TEMPLATE_NAME="python3-http"

--- a/build_integration_test.sh
+++ b/build_integration_test.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 cli="./bin/faas-cli"
-template="python3"
+
+TEMPLATE_NAME="python3-http"
 
 get_package() {
     uname=$(uname)
@@ -22,21 +23,20 @@ get_package() {
         case $arch in
         "armv6l" | "armv7l")
         cli="./faas-cli-armhf"
-        template="python3-armhf"
         ;;
         esac
     ;;
     esac
 
     echo "Using package $cli"
-    echo "Using template $template"
+    echo "Using template $TEMPLATE_NAME"
 }
 
 build_faas_function() {
 
     function_name=$1
 
-    eval $cli new $function_name --lang $template
+    eval $cli new $function_name --lang $TEMPLATE_NAME
 
 cat << EOF > $function_name/handler.py
 def handle(req):
@@ -119,6 +119,13 @@ EOF
     echo "Removing created files..."
     rm -rf got.txt want.txt $function_name*
 }
+
+get_templates() {
+    echo "Getting templates..."
+    eval $cli template pull $TEMPLATE_NAME
+}
+
+get_templates
 
 get_package
 build_faas_function $FUNCTION

--- a/builder/build.go
+++ b/builder/build.go
@@ -34,7 +34,7 @@ func BuildImage(image string, handler string, functionName string, language stri
 
 	if stack.IsValidTemplate(language) {
 		pathToTemplateYAML := fmt.Sprintf("./template/%s/template.yml", language)
-		if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
+		if _, err := os.Stat(pathToTemplateYAML); err != nil && os.IsNotExist(err) {
 			return err
 		}
 

--- a/builder/copy_test.go
+++ b/builder/copy_test.go
@@ -103,7 +103,7 @@ func checkDestinationFiles(dir string, numberOfFiles, mode int) error {
 	// Check each file inside the destination folder
 	for i := 1; i <= numberOfFiles; i++ {
 		fileStat, err := os.Stat(fmt.Sprintf("%s/test-file-%d", dir, i))
-		if os.IsNotExist(err) {
+		if err != nil && os.IsNotExist(err) {
 			return err
 		}
 		if fileStat.Mode() != os.FileMode(mode) {

--- a/builder/publish.go
+++ b/builder/publish.go
@@ -48,7 +48,7 @@ func PublishImage(image string, handler string, functionName string, language st
 
 	if stack.IsValidTemplate(language) {
 		pathToTemplateYAML := fmt.Sprintf("./template/%s/template.yml", language)
-		if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
+		if _, err := os.Stat(pathToTemplateYAML); err != nil && os.IsNotExist(err) {
 			return err
 		}
 

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -458,7 +458,7 @@ func deriveFprocess(function stack.Function) (string, error) {
 	}
 
 	pathToTemplateYAML := "./template/" + function.Language + "/template.yml"
-	if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
+	if _, err := os.Stat(pathToTemplateYAML); err != nil && os.IsNotExist(err) {
 		return "", err
 	}
 

--- a/commands/faas.go
+++ b/commands/faas.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	defaultGateway       = "http://127.0.0.1:8080"
-	defaultNetwork       = ""
-	defaultYAML          = "stack.yml"
+	defaultGateway = "http://127.0.0.1:8080"
+	defaultNetwork = ""
+	defaultYML     = "stack.yml"
+	defaultYAML    = "stack.yaml"
+
 	defaultSchemaVersion = "1.0"
 )
 
@@ -144,6 +146,8 @@ func checkAndSetDefaultYaml() {
 	// Check if there is a default yaml file and set it
 	if _, err := stat(defaultYAML); err == nil {
 		yamlFile = defaultYAML
+	} else if _, err := stat(defaultYML); err == nil {
+		yamlFile = defaultYML
 	}
 }
 

--- a/commands/faas_test.go
+++ b/commands/faas_test.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 )
@@ -11,7 +11,7 @@ var mockStatParams string
 func setupFaas(statError error) {
 	yamlFile = ""
 	mockStatParams = ""
-	faasCmd.SetOutput(ioutil.Discard)
+	faasCmd.SetOutput(io.Discard)
 
 	stat = func(f string) (os.FileInfo, error) {
 		mockStatParams = f
@@ -19,7 +19,7 @@ func setupFaas(statError error) {
 	}
 }
 
-func TestCallsStatWithDefaulYAMLFileName(t *testing.T) {
+func TestCallsStatWithDefaultYAMLFileName(t *testing.T) {
 	setupFaas(nil)
 
 	Execute([]string{"help"})

--- a/commands/fetch_templates_test.go
+++ b/commands/fetch_templates_test.go
@@ -21,17 +21,18 @@ func Test_PullTemplates(t *testing.T) {
 	defer os.RemoveAll(localTemplateRepository)
 	defer tearDownFetchTemplates(t)
 
+	templateName := ""
 	t.Run("pullTemplates", func(t *testing.T) {
 		defer tearDownFetchTemplates(t)
-		if err := pullTemplates(localTemplateRepository); err != nil {
-			t.Fatal(err)
+		if err := pullTemplates(localTemplateRepository, templateName); err != nil {
+			t.Fatalf("Trying to pull %s, error: %s", localTemplateRepository, err)
 		}
 	})
 
 	t.Run("fetchTemplates with master ref", func(t *testing.T) {
 		defer tearDownFetchTemplates(t)
 
-		if err := fetchTemplates(localTemplateRepository, "master", false); err != nil {
+		if err := fetchTemplates(localTemplateRepository, "master", templateName, false); err != nil {
 			t.Fatal(err)
 		}
 
@@ -40,8 +41,8 @@ func Test_PullTemplates(t *testing.T) {
 	t.Run("fetchTemplates with default ref", func(t *testing.T) {
 		defer tearDownFetchTemplates(t)
 
-		err := fetchTemplates(localTemplateRepository, "", false)
-		if err != nil {
+		templateName := ""
+		if err := fetchTemplates(localTemplateRepository, "", templateName, false); err != nil {
 			t.Error(err)
 		}
 

--- a/commands/generate_test.go
+++ b/commands/generate_test.go
@@ -150,7 +150,7 @@ functions:
   handler: ./sample/url-ping
   image: alexellis/faas-url-ping:0.2
  astronaut-finder:
-  lang: python3
+  lang: python3-http
   handler: ./astronaut-finder
   image: astronaut-finder
   environment:
@@ -348,43 +348,43 @@ provider:
   network: "func_functions"    
 functions:
  fn1:
-  lang: python3
+  lang: python3-http
   handler: ./fn1
   image: fn1:latest
  fn2:
-  lang: python3
+  lang: python3-http
   handler: ./fn2
   image: fn2:latest
  fn3:
-  lang: python3
+  lang: python3-http
   handler: ./fn3
   image: fn3:latest
  fn4:
-  lang: python3
+  lang: python3-http
   handler: ./fn4
   image: fn4:latest
  fn5:
-  lang: python3
+  lang: python3-http
   handler: ./fn5
   image: fn5:latest
  fn6:
-  lang: python3
+  lang: python3-http
   handler: ./fn6
   image: fn6:latest
  fn7:
-  lang: python3
+  lang: python3-http
   handler: ./fn7
   image: fn7:latest
  fn8:
-  lang: python3
+  lang: python3-http
   handler: ./fn8
   image: fn8:latest
  fn9:
-  lang: python3
+  lang: python3-http
   handler: ./fn9
   image: fn9:latest
  fn10:
-  lang: python3
+  lang: python3-http
   handler: ./fn10
   image: fn10:latest`,
 		Output: []string{
@@ -405,43 +405,43 @@ provider:
   network: "func_functions"    
 functions:
  fn3:
-  lang: python3
+  lang: python3-http
   handler: ./fn3
   image: fn3:latest
  fn7:
-  lang: python3
+  lang: python3-http
   handler: ./fn7
   image: fn7:latest
  fn2:
-  lang: python3
+  lang: python3-http
   handler: ./fn2
   image: fn2:latest
  fn10:
-  lang: python3
+  lang: python3-http
   handler: ./fn10
   image: fn10:latest
  fn5:
-  lang: python3
+  lang: python3-http
   handler: ./fn5
   image: fn5:latest
  fn1:
-  lang: python3
+  lang: python3-http
   handler: ./fn1
   image: fn1:latest
  fn6:
-  lang: python3
+  lang: python3-http
   handler: ./fn6
   image: fn6:latest
  fn9:
-  lang: python3
+  lang: python3-http
   handler: ./fn9
   image: fn9:latest
  fn4:
-  lang: python3
+  lang: python3-http
   handler: ./fn4
   image: fn4:latest
  fn8:
-  lang: python3
+  lang: python3-http
   handler: ./fn8
   image: fn8:latest`,
 		Output: []string{
@@ -462,43 +462,43 @@ provider:
   network: "func_functions"    
 functions:
  fn3:
-  lang: python3
+  lang: python3-http
   handler: ./fn3
   image: fn3:latest
  fn7:
-  lang: python3
+  lang: python3-http
   handler: ./fn7
   image: fn7:latest
  fn2:
-  lang: python3
+  lang: python3-http
   handler: ./fn2
   image: fn2:latest
  fn10:
-  lang: python3
+  lang: python3-http
   handler: ./fn10
   image: fn10:latest
  fn5:
-  lang: python3
+  lang: python3-http
   handler: ./fn5
   image: fn5:latest
  fn1:
-  lang: python3
+  lang: python3-http
   handler: ./fn1
   image: fn1:latest
  fn6:
-  lang: python3
+  lang: python3-http
   handler: ./fn6
   image: fn6:latest
  fn9:
-  lang: python3
+  lang: python3-http
   handler: ./fn9
   image: fn9:latest
  fn4:
-  lang: python3
+  lang: python3-http
   handler: ./fn4
   image: fn4:latest
  fn8:
-  lang: python3
+  lang: python3-http
   handler: ./fn8
   image: fn8:latest`,
 		Output: []string{

--- a/commands/new_function.go
+++ b/commands/new_function.go
@@ -207,7 +207,7 @@ Download templates:
 	}
 
 	pathToTemplateYAML := fmt.Sprintf("./template/%s/template.yml", language)
-	if _, err := os.Stat(pathToTemplateYAML); os.IsNotExist(err) {
+	if _, err := os.Stat(pathToTemplateYAML); err != nil && os.IsNotExist(err) {
 		return err
 	}
 

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -150,18 +150,18 @@ func runNewFunctionTest(t *testing.T, nft NewFunctionTest) {
 	if nft.expectedMsg == SuccessMsg {
 
 		// Make sure that the folder and file was created:
-		if _, err := os.Stat("./" + dirName); os.IsNotExist(err) {
+		if _, err := os.Stat("./" + dirName); err != nil && os.IsNotExist(err) {
 			t.Fatalf("%s/ directory was not created", dirName)
 		}
 
 		// Check that the Dockerfile was created
 		if funcLang == "Dockerfile" || funcLang == "dockerfile" {
-			if _, err := os.Stat("./" + dirName + "/Dockerfile"); os.IsNotExist(err) {
+			if _, err := os.Stat("./" + dirName + "/Dockerfile"); err != nil && os.IsNotExist(err) {
 				t.Fatalf("Dockerfile language should create a Dockerfile for you: %s", funcName)
 			}
 		}
 
-		if _, err := os.Stat(funcYAML); os.IsNotExist(err) {
+		if _, err := os.Stat(funcYAML); err != nil && os.IsNotExist(err) {
 			t.Fatalf("\"%s\" yaml file was not created", funcYAML)
 		}
 

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -272,7 +272,7 @@ func Test_languageNotExists(t *testing.T) {
 
 func Test_appendInvalidSuffix(t *testing.T) {
 	const functionName = "samplefunc"
-	const functionLang = "ruby"
+	const functionLang = "dockerfile"
 
 	templatePullLocalTemplateRepo(t)
 	defer tearDownFetchTemplates(t)
@@ -294,7 +294,7 @@ func Test_appendInvalidSuffix(t *testing.T) {
 
 func Test_appendInvalidFile(t *testing.T) {
 	const functionName = "samplefunc"
-	const functionLang = "ruby"
+	const functionLang = "dockerfile"
 
 	templatePullLocalTemplateRepo(t)
 	defer tearDownFetchTemplates(t)
@@ -318,7 +318,7 @@ func Test_duplicateFunctionName(t *testing.T) {
 	resetForTest()
 
 	const functionName = "samplefunc"
-	const functionLang = "ruby"
+	const functionLang = "dockerfile"
 
 	templatePullLocalTemplateRepo(t)
 	defer tearDownFetchTemplates(t)
@@ -346,7 +346,7 @@ func Test_duplicateFunctionName(t *testing.T) {
 func Test_backfillTemplates(t *testing.T) {
 	resetForTest()
 	const functionName = "samplefunc"
-	const functionLang = "ruby"
+	const functionLang = "dockerfile"
 
 	// Delete cached templates
 	localTemplateRepository := setupLocalTemplateRepo(t)

--- a/commands/new_function_test.go
+++ b/commands/new_function_test.go
@@ -27,13 +27,15 @@ const (
 - dockerfile
 - ruby`
 
-	LangNotExistsOutput  = `(template: \"([0-9A-Za-z-])*\" was not found in the templates directory)`
+	LangNotExistsOutput  = `(template: \"([0-9A-Za-z-])*\" was not found in the templates folder or in the store)`
 	FunctionExistsOutput = `(Function (.+)? already exists in (.+)? file)`
 	NoTemplates          = `no language templates were found.
 
 Download templates:
-  faas-cli template pull           download the default templates
-  faas-cli template store list     view the community template store`
+  faas-cli template pull                download the default templates
+  faas-cli template store list          view the template store
+  faas-cli template store pull NAME     download the default templates
+  faas-cli new --lang NAME              Attempt to download NAME from the template store`
 	InvalidFileSuffix = "when appending to a stack the suffix should be .yml or .yaml"
 )
 

--- a/commands/plugin_get.go
+++ b/commands/plugin_get.go
@@ -99,7 +99,7 @@ func runPluginGetCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+	if _, err := os.Stat(pluginDir); err != nil && os.IsNotExist(err) {
 		if err := os.MkdirAll(pluginDir, 0755); err != nil && os.ErrExist != err {
 			return fmt.Errorf("failed to create plugin directory %s: %w", pluginDir, err)
 		}

--- a/commands/publish.go
+++ b/commands/publish.go
@@ -164,7 +164,7 @@ func runPublish(cmd *cobra.Command, args []string) error {
 	}
 
 	if needTemplates {
-		if _, err := os.Stat("./template"); os.IsNotExist(err) {
+		if _, err := os.Stat("./template"); err != nil && os.IsNotExist(err) {
 
 			return fmt.Errorf(`the "template" directory is missing but required by at least one function`)
 		}

--- a/commands/registry_login.go
+++ b/commands/registry_login.go
@@ -174,7 +174,7 @@ func generateECRRegistryAuth(accountID, region string) ([]byte, error) {
 
 func writeFileToFassCLITmp(fileBytes []byte) error {
 	path := "./credentials"
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	if _, err := os.Stat(path); err != nil && os.IsNotExist(err) {
 		err := os.Mkdir(path, 0744)
 		if err != nil {
 			return err

--- a/commands/template_pull.go
+++ b/commands/template_pull.go
@@ -43,8 +43,11 @@ func runTemplatePull(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		repository = args[0]
 	}
+
+	templateName := "" // templateName may not be known at this point
+
 	repository = getTemplateURL(repository, os.Getenv(templateURLEnvironment), DefaultTemplateRepository)
-	return pullTemplate(repository)
+	return pullTemplate(repository, templateName)
 }
 
 func pullDebugPrint(message string) {

--- a/commands/template_pull_stack.go
+++ b/commands/template_pull_stack.go
@@ -77,19 +77,12 @@ func pullStackTemplates(templateInfo []stack.TemplateSource, cmd *cobra.Command)
 				return pullErr
 			}
 		} else {
-			pullErr := pullTemplate(val.Source)
+
+			templateName := val.Name
+			pullErr := pullTemplate(val.Source, templateName)
 			if pullErr != nil {
 				return pullErr
 			}
-		}
-	}
-	return nil
-}
-
-func findTemplate(templateInfo []stack.TemplateSource, customName string) (specificTemplate *stack.TemplateSource) {
-	for _, val := range templateInfo {
-		if val.Name == customName {
-			return &val
 		}
 	}
 	return nil

--- a/commands/template_pull_stack.go
+++ b/commands/template_pull_stack.go
@@ -93,7 +93,7 @@ func filterExistingTemplates(templateInfo []stack.TemplateSource, templatesDir s
 	var newTemplates []stack.TemplateSource
 	for _, info := range templateInfo {
 		templatePath := fmt.Sprintf("%s/%s", templatesDir, info.Name)
-		if _, err := os.Stat(templatePath); os.IsNotExist(err) {
+		if _, err := os.Stat(templatePath); err != nil && os.IsNotExist(err) {
 			newTemplates = append(newTemplates, info)
 		}
 	}

--- a/commands/template_pull_stack_test.go
+++ b/commands/template_pull_stack_test.go
@@ -3,48 +3,11 @@ package commands
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/openfaas/faas-cli/builder"
 	"github.com/openfaas/faas-cli/stack"
 )
-
-func Test_findTemplate(t *testing.T) {
-	tests := []struct {
-		title             string
-		desiredTemplate   string
-		existingTemplates []stack.TemplateSource
-		expectedTemplate  *stack.TemplateSource
-	}{
-		{
-			title:           "Desired template is found",
-			desiredTemplate: "powershell",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "powershell", Source: "exampleURL"},
-				{Name: "rust", Source: "exampleURL"},
-			},
-			expectedTemplate: &stack.TemplateSource{Name: "powershell", Source: "exampleURL"},
-		},
-		{
-			title:           "Desired template is not found",
-			desiredTemplate: "golang",
-			existingTemplates: []stack.TemplateSource{
-				{Name: "powershell", Source: "exampleURL"},
-				{Name: "rust", Source: "exampleURL"},
-			},
-			expectedTemplate: nil,
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.title, func(t *testing.T) {
-			result := findTemplate(test.existingTemplates, test.desiredTemplate)
-			if !reflect.DeepEqual(result, test.expectedTemplate) {
-				t.Errorf("Wanted template: `%s` got `%s`", test.expectedTemplate, result)
-			}
-		})
-	}
-}
 
 func Test_pullAllTemplates(t *testing.T) {
 	tests := []struct {

--- a/commands/template_pull_stack_test.go
+++ b/commands/template_pull_stack_test.go
@@ -77,8 +77,8 @@ func Test_filterExistingTemplates(t *testing.T) {
 	defer os.RemoveAll(templatesDir)
 
 	templates := []stack.TemplateSource{
-		{Name: "dockerfile", Source: "https://github.com/openfaas-incubator/powershell-http-template"},
-		{Name: "ruby", Source: "https://github.com/openfaas-incubator/openfaas-rust-template"},
+		{Name: "dockerfile", Source: "https://github.com/openfaas/templates"},
+		{Name: "ruby", Source: "https://github.com/openfaas/classic-templates"},
 		{Name: "perl", Source: "https://github.com/openfaas-incubator/perl-template"},
 	}
 

--- a/commands/template_store_list.go
+++ b/commands/template_store_list.go
@@ -138,7 +138,7 @@ func getTemplateInfo(repository string) ([]TemplateInfo, error) {
 
 	templatesInfo := []TemplateInfo{}
 	if err := json.Unmarshal(body, &templatesInfo); err != nil {
-		return nil, fmt.Errorf("can't unmarshal text: %s", err.Error())
+		return nil, fmt.Errorf("can't unmarshal text: %s, value: %s", err.Error(), string(body))
 	}
 
 	sortTemplates(templatesInfo)

--- a/config/config_file.go
+++ b/config/config_file.go
@@ -135,7 +135,7 @@ func EnsureFile() (string, error) {
 		return "", err
 	}
 
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+	if _, err := os.Stat(filePath); err != nil && os.IsNotExist(err) {
 		file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return "", err
@@ -155,7 +155,7 @@ func fileExists() bool {
 	}
 
 	filePath := path.Clean(filepath.Join(dirPath, DefaultFile))
-	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+	if _, err := os.Stat(filePath); err != nil && os.IsNotExist(err) {
 		return false
 	}
 
@@ -185,7 +185,7 @@ func (configFile *ConfigFile) save() error {
 func (configFile *ConfigFile) load() error {
 	conf := &ConfigFile{}
 
-	if _, err := os.Stat(configFile.FilePath); os.IsNotExist(err) {
+	if _, err := os.Stat(configFile.FilePath); err != nil && os.IsNotExist(err) {
 		return fmt.Errorf("can't load config from non existent filePath")
 	}
 

--- a/config/config_file_test.go
+++ b/config/config_file_test.go
@@ -234,8 +234,7 @@ func Test_EnsureFile(t *testing.T) {
 	if err != nil {
 		t.Error(err.Error())
 	}
-	_, err = os.Stat(cfg)
-	if os.IsNotExist(err) {
+	if _, err = os.Stat(cfg); err != nil && os.IsNotExist(err) {
 		t.Errorf("expected config at %s", cfg)
 	}
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Pull templates from store when not present

Implements a user-experience changes:

faas-cli new - when the templates folder is not present the language will be looked up in the template store using the default URL or an overriden one.

faas-cli publish - when no template folder is available then a pull will be carried out if a configuration section is present with a template given within in

Filtering - whilst there is no way to avoid pulling all the templates wihtin a repository, only the requested/needed ones are expanded by commands like faas-cli new.

## Motivation and Context

Improve user experience as discussed on community call Jan 22 2025

## How Has This Been Tested?

Tested mainly with existing-unit tests, faas-cli new / publish with and without a templates folder.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

