### PR TITLE
Use same header format as curl for invoke command

### DIFF
--- a/commands/invoke_test.go
+++ b/commands/invoke_test.go
@@ -177,6 +177,29 @@ func Test_parseHeaders_valid(t *testing.T) {
 	}{
 		{
 			name:  "Header with key-value pair as value",
+			input: []string{`X-Hub-Signature: "sha1: "shashashaebaf43""`, "X-Hub-Signature-1: sha1: shashashaebaf43", "X-Hub-Signature-2:sha1:shashashaebaf43"},
+			want: http.Header{
+				"X-Hub-Signature":   []string{`"sha1: "shashashaebaf43""`},
+				"X-Hub-Signature-1": []string{"sha1: shashashaebaf43"},
+				"X-Hub-Signature-2": []string{"sha1:shashashaebaf43"},
+			},
+		},
+		{
+			name:  "Header with normal values",
+			input: []string{`X-Hub-Signature: "shashashaebaf43"`, "X-Hub-Signature-1: shashashaebaf43", "X-Hub-Signature-2:shashashaebaf43"},
+			want: http.Header{
+				"X-Hub-Signature":   []string{`"shashashaebaf43"`},
+				"X-Hub-Signature-1": []string{"shashashaebaf43"},
+				"X-Hub-Signature-2": []string{"shashashaebaf43"},
+			},
+		},
+		{
+			name:  "Header with base64 string value",
+			input: []string{`X-Hub-Signature: "shashashaebaf43="`},
+			want:  http.Header{"X-Hub-Signature": []string{`"shashashaebaf43="`}},
+		},
+		{
+			name:  "Deprecated header format with key-value pair as value",
 			input: []string{`X-Hub-Signature="sha1="shashashaebaf43""`, "X-Hub-Signature-1=sha1=shashashaebaf43"},
 			want: http.Header{
 				"X-Hub-Signature":   []string{`"sha1="shashashaebaf43""`},
@@ -184,12 +207,12 @@ func Test_parseHeaders_valid(t *testing.T) {
 			},
 		},
 		{
-			name:  "Header with normal values",
+			name:  "Deprecated header format with normal values",
 			input: []string{`X-Hub-Signature="shashashaebaf43"`, "X-Hub-Signature-1=shashashaebaf43"},
 			want:  http.Header{"X-Hub-Signature": []string{`"shashashaebaf43"`}, "X-Hub-Signature-1": []string{"shashashaebaf43"}},
 		},
 		{
-			name:  "Header with base64 string value",
+			name:  "Deprecated header format with base64 string value",
 			input: []string{`X-Hub-Signature="shashashaebaf43="`},
 			want:  http.Header{"X-Hub-Signature": []string{`"shashashaebaf43="`}},
 		},
@@ -221,10 +244,18 @@ func Test_parseHeaders_invalid(t *testing.T) {
 		},
 		{
 			name:  "Empty header key",
-			input: []string{"=shashashaebaf43"},
+			input: []string{":shashashaebaf43"},
 		},
 		{
 			name:  "Empty header value",
+			input: []string{"X-Hub-Signature:"},
+		},
+		{
+			name:  "Deprecated empty header key",
+			input: []string{"=shashashaebaf43"},
+		},
+		{
+			name:  "Deprecated empty header value",
 			input: []string{"X-Hub-Signature="},
 		},
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Change the header flag to accept key value pairs separated by a colon. e.g. "key: value".

The previous format is marked as deprecated but still supported. A warning is printed when it is used.

Fix an issues where the 'Content-Type' header was being overridden by the default value of the `--content-type` flag when the flag is not set explicitly.

e.g. when running `faas-cli invoke -H "Content-Type=application/tar"` the content type would be overridden with the default value `text/plain`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

Align the format more closely with `curl` to make the invoke command as intuitive and familiar as possible.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Changes are covered by unit test.

Verify headers can be set using the new format:

```sh
faas-cli invoke -H "foo: bar" <<< hello
```

Verify the deprecated format is still accepted and prints a warning:

```sh
faas-cli invoke -H "foo=bar" <<< hello
Warning: Using deprecated 'key=value' format for headers. Please use 'Key: Value' format instead.
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
