### PR TITLE
Remove the armhf binary from the release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,22 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
             REPO_URL=https://github.com/openfaas/faas-cli
           tags: openfaas/faas-cli:${{ github.sha }}
-      - 
+      -
+        name: Test the redistributable binaries cross-compile
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.redist
+          push: false
+          load: false
+          platforms: linux/amd64
+          target: release
+          build-args: |
+            VERSION=latest-dev
+            GIT_COMMIT=${{ github.sha }}
+            REPO_URL=https://github.com/openfaas/faas-cli
+          tags: openfaas/faas-cli-redist:${{ github.sha }}
+      -
         name: Copy binary to host
         run: |
           docker create --name faas-cli openfaas/faas-cli:${{ github.sha }} && \

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ build
 faas-cli
 faas-cli-darwin
 faas-cli-darwin-arm64
-faas-cli-armhf
 faas-cli.exe
 faas-cli-arm64
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ To build the release binaries type in:
 ./extract_binaries.sh
 ```
 
-This creates the faas-cli for Mac, Windows, Linux x64, Linux ARMHF and Linux ARM64.
+This creates the faas-cli for Mac, Windows, Linux x64 and Linux ARM64.
 
 * The project manages dependencies using Go modules and the `vendor/` folder. When updating a dependency you must run
 

--- a/Dockerfile.redist
+++ b/Dockerfile.redist
@@ -55,13 +55,6 @@ RUN CGO_ENABLED=0 GOOS=windows go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/commands.Platform=x86_64" \
        -o faas-cli.exe
 
-FROM builder as arm
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build --ldflags "-s -w \
-       -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
-       -X github.com/openfaas/faas-cli/version.Version=${VERSION} \
-       -X github.com/openfaas/faas-cli/commands.Platform=armhf" \
-       -o faas-cli-armhf
-
 FROM builder as arm64
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build --ldflags "-s -w \
        -X github.com/openfaas/faas-cli/version.GitCommit=${GIT_COMMIT} \
@@ -83,7 +76,6 @@ WORKDIR /home/app
 COPY --from=linux          /go/src/github.com/openfaas/faas-cli/faas-cli                .
 COPY --from=darwin         /go/src/github.com/openfaas/faas-cli/faas-cli-darwin         .
 COPY --from=darwin-arm64   /go/src/github.com/openfaas/faas-cli/faas-cli-darwin-arm64   .
-COPY --from=arm            /go/src/github.com/openfaas/faas-cli/faas-cli-armhf          .
 COPY --from=windows        /go/src/github.com/openfaas/faas-cli/faas-cli.exe            .
 COPY --from=arm64          /go/src/github.com/openfaas/faas-cli/faas-cli-arm64          .
 

--- a/Makefile
+++ b/Makefile
@@ -65,14 +65,6 @@ dist:
 test-unit:
 	go test $(shell go list ./... | grep -v /vendor/ | grep -v /template/ | grep -v build) -cover
 
-.PHONY: ci-armhf-push
-ci-armhf-push:
-	(docker push openfaas/faas-cli:$(TAG)-armhf && docker push openfaas/faas-cli:$(TAG)-root-armhf)
-
-.PHONY: ci-armhf-build
-ci-armhf-build:
-	(./build.sh $(TAG)-armhf)
-
 .PHONY: ci-arm64-push
 ci-arm64-push:
 	(docker push openfaas/faas-cli:$(TAG)-arm64 && docker push openfaas/faas-cli:$(TAG)-root-arm64)

--- a/build_integration_test.sh
+++ b/build_integration_test.sh
@@ -23,13 +23,6 @@ get_package() {
         ;;
         esac
     ;;
-    "Linux")
-        case $arch in
-        "armv6l" | "armv7l")
-        cli="./faas-cli-armhf"
-        ;;
-        esac
-    ;;
     esac
 
     echo "Using package $cli"

--- a/commands/local_run_resources.go
+++ b/commands/local_run_resources.go
@@ -136,7 +136,7 @@ func negativeMemoryError(value string) error {
 
 func oversizedMemoryError(value string) error {
 	// Typed as int64 so the constant does not take its default type of int,
-	// which overflows when cross-compiling for a 32-bit target such as armhf.
+	// which would overflow when building for a 32-bit target.
 	return fmt.Errorf("invalid memory value %q: must be under %d bytes", value, int64(math.MaxInt64))
 }
 

--- a/extract_binaries.sh
+++ b/extract_binaries.sh
@@ -15,7 +15,6 @@ docker create --name faas-cli openfaas/faas-cli:${eTAG} && \
   docker cp faas-cli:/home/app/faas-cli ./bin && \
   docker cp faas-cli:/home/app/faas-cli-darwin ./bin && \
   docker cp faas-cli:/home/app/faas-cli-darwin-arm64 ./bin && \
-  docker cp faas-cli:/home/app/faas-cli-armhf ./bin && \
   docker cp faas-cli:/home/app/faas-cli-arm64 ./bin && \
   docker cp faas-cli:/home/app/faas-cli.exe ./bin && \
   docker rm -f faas-cli

--- a/npm/lib.js
+++ b/npm/lib.js
@@ -18,10 +18,6 @@ module.exports = {
             if (arch === 'aarch64') {
                 return '-arm64';
             }
-
-            if (arch === 'armv61' || arch === 'armv71') {
-                return '-armhf'
-            }
         }
 
         if (type === 'Darwin') {

--- a/npm/test.js
+++ b/npm/test.js
@@ -14,13 +14,9 @@ describe('Platform Suffix', function () {
         let result = lib.getSuffix('Linux', 'aarch64');
         assert.equal(result, '-arm64', `Expected '-arm64', but got: ${result}`);
     });
-    it('should return -armhf for Linux armv61', function () {
-        let result = lib.getSuffix('Linux', 'armv61');
-        assert.equal(result, '-armhf', `Expected '-armhf', but got: ${result}`);
-    });
-    it('should return -armhf for Linux armv71', function () {
-        let result = lib.getSuffix('Linux', 'armv71');
-        assert.equal(result, '-armhf', `Expected '-armhf', but got: ${result}`);
+    it('should throw for 32-bit Arm, which is no longer published', function () {
+        assert.throws(() => {lib.getSuffix('Linux', 'armv61')});
+        assert.throws(() => {lib.getSuffix('Linux', 'armv71')});
     });
     it('should return -darwin for MacOS', function () {
         let result = lib.getSuffix('Darwin', '');


### PR DESCRIPTION
## Motivation

`faas-cli-armhf` is the least-used artifact we publish, and it is the only build target that cannot fail anywhere except during a release. Both of those came to a head this week: a compile error affecting only the 32-bit Arm target broke the `0.18.12` publish and the release had to be retracted.

## Why it doesn't make sense to keep building it

**Nobody is downloading it.** Asset download counts for the last five releases:

| Release | armhf | arm64 | amd64 | .exe |
|---|---|---|---|---|
| 0.18.11 | **2** | 11 | 101 | 17 |
| 0.18.10 | **15** | 68 | 2466 | 228 |
| 0.18.9 | **4** | 4 | 29 | 9 |
| 0.18.8 | **19** | 189 | 8936 | 689 |
| 0.18.7 | **15** | 31 | 1106 | 102 |

That is ~55 downloads against ~12,600 for `linux/amd64` — around 0.4%, and roughly a fifth of `arm64`. It is the least-downloaded binary in every single release. These counts include bots and mirrors, so treat them as an upper bound.

**Nothing else in the project ships armhf.** The `faas-cli` container images are already limited to `linux/amd64,linux/arm64`. The language templates dropped armhf when they moved to multi-arch buildx. OpenFaaS itself does not support armhf, so an armhf user could only ever run the CLI against a remote cluster — they could not run a gateway or build a function for that architecture.

**It is the only target that can fail at release time and nowhere else.** The armhf cross-compile lives in `Dockerfile.redist`, which only the `publish` workflow builds. `build.yaml` covers `linux/amd64` and a `linux/amd64,linux/arm64` multi-arch check, and never touches the redistributable binaries. So a compile error specific to a 32-bit target is undetectable until a tag is pushed. That is exactly what happened with `0.18.12`:

```
commands/local_run_resources.go:138:78: cannot use math.MaxInt64
  (untyped int constant 9223372036854775807) as int value in argument
  to fmt.Errorf (overflows)
```

An untyped constant passed to a variadic `interface{}` takes its default type of `int`, which is 32 bits on armhf. `go build`, `go test`, and the whole `build` workflow all passed.

## What changes

- `Dockerfile.redist` — drop the `arm` build stage and its `COPY` into the release stage
- `extract_binaries.sh` — stop copying `faas-cli-armhf` out of the image
- `Makefile` — remove the `ci-armhf-build` / `ci-armhf-push` targets
- `build_integration_test.sh` — remove the armv6l/armv7l binary selection
- `npm/lib.js` — `armv6l` / `armv7l` now report `Unsupported platform` instead of fetching a binary that will not exist. This is a clearer failure than a 404 partway through an install.
- `.gitignore`, `CONTRIBUTING.md` — housekeeping

The second commit adds `Dockerfile.redist` to the `build` workflow, so the remaining cross-compiled targets — Windows, macOS x86_64, macOS arm64, Linux arm64 — are compiled on every push rather than only at release. The image is built and discarded, not loaded or pushed. This is what would have caught the `0.18.12` failure in the PR that introduced it.

## Impact on users

**Anyone still on 32-bit Arm can stay on `0.18.11` or earlier.** Those binaries remain published and downloadable indefinitely; nothing is being deleted from existing releases. They simply will not receive new versions.

In practice this is a very small group. 32-bit Arm means ARMv6 hardware — Pi 1, Pi Zero, Pi Zero W — or a 32-bit Pi OS image on a 64-bit board. Raspberry Pi OS has defaulted to 64-bit since 2022, and the Pi Zero 2 W is ARMv8. Anyone on 64-bit Arm continues to use `faas-cli-arm64`, which is unaffected.

No change for users on amd64, arm64, macOS or Windows.

## Testing

- `Dockerfile.redist` builds clean and produces exactly the expected set, with no armhf: `faas-cli`, `faas-cli-arm64`, `faas-cli-darwin`, `faas-cli-darwin-arm64`, `faas-cli.exe`
- `go build ./...`, `go test ./...` and `gofmt -l` clean
- `npm` suffix resolution verified: `x64` → `""`, `aarch64` → `-arm64`, `Darwin` → `-darwin`, `Windows_NT` → `.exe`, and `armv61` / `armv71` now throw `Unsupported platform`
- `build.yaml` validated as parseable YAML

Raised as a PR rather than pushed to master so it is visible and open to comment.
