### PR TITLE
Set the default namespace with OPENFAAS_NS

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ $ uname -a | curl http://127.0.0.1:8080/function/nodejs-echo--data-binary @-
 * `OPENFAAS_TEMPLATE_URL` - to set the default URL to pull templates from
 * `OPENFAAS_PREFIX` - for use with `faas-cli new` - this can act in place of `--prefix`
 * `OPENFAAS_URL` - to override the default gateway URL
+* `OPENFAAS_NS` - to set the default function namespace
 * `OPENFAAS_REMOTE_BUILDER` - default value for `--remote-builder`
 * `OPENFAAS_PAYLOAD_SECRET` - default value for `--payload-secret`
 * `OPENFAAS_BUILDER_PUBLIC_KEY` - builder public key as a literal value, or a path to a file containing raw base64 or the JSON response from `/public-key`

--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -199,7 +199,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 
 			// Check if there is a functionNamespace flag passed, if so, override the namespace value
 			// defined in the stack.yaml
-			function.Namespace = getNamespace(functionNamespace, function.Namespace)
+			function.Namespace = getNamespace(functionNamespace, function.Namespace, os.Getenv(openFaaSNamespaceEnvironment))
 
 			fileEnvironment, err := readFiles(function.EnvironmentFile)
 			if err != nil {
@@ -319,7 +319,7 @@ Error: %s`, fprocessErr.Error())
 			tlsInsecure,
 			defaultReadOnlyRFS,
 			token,
-			functionNamespace,
+			getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment)),
 			cpuRequest,
 			cpuLimit,
 			memoryRequest,

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -83,14 +83,15 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
 
-	function, err := cliClient.GetFunctionInfo(ctx, functionName, functionNamespace)
+	function, err := cliClient.GetFunctionInfo(ctx, functionName, namespace)
 	if err != nil {
 		return err
 	}
 
 	//To get correct value for invocation count from /system/functions endpoint
-	functionList, err := cliClient.ListFunctions(ctx, functionNamespace)
+	functionList, err := cliClient.ListFunctions(ctx, namespace)
 	if err != nil {
 		return err
 	}
@@ -108,7 +109,7 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 		status = "Ready"
 	}
 
-	url, asyncURL := getFunctionURLs(gatewayAddress, functionName, functionNamespace)
+	url, asyncURL := getFunctionURLs(gatewayAddress, functionName, namespace)
 
 	funcDesc := schema.FunctionDescription{
 		FunctionStatus:  function,

--- a/commands/diff.go
+++ b/commands/diff.go
@@ -94,7 +94,8 @@ func runDiff(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	functions, err := proxyClient.ListFunctions(context.Background(), functionNamespace)
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	functions, err := proxyClient.ListFunctions(context.Background(), namespace)
 	if err != nil {
 		return err
 	}
@@ -103,7 +104,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	yamlMap := make(map[string]funcDiff)
 	for name, fn := range yamlFns {
-		key := diffKey(name, namespaceForDiffKey(functionNamespace, fn.Namespace))
+		key := diffKey(name, getNamespace(functionNamespace, fn.Namespace, os.Getenv(openFaaSNamespaceEnvironment)))
 
 		imageName, err := buildDiffImageName(fn.Image, fn.Handler, tagFormat)
 		if err != nil {

--- a/commands/diff.go
+++ b/commands/diff.go
@@ -94,12 +94,6 @@ func runDiff(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
-	functions, err := proxyClient.ListFunctions(context.Background(), namespace)
-	if err != nil {
-		return err
-	}
-
 	yamlFns := parsedServices.Functions
 
 	yamlMap := make(map[string]funcDiff)
@@ -130,27 +124,19 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	deployedMap := make(map[string]funcDiff)
-	for _, fn := range functions {
-		envMap := fn.EnvVars
-		if envMap == nil {
-			envMap = make(map[string]string)
+	ctx := context.Background()
+	for _, namespace := range namespacesForDiff(functionNamespace, parsedServices.Functions, os.Getenv(openFaaSNamespaceEnvironment)) {
+		deployed, err := proxyClient.ListFunctions(ctx, namespace)
+		if err != nil {
+			return err
 		}
 
-		fnDiff := funcDiff{
-			Image:                  fn.Image,
-			FProcess:               fn.EnvProcess,
-			Env:                    envMap,
-			Secrets:                fn.Secrets,
-			Constraints:            fn.Constraints,
-			Labels:                 mapFromPtr(fn.Labels),
-			Annotations:            mapFromPtr(fn.Annotations),
-			Limits:                 resourcesFromStatus(fn.Limits),
-			Requests:               resourcesFromStatus(fn.Requests),
-			ReadOnlyRootFilesystem: fn.ReadOnlyRootFilesystem,
-		}
-		deployedMap[diffKey(fn.Name, "")] = fnDiff
-		if fn.Namespace != "" {
-			deployedMap[diffKey(fn.Name, fn.Namespace)] = fnDiff
+		for _, fn := range deployed {
+			key := diffKey(fn.Name, namespace)
+			if _, ok := yamlMap[key]; !ok {
+				continue
+			}
+			deployedMap[key] = functionStatusToDiff(fn)
 		}
 	}
 
@@ -176,6 +162,26 @@ func runDiff(cmd *cobra.Command, args []string) error {
 	}
 
 	return fmt.Errorf("differences found")
+}
+
+func functionStatusToDiff(fn types.FunctionStatus) funcDiff {
+	env := fn.EnvVars
+	if env == nil {
+		env = make(map[string]string)
+	}
+
+	return funcDiff{
+		Image:                  fn.Image,
+		FProcess:               fn.EnvProcess,
+		Env:                    env,
+		Secrets:                fn.Secrets,
+		Constraints:            fn.Constraints,
+		Labels:                 mapFromPtr(fn.Labels),
+		Annotations:            mapFromPtr(fn.Annotations),
+		Limits:                 resourcesFromStatus(fn.Limits),
+		Requests:               resourcesFromStatus(fn.Requests),
+		ReadOnlyRootFilesystem: fn.ReadOnlyRootFilesystem,
+	}
 }
 
 func buildDiffImageName(image string, handler string, tagMode schema.BuildFormat) (string, error) {
@@ -435,11 +441,19 @@ func sortedAttrKeys(m map[string]string) []string {
 	return keys
 }
 
-func namespaceForDiffKey(flagNamespace string, stackNamespace string) string {
-	if flagNamespace != "" {
-		return flagNamespace
+func namespacesForDiff(flagNamespace string, functions map[string]stack.Function, environmentNamespace string) []string {
+	namespaces := map[string]struct{}{}
+	for _, function := range functions {
+		namespace := getNamespace(flagNamespace, function.Namespace, environmentNamespace)
+		namespaces[namespace] = struct{}{}
 	}
-	return stackNamespace
+
+	result := make([]string, 0, len(namespaces))
+	for namespace := range namespaces {
+		result = append(result, namespace)
+	}
+	sort.Strings(result)
+	return result
 }
 
 func diffKey(name string, namespace string) string {

--- a/commands/diff_test.go
+++ b/commands/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/openfaas/faas-cli/schema"
 	"github.com/openfaas/faas-cli/test"
 	types "github.com/openfaas/faas-provider/types"
+	"github.com/openfaas/go-sdk/stack"
 )
 
 func Test_diff_no_changes(t *testing.T) {
@@ -123,6 +125,124 @@ functions:
 
 	if !strings.Contains(stdOut, "no differences found") {
 		t.Fatalf("Expected no differences, got:\n%s", stdOut)
+	}
+}
+
+func TestNamespacesForDiffPrecedence(t *testing.T) {
+	functions := map[string]stack.Function{
+		"first":  {Namespace: "stack-a"},
+		"second": {Namespace: "stack-b"},
+		"third":  {},
+	}
+
+	got := namespacesForDiff("", functions, "environment")
+	want := []string{"environment", "stack-a", "stack-b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want namespaces %v, got %v", want, got)
+	}
+
+	got = namespacesForDiff("flag", functions, "environment")
+	want = []string{"flag"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("want flag namespace %v, got %v", want, got)
+	}
+}
+
+func TestDiffDoesNotMatchDefaultFunctionFromAnotherNamespace(t *testing.T) {
+	t.Setenv(openFaaSNamespaceEnvironment, "")
+	yamlPath := filepath.Join(t.TempDir(), "stack.yaml")
+	yamlContent := `version: 1.0
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+  echo:
+    image: ttl.sh/test/echo:latest
+  worker:
+    image: ttl.sh/test/worker:latest
+    namespace: team-a
+`
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			Method:             http.MethodGet,
+			Uri:                "/system/functions",
+			ResponseStatusCode: http.StatusOK,
+			ResponseBody:       []types.FunctionStatus{},
+		},
+		{
+			Method:             http.MethodGet,
+			Uri:                "/system/functions?namespace=team-a",
+			ResponseStatusCode: http.StatusOK,
+			ResponseBody: []types.FunctionStatus{
+				{Name: "echo", Namespace: "team-a", Image: "ttl.sh/test/echo:latest"},
+				{Name: "worker", Namespace: "team-a", Image: "ttl.sh/test/worker:latest"},
+			},
+		},
+	})
+	defer s.Close()
+
+	resetForTest()
+	var executeErr error
+	stdOut := test.CaptureStdout(func() {
+		faasCmd.SetArgs([]string{"diff", "--yaml", yamlPath, "--gateway", s.URL})
+		executeErr = faasCmd.Execute()
+	})
+
+	if executeErr == nil || !strings.Contains(executeErr.Error(), "differences found") {
+		t.Fatalf("want missing default function to produce a difference, got: %v", executeErr)
+	}
+	if !strings.Contains(stdOut, "echo") || !strings.Contains(stdOut, "not deployed") {
+		t.Fatalf("want default namespace echo to be reported as not deployed, got:\n%s", stdOut)
+	}
+	if strings.Contains(stdOut, "worker.team-a") {
+		t.Fatalf("want matching namespaced worker to be omitted from diff, got:\n%s", stdOut)
+	}
+}
+
+func TestDiffUsesQueriedNamespaceWhenStatusOmitsNamespace(t *testing.T) {
+	t.Setenv(openFaaSNamespaceEnvironment, "")
+	yamlPath := filepath.Join(t.TempDir(), "stack.yaml")
+	yamlContent := `version: 1.0
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+  worker:
+    image: ttl.sh/test/worker:latest
+    namespace: team-a
+`
+	if err := os.WriteFile(yamlPath, []byte(yamlContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	s := test.MockHttpServer(t, []test.Request{
+		{
+			Method:             http.MethodGet,
+			Uri:                "/system/functions?namespace=team-a",
+			ResponseStatusCode: http.StatusOK,
+			ResponseBody: []types.FunctionStatus{
+				{Name: "worker", Image: "ttl.sh/test/worker:latest"},
+			},
+		},
+	})
+	defer s.Close()
+
+	resetForTest()
+	var executeErr error
+	stdOut := test.CaptureStdout(func() {
+		faasCmd.SetArgs([]string{"diff", "--yaml", yamlPath, "--gateway", s.URL})
+		executeErr = faasCmd.Execute()
+	})
+
+	if executeErr != nil {
+		t.Fatalf("want queried namespace to match stack function, got: %v\n%s", executeErr, stdOut)
+	}
+	if !strings.Contains(stdOut, "no differences found") {
+		t.Fatalf("want no differences, got:\n%s", stdOut)
 	}
 }
 

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -97,7 +97,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	functionNamespace = getNamespace(functionInvokeNamespace, stackNamespace)
+	functionNamespace = getNamespace(functionInvokeNamespace, stackNamespace, os.Getenv(openFaaSNamespaceEnvironment))
 
 	if missingSignFlag(sigHeader, key) {
 		return fmt.Errorf("signing requires both --sign <header-value> and --key <key-value>")
@@ -180,7 +180,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 			}
 			req.Header = httpHeader
 
-			res, err = client.InvokeFunction(functionName, functionInvokeNamespace, invokeAsync, authenticate, req)
+			res, err = client.InvokeFunction(functionName, functionNamespace, invokeAsync, authenticate, req)
 			if err != nil {
 				return fmt.Errorf("failed to invoke function: %s", err)
 			}

--- a/commands/list.go
+++ b/commands/list.go
@@ -77,7 +77,8 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	functions, err := proxyClient.ListFunctions(context.Background(), functionNamespace)
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	functions, err := proxyClient.ListFunctions(context.Background(), namespace)
 	if err != nil {
 		return err
 	}

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -179,7 +179,7 @@ func logRequestFromFlags(cmd *cobra.Command, args []string) logs.Request {
 
 	return logs.Request{
 		Name:      args[0],
-		Namespace: ns,
+		Namespace: getNamespace(ns, "", os.Getenv(openFaaSNamespaceEnvironment)),
 		Tail:      logFlagValues.lines,
 		Since:     sinceValue(logFlagValues.sinceTime.AsTime(), logFlagValues.since),
 		Follow:    logFlagValues.tail,

--- a/commands/logs_test.go
+++ b/commands/logs_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func Test_logsCmdFlagParsing(t *testing.T) {
+	t.Setenv(openFaaSNamespaceEnvironment, "")
 	nowFunc = func() time.Time {
 		ts, _ := time.Parse(time.RFC3339, "2019-01-01T01:00:00Z")
 		return ts
@@ -41,6 +42,34 @@ func Test_logsCmdFlagParsing(t *testing.T) {
 			logRequest := logRequestFromFlags(functionLogsCmd, functionLogsCmd.Flags().Args())
 			if logRequest.String() != s.expected.String() {
 				t.Errorf("expected log request %s, got %s", s.expected, logRequest)
+			}
+		})
+	}
+}
+
+func TestLogsNamespacePrecedence(t *testing.T) {
+	t.Setenv(openFaaSNamespaceEnvironment, "environment")
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "environment default", args: []string{"echo"}, want: "environment"},
+		{name: "flag override", args: []string{"echo", "--namespace=flag"}, want: "flag"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			functionLogsCmd.ResetFlags()
+			initLogCmdFlags(functionLogsCmd)
+			if err := functionLogsCmd.ParseFlags(test.args); err != nil {
+				t.Fatal(err)
+			}
+
+			request := logRequestFromFlags(functionLogsCmd, functionLogsCmd.Flags().Args())
+			if request.Namespace != test.want {
+				t.Fatalf("want namespace %q, got %q", test.want, request.Namespace)
 			}
 		})
 	}

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
-	openFaaSURLEnvironment      = "OPENFAAS_URL"
-	remoteBuilderEnvironment    = "OPENFAAS_REMOTE_BUILDER"
-	payloadSecretEnvironment    = "OPENFAAS_PAYLOAD_SECRET"
-	builderPublicKeyEnvironment = "OPENFAAS_BUILDER_PUBLIC_KEY"
-	templateURLEnvironment      = "OPENFAAS_TEMPLATE_URL"
-	templateStoreURLEnvironment = "OPENFAAS_TEMPLATE_STORE_URL"
-	defaultFunctionNamespace    = ""
+	openFaaSURLEnvironment       = "OPENFAAS_URL"
+	openFaaSNamespaceEnvironment = "OPENFAAS_NS"
+	remoteBuilderEnvironment     = "OPENFAAS_REMOTE_BUILDER"
+	payloadSecretEnvironment     = "OPENFAAS_PAYLOAD_SECRET"
+	builderPublicKeyEnvironment  = "OPENFAAS_BUILDER_PUBLIC_KEY"
+	templateURLEnvironment       = "OPENFAAS_TEMPLATE_URL"
+	templateStoreURLEnvironment  = "OPENFAAS_TEMPLATE_STORE_URL"
+	defaultFunctionNamespace     = ""
 )
 
 func getGatewayURL(argumentURL, defaultURL, yamlURL, environmentURL string) string {
@@ -64,7 +65,7 @@ func getTemplateStoreURL(argumentURL, environmentURL, defaultURL string) string 
 	}
 }
 
-func getNamespace(flagNamespace, stackNamespace string) string {
+func getNamespace(flagNamespace, stackNamespace, environmentNamespace string) string {
 	// If the namespace flag is passed use it
 	if len(flagNamespace) > 0 {
 		return flagNamespace
@@ -72,6 +73,9 @@ func getNamespace(flagNamespace, stackNamespace string) string {
 	// https://github.com/openfaas/faas-cli/issues/742#issuecomment-625746405
 	if len(stackNamespace) > 0 {
 		return stackNamespace
+	}
+	if len(environmentNamespace) > 0 {
+		return environmentNamespace
 	}
 
 	return defaultFunctionNamespace

--- a/commands/priority_test.go
+++ b/commands/priority_test.go
@@ -1,6 +1,81 @@
 package commands
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openfaas/go-sdk/stack"
+)
+
+func TestGetNamespacePrecedence(t *testing.T) {
+	tests := []struct {
+		name                 string
+		flagNamespace        string
+		stackNamespace       string
+		environmentNamespace string
+		want                 string
+	}{
+		{
+			name:                 "environment namespace is the default",
+			environmentNamespace: "environment",
+			want:                 "environment",
+		},
+		{
+			name:                 "stack namespace overrides environment",
+			stackNamespace:       "stack",
+			environmentNamespace: "environment",
+			want:                 "stack",
+		},
+		{
+			name:                 "flag overrides stack and environment",
+			flagNamespace:        "flag",
+			stackNamespace:       "stack",
+			environmentNamespace: "environment",
+			want:                 "flag",
+		},
+		{
+			name: "empty values retain the existing default",
+			want: defaultFunctionNamespace,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getNamespace(test.flagNamespace, test.stackNamespace, test.environmentNamespace)
+			if got != test.want {
+				t.Fatalf("want namespace %q, got %q", test.want, got)
+			}
+		})
+	}
+}
+
+func TestGetNamespaceUsesSubstitutedStackNamespaceBeforeEnvironment(t *testing.T) {
+	t.Setenv("STACK_NAMESPACE", "substituted-stack")
+	path := filepath.Join(t.TempDir(), "stack.yaml")
+	contents := `version: 1.0
+provider:
+  name: openfaas
+  gateway: http://127.0.0.1:8080
+functions:
+  echo:
+    image: echo:latest
+    namespace: ${STACK_NAMESPACE}
+`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	services, err := stack.ParseYAMLFile(path, "", "", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := getNamespace("", services.Functions["echo"].Namespace, "environment")
+	if got != "substituted-stack" {
+		t.Fatalf("want substituted stack namespace, got %q", got)
+	}
+}
 
 func TestApplyRemoteBuilderEnvironmentUsesEnvFallbacks(t *testing.T) {
 	t.Setenv(remoteBuilderEnvironment, "http://builder.example.com")

--- a/commands/ready.go
+++ b/commands/ready.go
@@ -128,16 +128,17 @@ func runReadyCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		ctx := context.Background()
+		namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
 
 		for i := 0; i < attempts; i++ {
 			suffix := ""
-			if len(functionNamespace) > 0 {
-				suffix = "." + functionNamespace
+			if len(namespace) > 0 {
+				suffix = "." + namespace
 			}
 
 			fmt.Printf("[%d/%d] Waiting for function %s%s\n", i+1, attempts, functionName, suffix)
 
-			function, err := cliClient.GetFunctionInfo(ctx, functionName, functionNamespace)
+			function, err := cliClient.GetFunctionInfo(ctx, functionName, namespace)
 			if err != nil {
 				fmt.Printf("[%d/%d] Error getting function info: %s\n", i+1, attempts, err.Error())
 			}

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -74,7 +74,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if len(services.Functions) > 0 {
 
 		for k, function := range services.Functions {
-			function.Namespace = getNamespace(functionNamespace, function.Namespace)
+			function.Namespace = getNamespace(functionNamespace, function.Namespace, os.Getenv(openFaaSNamespaceEnvironment))
 			function.Name = k
 			fmt.Printf("Deleting: %s.%s\n", function.Name, function.Namespace)
 
@@ -86,8 +86,9 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 
 		functionName = args[0]
-		fmt.Printf("Deleting: %s.%s\n", functionName, functionNamespace)
-		err := proxyclient.DeleteFunction(ctx, functionName, functionNamespace)
+		namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+		fmt.Printf("Deleting: %s.%s\n", functionName, namespace)
+		err := proxyclient.DeleteFunction(ctx, functionName, namespace)
 		if err != nil {
 			return err
 		}

--- a/commands/secret_apply.go
+++ b/commands/secret_apply.go
@@ -42,6 +42,7 @@ func init() {
 }
 
 func runSecretApply(cmd *cobra.Command, args []string) error {
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
 	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
@@ -81,7 +82,7 @@ func runSecretApply(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get list of existing secrets from gateway to check if they exist
-	existingSecrets, err := client.GetSecretList(context.Background(), functionNamespace)
+	existingSecrets, err := client.GetSecretList(context.Background(), namespace)
 	if err != nil {
 		return fmt.Errorf("failed to get secret list: %w", err)
 	}
@@ -90,7 +91,7 @@ func runSecretApply(cmd *cobra.Command, args []string) error {
 	secretMap := make(map[string]bool)
 	for _, secret := range existingSecrets {
 		// Match by name and namespace
-		if secret.Namespace == functionNamespace {
+		if secret.Namespace == namespace {
 			secretMap[secret.Name] = true
 		}
 	}
@@ -130,7 +131,7 @@ func runSecretApply(cmd *cobra.Command, args []string) error {
 
 		secret := types.Secret{
 			Name:      secretName,
-			Namespace: functionNamespace,
+			Namespace: namespace,
 			Value:     secretValue,
 			RawValue:  fileData,
 		}
@@ -140,7 +141,7 @@ func runSecretApply(cmd *cobra.Command, args []string) error {
 			fmt.Printf("Secret %s exists, deleting before recreating...\n", secretName)
 			deleteSecret := types.Secret{
 				Name:      secretName,
-				Namespace: functionNamespace,
+				Namespace: namespace,
 			}
 			err = client.RemoveSecret(context.Background(), deleteSecret)
 			if err != nil {
@@ -150,7 +151,7 @@ func runSecretApply(cmd *cobra.Command, args []string) error {
 		}
 
 		// Create the secret
-		fmt.Printf("Creating secret: %s.%s\n", secret.Name, functionNamespace)
+		fmt.Printf("Creating secret: %s.%s\n", secret.Name, namespace)
 		status, output := client.CreateSecret(context.Background(), secret)
 
 		if status == http.StatusConflict {

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -91,9 +91,10 @@ func preRunSecretCreate(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretCreate(cmd *cobra.Command, args []string) error {
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
 	secret := types.Secret{
 		Name:      args[0],
-		Namespace: functionNamespace,
+		Namespace: namespace,
 	}
 
 	switch {
@@ -146,7 +147,7 @@ func runSecretCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("Creating secret: %s.%s\n", secret.Name, functionNamespace)
+	fmt.Printf("Creating secret: %s.%s\n", secret.Name, namespace)
 	status, output := client.CreateSecret(context.Background(), secret)
 	if status == http.StatusConflict && replaceSecret {
 		fmt.Printf("Secret %s already exists, updating...\n", secret.Name)

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -63,7 +63,8 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	secrets, err := client.GetSecretList(context.Background(), functionNamespace)
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	secrets, err := client.GetSecretList(context.Background(), namespace)
 	if err != nil {
 		return err
 	}

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -44,6 +44,7 @@ func preRunSecretRemoveCmd(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretRemove(cmd *cobra.Command, args []string) error {
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
 	var gatewayAddress string
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
@@ -53,7 +54,7 @@ func runSecretRemove(cmd *cobra.Command, args []string) error {
 
 	secret := types.Secret{
 		Name:      args[0],
-		Namespace: functionNamespace,
+		Namespace: namespace,
 	}
 
 	cliAuth, err := proxy.NewCLIAuth(token, gatewayAddress)

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -58,6 +58,7 @@ func preRunSecretUpdate(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretUpdate(cmd *cobra.Command, args []string) error {
+	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
 	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {
@@ -66,7 +67,7 @@ func runSecretUpdate(cmd *cobra.Command, args []string) error {
 
 	secret := types.Secret{
 		Name:      args[0],
-		Namespace: functionNamespace,
+		Namespace: namespace,
 	}
 
 	switch {

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -156,7 +156,7 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		tlsInsecure,
 		item.ReadOnlyRootFilesystem,
 		token,
-		functionNamespace,
+		getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment)),
 		cpuRequest,
 		cpuLimit,
 		memoryRequest,


### PR DESCRIPTION
## Description

Add support for the `OPENFAAS_NS` environment variable as the default
namespace for namespace-aware commands (`up`, `deploy`, `describe`,
`diff`, `invoke`, `list`, `logs`, `ready`, `remove` and the `secret`
commands).

Namespace resolution precedence is unchanged: the `--namespace` flag
wins, then the stack.yaml namespace, then `OPENFAAS_NS`, then the
cluster default namespace.

`diff` previously listed deployed functions from a single namespace
only: the `--namespace` flag value, or the cluster default if the flag
was not set. For a stack that spans multiple namespaces this meant
deployed functions in other namespaces were invisible, so `diff` would
report them as not deployed. It now collects the set of namespaces
that the stack's functions resolve to (applying the same precedence)
and lists deployed functions from each of them, so every deployed
function that a stack function could match is found.

Also fixes `invoke` to use the resolved namespace on the 401 retry
path, which previously used the raw `--namespace` flag and dropped the
stack.yaml and `OPENFAAS_NS` values.

## Motivation and Context

Users with access to a non-default namespace, e.g. a per-user
namespace on a shared cluster, currently have to pass `--namespace`
to every command. Setting `OPENFAAS_NS` in the environment lets their
commands avoid implicitly targeting the cluster default namespace.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

- Added unit tests for namespace precedence, env-substituted stack
  namespaces, logs resolution, and multi-namespace `diff` behavior.
- Covered same-named functions in different namespaces and API responses
  that omit the function namespace.
- Tested `OPENFAAS_NS` end to end with deploy, store deploy, list,
  describe, ready, invoke, logs, remove, and the secret lifecycle.
- Verified that `--namespace` overrides the environment and that existing
  stack namespace precedence is preserved.
- Tested `diff` with a stack spanning multiple namespaces. The old CLI
  missed namespaced functions, while the updated CLI matched each function
  to its queried namespace and reported only genuinely missing functions.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
