### PR TITLE
Encapsulate OPENFAAS_NS lookup

### DIFF
--- a/commands/deploy.go
+++ b/commands/deploy.go
@@ -199,7 +199,7 @@ func runDeployCommand(args []string, image string, fprocess string, functionName
 
 			// Check if there is a functionNamespace flag passed, if so, override the namespace value
 			// defined in the stack.yaml
-			function.Namespace = getNamespace(functionNamespace, function.Namespace, os.Getenv(openFaaSNamespaceEnvironment))
+			function.Namespace = getNamespace(functionNamespace, function.Namespace)
 
 			fileEnvironment, err := readFiles(function.EnvironmentFile)
 			if err != nil {
@@ -319,7 +319,7 @@ Error: %s`, fprocessErr.Error())
 			tlsInsecure,
 			defaultReadOnlyRFS,
 			token,
-			getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment)),
+			getNamespace(functionNamespace, ""),
 			cpuRequest,
 			cpuLimit,
 			memoryRequest,

--- a/commands/describe.go
+++ b/commands/describe.go
@@ -83,7 +83,7 @@ func runDescribe(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 
 	function, err := cliClient.GetFunctionInfo(ctx, functionName, namespace)
 	if err != nil {

--- a/commands/diff.go
+++ b/commands/diff.go
@@ -98,7 +98,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	yamlMap := make(map[string]funcDiff)
 	for name, fn := range yamlFns {
-		key := diffKey(name, getNamespace(functionNamespace, fn.Namespace, os.Getenv(openFaaSNamespaceEnvironment)))
+		key := diffKey(name, getNamespace(functionNamespace, fn.Namespace))
 
 		imageName, err := buildDiffImageName(fn.Image, fn.Handler, tagFormat)
 		if err != nil {
@@ -125,7 +125,7 @@ func runDiff(cmd *cobra.Command, args []string) error {
 
 	deployedMap := make(map[string]funcDiff)
 	ctx := context.Background()
-	for _, namespace := range namespacesForDiff(functionNamespace, parsedServices.Functions, os.Getenv(openFaaSNamespaceEnvironment)) {
+	for _, namespace := range namespacesForDiff(functionNamespace, parsedServices.Functions) {
 		deployed, err := proxyClient.ListFunctions(ctx, namespace)
 		if err != nil {
 			return err
@@ -441,10 +441,10 @@ func sortedAttrKeys(m map[string]string) []string {
 	return keys
 }
 
-func namespacesForDiff(flagNamespace string, functions map[string]stack.Function, environmentNamespace string) []string {
+func namespacesForDiff(flagNamespace string, functions map[string]stack.Function) []string {
 	namespaces := map[string]struct{}{}
 	for _, function := range functions {
-		namespace := getNamespace(flagNamespace, function.Namespace, environmentNamespace)
+		namespace := getNamespace(flagNamespace, function.Namespace)
 		namespaces[namespace] = struct{}{}
 	}
 

--- a/commands/diff_test.go
+++ b/commands/diff_test.go
@@ -129,19 +129,21 @@ functions:
 }
 
 func TestNamespacesForDiffPrecedence(t *testing.T) {
+	t.Setenv(openFaaSNamespaceEnvironment, "environment")
+
 	functions := map[string]stack.Function{
 		"first":  {Namespace: "stack-a"},
 		"second": {Namespace: "stack-b"},
 		"third":  {},
 	}
 
-	got := namespacesForDiff("", functions, "environment")
+	got := namespacesForDiff("", functions)
 	want := []string{"environment", "stack-a", "stack-b"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("want namespaces %v, got %v", want, got)
 	}
 
-	got = namespacesForDiff("flag", functions, "environment")
+	got = namespacesForDiff("flag", functions)
 	want = []string{"flag"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("want flag namespace %v, got %v", want, got)

--- a/commands/invoke.go
+++ b/commands/invoke.go
@@ -97,7 +97,7 @@ func runInvoke(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
-	functionNamespace = getNamespace(functionInvokeNamespace, stackNamespace, os.Getenv(openFaaSNamespaceEnvironment))
+	functionNamespace = getNamespace(functionInvokeNamespace, stackNamespace)
 
 	if missingSignFlag(sigHeader, key) {
 		return fmt.Errorf("signing requires both --sign <header-value> and --key <key-value>")

--- a/commands/list.go
+++ b/commands/list.go
@@ -77,7 +77,7 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 	functions, err := proxyClient.ListFunctions(context.Background(), namespace)
 	if err != nil {
 		return err

--- a/commands/logs.go
+++ b/commands/logs.go
@@ -179,7 +179,7 @@ func logRequestFromFlags(cmd *cobra.Command, args []string) logs.Request {
 
 	return logs.Request{
 		Name:      args[0],
-		Namespace: getNamespace(ns, "", os.Getenv(openFaaSNamespaceEnvironment)),
+		Namespace: getNamespace(ns, ""),
 		Tail:      logFlagValues.lines,
 		Since:     sinceValue(logFlagValues.sinceTime.AsTime(), logFlagValues.since),
 		Follow:    logFlagValues.tail,

--- a/commands/priority.go
+++ b/commands/priority.go
@@ -65,7 +65,7 @@ func getTemplateStoreURL(argumentURL, environmentURL, defaultURL string) string 
 	}
 }
 
-func getNamespace(flagNamespace, stackNamespace, environmentNamespace string) string {
+func getNamespace(flagNamespace, stackNamespace string) string {
 	// If the namespace flag is passed use it
 	if len(flagNamespace) > 0 {
 		return flagNamespace
@@ -74,6 +74,7 @@ func getNamespace(flagNamespace, stackNamespace, environmentNamespace string) st
 	if len(stackNamespace) > 0 {
 		return stackNamespace
 	}
+	environmentNamespace := os.Getenv(openFaaSNamespaceEnvironment)
 	if len(environmentNamespace) > 0 {
 		return environmentNamespace
 	}

--- a/commands/priority_test.go
+++ b/commands/priority_test.go
@@ -42,7 +42,8 @@ func TestGetNamespacePrecedence(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := getNamespace(test.flagNamespace, test.stackNamespace, test.environmentNamespace)
+			t.Setenv(openFaaSNamespaceEnvironment, test.environmentNamespace)
+			got := getNamespace(test.flagNamespace, test.stackNamespace)
 			if got != test.want {
 				t.Fatalf("want namespace %q, got %q", test.want, got)
 			}
@@ -52,6 +53,7 @@ func TestGetNamespacePrecedence(t *testing.T) {
 
 func TestGetNamespaceUsesSubstitutedStackNamespaceBeforeEnvironment(t *testing.T) {
 	t.Setenv("STACK_NAMESPACE", "substituted-stack")
+	t.Setenv(openFaaSNamespaceEnvironment, "environment")
 	path := filepath.Join(t.TempDir(), "stack.yaml")
 	contents := `version: 1.0
 provider:
@@ -71,7 +73,7 @@ functions:
 		t.Fatal(err)
 	}
 
-	got := getNamespace("", services.Functions["echo"].Namespace, "environment")
+	got := getNamespace("", services.Functions["echo"].Namespace)
 	if got != "substituted-stack" {
 		t.Fatalf("want substituted stack namespace, got %q", got)
 	}

--- a/commands/ready.go
+++ b/commands/ready.go
@@ -128,7 +128,7 @@ func runReadyCmd(cmd *cobra.Command, args []string) error {
 		}
 
 		ctx := context.Background()
-		namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+		namespace := getNamespace(functionNamespace, "")
 
 		for i := 0; i < attempts; i++ {
 			suffix := ""

--- a/commands/remove.go
+++ b/commands/remove.go
@@ -74,7 +74,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	if len(services.Functions) > 0 {
 
 		for k, function := range services.Functions {
-			function.Namespace = getNamespace(functionNamespace, function.Namespace, os.Getenv(openFaaSNamespaceEnvironment))
+			function.Namespace = getNamespace(functionNamespace, function.Namespace)
 			function.Name = k
 			fmt.Printf("Deleting: %s.%s\n", function.Name, function.Namespace)
 
@@ -86,7 +86,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		}
 
 		functionName = args[0]
-		namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+		namespace := getNamespace(functionNamespace, "")
 		fmt.Printf("Deleting: %s.%s\n", functionName, namespace)
 		err := proxyclient.DeleteFunction(ctx, functionName, namespace)
 		if err != nil {

--- a/commands/secret_apply.go
+++ b/commands/secret_apply.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 func runSecretApply(cmd *cobra.Command, args []string) error {
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
 	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {

--- a/commands/secret_create.go
+++ b/commands/secret_create.go
@@ -91,7 +91,7 @@ func preRunSecretCreate(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretCreate(cmd *cobra.Command, args []string) error {
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 	secret := types.Secret{
 		Name:      args[0],
 		Namespace: namespace,

--- a/commands/secret_list.go
+++ b/commands/secret_list.go
@@ -63,7 +63,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 	secrets, err := client.GetSecretList(context.Background(), namespace)
 	if err != nil {
 		return err

--- a/commands/secret_remove.go
+++ b/commands/secret_remove.go
@@ -44,7 +44,7 @@ func preRunSecretRemoveCmd(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretRemove(cmd *cobra.Command, args []string) error {
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 	var gatewayAddress string
 	gatewayAddress = getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 

--- a/commands/secret_update.go
+++ b/commands/secret_update.go
@@ -58,7 +58,7 @@ func preRunSecretUpdate(cmd *cobra.Command, args []string) error {
 }
 
 func runSecretUpdate(cmd *cobra.Command, args []string) error {
-	namespace := getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment))
+	namespace := getNamespace(functionNamespace, "")
 	gatewayAddress := getGatewayURL(gateway, defaultGateway, "", os.Getenv(openFaaSURLEnvironment))
 
 	if msg := checkTLSInsecure(gatewayAddress, tlsInsecure); len(msg) > 0 {

--- a/commands/store_deploy.go
+++ b/commands/store_deploy.go
@@ -156,7 +156,7 @@ func runStoreDeploy(cmd *cobra.Command, args []string) error {
 		tlsInsecure,
 		item.ReadOnlyRootFilesystem,
 		token,
-		getNamespace(functionNamespace, "", os.Getenv(openFaaSNamespaceEnvironment)),
+		getNamespace(functionNamespace, ""),
 		cpuRequest,
 		cpuLimit,
 		memoryRequest,


### PR DESCRIPTION
## Description

Move the `OPENFAAS_NS` environment lookup into `getNamespace` and restore its two-argument signature.

Update namespace-aware commands and tests to use the self-contained helper. Namespace precedence and behaviour remain unchanged.

## Motivation and Context

This is a follow-up to #1028 and its [review discussion](https://github.com/openfaas/faas-cli/pull/1028#discussion_r3936369737).

Every caller previously passed the same `os.Getenv("OPENFAAS_NS")` value into `getNamespace`. Keeping the lookup within the helper removes repetitive plumbing and keeps namespace resolution in one place.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

The namespace resolution unit tests set `OPENFAAS_NS` through the test environment and cover the environment fallback along with flag and stack namespace precedence.

The CLI was also tested against an OpenFaaS gateway with `OPENFAAS_NS` set, verifying that it resolved the namespace and listed functions successfully.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
