### PR TITLE
Vendor SDK build context containment fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,3 +59,5 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
+
+replace github.com/openfaas/go-sdk => ../go-sdk

--- a/vendor/github.com/openfaas/go-sdk/builder/builder.go
+++ b/vendor/github.com/openfaas/go-sdk/builder/builder.go
@@ -439,6 +439,7 @@ func WithHandlerOverlay(path string) BuildContextOption {
 //
 // The function returns the path to the build context, `./build/<functionName>` by default.
 // The build directory can be overridden by setting the `builder.WithBuildDir` option.
+// functionName must be a valid directory name.
 // An error is returned if creating the build context fails.
 func CreateBuildContext(functionName string, handler string, language string, copyExtraPaths []string, options ...BuildContextOption) (string, error) {
 	c := &BuildContextConfig{
@@ -451,15 +452,13 @@ func CreateBuildContext(functionName string, handler string, language string, co
 		option(c)
 	}
 
-	contextPath := path.Join(c.BuildDir, functionName)
+	contextPath, err := functionBuildContextPath(c.BuildDir, functionName)
+	if err != nil {
+		return "", err
+	}
 
 	if err := os.RemoveAll(contextPath); err != nil {
 		return contextPath, fmt.Errorf("unable to clear context folder: %s", contextPath)
-	}
-
-	handlerDst := contextPath
-	if language != "dockerfile" {
-		handlerDst = path.Join(contextPath, c.TemplateHandlerOverlay)
 	}
 
 	permissions := defaultDirPermissions
@@ -467,7 +466,16 @@ func CreateBuildContext(functionName string, handler string, language string, co
 		permissions = 0777
 	}
 
-	err := os.MkdirAll(handlerDst, permissions)
+	handlerDst := contextPath
+	if language != "dockerfile" {
+		var err error
+		handlerDst, err = handlerFolderWithinScope(contextPath, c.TemplateHandlerOverlay)
+		if err != nil {
+			return contextPath, err
+		}
+	}
+
+	err = os.MkdirAll(handlerDst, permissions)
 	if err != nil {
 		return contextPath, fmt.Errorf("error creating function handler path %s: %w", handlerDst, err)
 	}
@@ -501,17 +509,12 @@ func CreateBuildContext(functionName string, handler string, language string, co
 	}
 
 	for _, extraPath := range copyExtraPaths {
-		extraPathAbs, err := pathInScope(extraPath, ".")
+		extraPathAbs, extraPathRel, err := pathInScope(extraPath, ".")
 		if err != nil {
 			return contextPath, err
 		}
-		// Note that if template is nil or the language is `dockerfile`, then
-		// handlerDest == contextPath, the docker build context, not the handler folder
-		// inside the docker build context.
-		if err := copyFiles(
-			extraPathAbs,
-			filepath.Clean(path.Join(handlerDst, extraPath)),
-		); err != nil {
+		// Use the validated relative path to keep the destination beneath handlerDst.
+		if err := copyFiles(extraPathAbs, filepath.Join(handlerDst, extraPathRel)); err != nil {
 			return contextPath, fmt.Errorf("error copying extra paths: %w", err)
 		}
 	}
@@ -519,29 +522,60 @@ func CreateBuildContext(functionName string, handler string, language string, co
 	return contextPath, nil
 }
 
-// pathInScope returns the absolute path to `path` and ensures that it is located within the
-// provided scope. An error will be returned, if the path is outside of the provided scope.
-func pathInScope(path string, scope string) (string, error) {
+// functionBuildContextPath constructs the build path for a function.
+// functionName must be a valid directory name.
+func functionBuildContextPath(buildDir, functionName string) (string, error) {
+	if !filepath.IsLocal(functionName) ||
+		functionName == "." ||
+		strings.ContainsAny(functionName, `/\`) {
+		return "", fmt.Errorf("function name %q must be a single path component within the build directory %q", functionName, buildDir)
+	}
+
+	return filepath.Join(buildDir, functionName), nil
+}
+
+// handlerFolderWithinScope validates handlerFolder lexically and returns its path
+// beneath buildRoot. An empty folder or "." selects buildRoot itself.
+// It rejects absolute paths and relative paths that escape buildRoot.
+func handlerFolderWithinScope(buildRoot, handlerFolder string) (string, error) {
+	folder := filepath.FromSlash(handlerFolder)
+	if folder == "" {
+		folder = "."
+	}
+	if !filepath.IsLocal(folder) {
+		return "", fmt.Errorf("handler folder %q must be a relative path within the build context %q", handlerFolder, buildRoot)
+	}
+
+	return filepath.Join(buildRoot, folder), nil
+}
+
+// pathInScope returns the absolute and scope-relative paths after checking lexical
+// containment. It rejects paths outside scope and paths equal to scope itself.
+func pathInScope(path string, scope string) (string, string, error) {
 	scope, err := filepath.Abs(filepath.FromSlash(scope))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
 	abs, err := filepath.Abs(filepath.FromSlash(path))
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	if abs == scope {
-		return "", fmt.Errorf("forbidden path appears to equal the entire project: %s (%s)", path, abs)
+	rel, err := filepath.Rel(scope, abs)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to resolve path %s: %w", path, err)
 	}
 
-	if strings.HasPrefix(abs, scope) {
-		return abs, nil
+	if rel == "." {
+		return "", "", fmt.Errorf("forbidden path appears to equal the entire project: %s (%s)", path, abs)
 	}
 
-	// default return is an error
-	return "", fmt.Errorf("forbidden path appears to be outside of the build context: %s (%s)", path, abs)
+	if !filepath.IsLocal(rel) {
+		return "", "", fmt.Errorf("forbidden path appears to be outside of the build context: %s (%s)", path, abs)
+	}
+
+	return abs, rel, nil
 }
 
 const defaultDirPermissions os.FileMode = 0700

--- a/vendor/github.com/openfaas/go-sdk/client.go
+++ b/vendor/github.com/openfaas/go-sdk/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -16,6 +17,13 @@ import (
 	"github.com/openfaas/faas-provider/logs"
 	"github.com/openfaas/faas-provider/types"
 	"github.com/openfaas/go-sdk/internal/httpclient"
+)
+
+var (
+	ErrNotFound         = errors.New("not found")
+	ErrUnauthorized     = errors.New("unauthorized")
+	ErrForbidden        = errors.New("forbidden")
+	ErrUnexpectedStatus = errors.New("unexpected response status")
 )
 
 // Client is used to manage OpenFaaS and invoke functions
@@ -64,6 +72,20 @@ func WithAuthentication(auth ClientAuth) ClientOption {
 func WithFunctionTokenCache(cache TokenCache) ClientOption {
 	return func(c *Client) {
 		c.fnTokenCache = cache
+	}
+}
+
+// FunctionOption configures a function operation.
+type FunctionOption func(*functionOptions)
+
+type functionOptions struct {
+	usage bool
+}
+
+// WithUsage includes CPU and RAM usage metrics in function query responses.
+func WithUsage() FunctionOption {
+	return func(opts *functionOptions) {
+		opts.usage = true
 	}
 }
 
@@ -127,24 +149,37 @@ func (s *Client) GetNamespaces(ctx context.Context) ([]string, error) {
 		defer res.Body.Close()
 	}
 
-	bytesOut, err := io.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return namespaces, err
 	}
 
-	if res.StatusCode == http.StatusUnauthorized {
-		return namespaces, fmt.Errorf("check authorization, status code: %d", res.StatusCode)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		if len(body) == 0 {
+			return namespaces, nil
+		}
 
-	if len(bytesOut) == 0 {
+		if err := json.Unmarshal(body, &namespaces); err != nil {
+			return namespaces, fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
 		return namespaces, nil
-	}
 
-	if err := json.Unmarshal(bytesOut, &namespaces); err != nil {
-		return namespaces, fmt.Errorf("unable to marshal to JSON: %s, error: %w", string(bytesOut), err)
-	}
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return namespaces, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return namespaces, ErrUnauthorized
 
-	return namespaces, err
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return namespaces, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return namespaces, ErrForbidden
+
+	default:
+		return namespaces, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 // GetNamespaces get openfaas namespaces
@@ -183,13 +218,22 @@ func (s *Client) GetNamespace(ctx context.Context, namespace string) (types.Func
 		return fnNamespace, err
 
 	case http.StatusNotFound:
-		return types.FunctionNamespace{}, fmt.Errorf("namespace %s not found", namespace)
+		return types.FunctionNamespace{}, fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
 
 	case http.StatusUnauthorized:
-		return types.FunctionNamespace{}, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return types.FunctionNamespace{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return types.FunctionNamespace{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return types.FunctionNamespace{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return types.FunctionNamespace{}, ErrForbidden
 
 	default:
-		return types.FunctionNamespace{}, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return types.FunctionNamespace{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -246,10 +290,19 @@ func (s *Client) CreateNamespace(ctx context.Context, spec types.FunctionNamespa
 		return res.StatusCode, nil
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -306,13 +359,22 @@ func (s *Client) UpdateNamespace(ctx context.Context, spec types.FunctionNamespa
 		return res.StatusCode, nil
 
 	case http.StatusNotFound:
-		return res.StatusCode, fmt.Errorf("namespace %s not found", spec.Name)
+		return res.StatusCode, fmt.Errorf("%w: namespace %s", ErrNotFound, spec.Name)
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -355,24 +417,29 @@ func (s *Client) DeleteNamespace(ctx context.Context, namespace string) error {
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("namespace %s not found", namespace)
+		return fmt.Errorf("%w: namespace %s", ErrNotFound, namespace)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -410,13 +477,30 @@ func (s *Client) GetFunctions(ctx context.Context, namespace string) ([]types.Fu
 
 	body, _ := io.ReadAll(res.Body)
 
-	functions := []types.FunctionStatus{}
-	if err := json.Unmarshal(body, &functions); err != nil {
-		return []types.FunctionStatus{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		functions := []types.FunctionStatus{}
+		if err := json.Unmarshal(body, &functions); err != nil {
+			return []types.FunctionStatus{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return functions, nil
 
-	return functions, nil
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return []types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return []types.FunctionStatus{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return []types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return []types.FunctionStatus{}, ErrForbidden
+
+	default:
+		return []types.FunctionStatus{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 func (s *Client) GetInfo(ctx context.Context) (SystemInfo, error) {
@@ -445,23 +529,50 @@ func (s *Client) GetInfo(ctx context.Context) (SystemInfo, error) {
 
 	body, _ := io.ReadAll(res.Body)
 
-	info := SystemInfo{}
-	if err := json.Unmarshal(body, &info); err != nil {
-		return SystemInfo{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		info := SystemInfo{}
+		if err := json.Unmarshal(body, &info); err != nil {
+			return SystemInfo{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return info, nil
 
-	return info, nil
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return SystemInfo{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return SystemInfo{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return SystemInfo{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return SystemInfo{}, ErrForbidden
+
+	default:
+		return SystemInfo{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 // GetFunction gives a richer payload than GetFunctions, but for a specific function
-func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types.FunctionStatus, error) {
+func (s *Client) GetFunction(ctx context.Context, name, namespace string, opts ...FunctionOption) (types.FunctionStatus, error) {
 	u, _ := url.Parse(s.GatewayURL.String())
 	u.Path = "/system/function/" + name
 
-	if len(namespace) > 0 {
+	functionOpts := &functionOptions{}
+	for _, opt := range opts {
+		opt(functionOpts)
+	}
+
+	if len(namespace) > 0 || functionOpts.usage {
 		query := u.Query()
-		query.Set("namespace", namespace)
+		if len(namespace) > 0 {
+			query.Set("namespace", namespace)
+		}
+		if functionOpts.usage {
+			query.Set("usage", "1")
+		}
 		u.RawQuery = query.Encode()
 	}
 
@@ -487,13 +598,33 @@ func (s *Client) GetFunction(ctx context.Context, name, namespace string) (types
 
 	body, _ := io.ReadAll(res.Body)
 
-	function := types.FunctionStatus{}
-	if err := json.Unmarshal(body, &function); err != nil {
-		return types.FunctionStatus{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		function := types.FunctionStatus{}
+		if err := json.Unmarshal(body, &function); err != nil {
+			return types.FunctionStatus{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return function, nil
 
-	return function, nil
+	case http.StatusNotFound:
+		return types.FunctionStatus{}, fmt.Errorf("%w: function %s", ErrNotFound, name)
+
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return types.FunctionStatus{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return types.FunctionStatus{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return types.FunctionStatus{}, ErrForbidden
+
+	default:
+		return types.FunctionStatus{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 func (s *Client) Deploy(ctx context.Context, spec types.FunctionDeployment) (int, error) {
@@ -545,10 +676,19 @@ func (s *Client) deploy(ctx context.Context, method string, spec types.FunctionD
 		return res.StatusCode, nil
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -590,24 +730,29 @@ func (s *Client) ScaleFunction(ctx context.Context, functionName, namespace stri
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("function %s not found", functionName)
+		return fmt.Errorf("%w: function %s", ErrNotFound, functionName)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("server returned unexpected status code %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -649,24 +794,29 @@ func (s *Client) DeleteFunction(ctx context.Context, functionName, namespace str
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("function %s not found", functionName)
+		return fmt.Errorf("%w: function %s", ErrNotFound, functionName)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("server returned unexpected status code %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -704,13 +854,30 @@ func (s *Client) GetSecrets(ctx context.Context, namespace string) ([]types.Secr
 
 	body, _ := io.ReadAll(res.Body)
 
-	secrets := []types.Secret{}
-	if err := json.Unmarshal(body, &secrets); err != nil {
-		return []types.Secret{},
-			fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
-	}
+	switch res.StatusCode {
+	case http.StatusOK:
+		secrets := []types.Secret{}
+		if err := json.Unmarshal(body, &secrets); err != nil {
+			return []types.Secret{},
+				fmt.Errorf("unable to unmarshal value: %q, error: %w", string(body), err)
+		}
+		return secrets, nil
 
-	return secrets, nil
+	case http.StatusUnauthorized:
+		if len(body) > 0 {
+			return []types.Secret{}, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return []types.Secret{}, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return []types.Secret{}, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return []types.Secret{}, ErrForbidden
+
+	default:
+		return []types.Secret{}, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
+	}
 }
 
 // CreateSecret creates a secret
@@ -754,10 +921,19 @@ func (s *Client) CreateSecret(ctx context.Context, spec types.Secret) (int, erro
 		return res.StatusCode, nil
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -802,13 +978,22 @@ func (s *Client) UpdateSecret(ctx context.Context, spec types.Secret) (int, erro
 		return res.StatusCode, nil
 
 	case http.StatusNotFound:
-		return res.StatusCode, fmt.Errorf("secret %s not found", spec.Name)
+		return res.StatusCode, fmt.Errorf("%w: secret %s", ErrNotFound, spec.Name)
 
 	case http.StatusUnauthorized:
-		return res.StatusCode, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return res.StatusCode, ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return res.StatusCode, fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return res.StatusCode, ErrForbidden
 
 	default:
-		return res.StatusCode, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(body))
+		return res.StatusCode, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 }
 
@@ -849,24 +1034,29 @@ func (s *Client) DeleteSecret(ctx context.Context, secretName, namespace string)
 		defer res.Body.Close()
 	}
 
+	body, _ := io.ReadAll(res.Body)
+
 	switch res.StatusCode {
 	case http.StatusAccepted, http.StatusOK, http.StatusCreated:
 		break
 
 	case http.StatusNotFound:
-		return fmt.Errorf("secret %s not found", secretName)
+		return fmt.Errorf("%w: secret %s", ErrNotFound, secretName)
 
 	case http.StatusUnauthorized:
-		return fmt.Errorf("unauthorized action, please setup authentication for this server")
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrUnauthorized, string(body))
+		}
+		return ErrUnauthorized
+
+	case http.StatusForbidden:
+		if len(body) > 0 {
+			return fmt.Errorf("%w: %s", ErrForbidden, string(body))
+		}
+		return ErrForbidden
 
 	default:
-		var err error
-		bytesOut, err := io.ReadAll(res.Body)
-		if err != nil {
-			return err
-		}
-
-		return fmt.Errorf("server returned unexpected status code %d, message: %q", res.StatusCode, string(bytesOut))
+		return fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(body))
 	}
 	return nil
 }
@@ -949,16 +1139,28 @@ func (s *Client) GetLogs(ctx context.Context, functionName, namespace string, fo
 		}()
 
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("function: %s not found", functionName)
+		return nil, fmt.Errorf("%w: function %s", ErrNotFound, functionName)
 
 	case http.StatusUnauthorized:
-		return nil, fmt.Errorf("unauthorized action, please setup authentication for this server")
+		bytesOut, err := io.ReadAll(res.Body)
+		if err == nil && len(bytesOut) > 0 {
+			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, string(bytesOut))
+		}
+		return nil, ErrUnauthorized
+
+	case http.StatusForbidden:
+		bytesOut, err := io.ReadAll(res.Body)
+		if err == nil && len(bytesOut) > 0 {
+			return nil, fmt.Errorf("%w: %s", ErrForbidden, string(bytesOut))
+		}
+		return nil, ErrForbidden
 
 	default:
 		bytesOut, err := io.ReadAll(res.Body)
 		if err == nil {
-			return nil, fmt.Errorf("unexpected status code: %d, message: %q", res.StatusCode, string(bytesOut))
+			return nil, fmt.Errorf("%w: status code %d, message: %q", ErrUnexpectedStatus, res.StatusCode, string(bytesOut))
 		}
+		return nil, fmt.Errorf("%w: status code %d", ErrUnexpectedStatus, res.StatusCode)
 	}
 	return logStream, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -182,7 +182,7 @@ github.com/openfaas/faas-provider/types
 ## explicit; go 1.23
 github.com/openfaas/faas/gateway/types
 github.com/openfaas/faas/gateway/version
-# github.com/openfaas/go-sdk v0.2.22
+# github.com/openfaas/go-sdk v0.2.22 => ../go-sdk
 ## explicit; go 1.24
 github.com/openfaas/go-sdk
 github.com/openfaas/go-sdk/builder
@@ -236,3 +236,4 @@ gopkg.in/warnings.v0
 # gopkg.in/yaml.v3 v3.0.1
 ## explicit
 gopkg.in/yaml.v3
+# github.com/openfaas/go-sdk => ../go-sdk


### PR DESCRIPTION
> WIP: `go.mod` temporarily replaces go-sdk with a local checkout containing [openfaas/go-sdk#40](https://github.com/openfaas/go-sdk/pull/40). Use a released SDK version and regenerate vendor before merging.

## Description

Vendor the SDK fixes for function names, handler folders and extra-copy paths
used by `faas-cli build` and `faas-cli publish`.

## Motivation and Context

Fix three build context containment issues: function names could cause deletion
of directories outside the build root, template `handler_folder` values could
write files outside the function's build context, and `configuration.copy` could
read files from sibling directories whose names merely start with the project
directory name. These paths are now rejected.

- [ ] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))

## How Has This Been Tested?

Tested multiple E2E cases across build/publish `--shrinkwrap`: reproduced the
failures on master, verified rejection and outside-file preservation, and checked
valid handler folders and extra-copy paths.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
